### PR TITLE
Flip the order of the trace queue

### DIFF
--- a/desktop-exporter/trace_store.go
+++ b/desktop-exporter/trace_store.go
@@ -41,7 +41,7 @@ func (store *TraceStore) enqueueTrace(traceID string) {
 		store.dequeueTrace()
 	}
 
-	// If the traceID is already in the queue, move it to the back of the line
+	// If the traceID is already in the queue, move it to the front of the line
 	_, traceIDExists := store.traceMap[traceID]
 	if traceIDExists {
 		element := store.findQueueElement(traceID)
@@ -49,17 +49,17 @@ func (store *TraceStore) enqueueTrace(traceID string) {
 			panic(errors.New("traceID mismatch between TraceStore.traceMap and TraceStore.traceQueue"))
 		}
 
-		store.traceQueue.MoveToBack(element)
+		store.traceQueue.MoveToFront(element)
 	} else {
-		// Add traceID to the back of the queue with the most recent traceIDs
-		store.traceQueue.PushBack(traceID)
+		// Add traceID to the front of the queue with the most recent traceIDs
+		store.traceQueue.PushFront(traceID)
 	}
 }
 
 func (store *TraceStore) dequeueTrace() {
-	expiringTraceID := store.traceQueue.Front().Value.(string)
+	expiringTraceID := store.traceQueue.Back().Value.(string)
 	delete(store.traceMap, expiringTraceID)
-	store.traceQueue.Remove(store.traceQueue.Front())
+	store.traceQueue.Remove(store.traceQueue.Back())
 }
 
 func (store *TraceStore) findQueueElement(traceID string) *list.Element {


### PR DESCRIPTION
Flip the order of the trace queue so that new elements are pushed to the front of the list, and old ones are popped off the back.

This is more intuitive/improves readability and potentially improves the performance of the findQueueElement function, since existing traceIDs of incoming spans are more likely to be recent, and therefore close to the front of the list.