### PR TITLE
Complete SpanData

### DIFF
--- a/desktop-exporter/otlp_payload_processor.go
+++ b/desktop-exporter/otlp_payload_processor.go
@@ -21,15 +21,15 @@ type ScopeData struct {
 }
 
 type SpanData struct {
-	TraceID    string
-	TraceState string
-
-	SpanId       string
+	TraceID      string
+	TraceState   string
+	SpanID       string
 	ParentSpanID string
-	Name         string
-	Kind         string
-	StartTime    time.Time
-	EndTime      time.Time
+
+	Name      string
+	Kind      string
+	StartTime time.Time
+	EndTime   time.Time
 
 	Attributes map[string]interface{}
 	Events     []EventData
@@ -141,7 +141,7 @@ func aggregateSpanData(span ptrace.Span, eventData []EventData, LinkData []LinkD
 		TraceID:    span.TraceID().HexString(),
 		TraceState: span.TraceState().AsRaw(),
 
-		SpanId:       span.SpanID().HexString(),
+		SpanID:       span.SpanID().HexString(),
 		ParentSpanID: span.ParentSpanID().HexString(),
 		Name:         span.Name(),
 		Kind:         span.Kind().String(),

--- a/desktop-exporter/otlp_payload_processor.go
+++ b/desktop-exporter/otlp_payload_processor.go
@@ -8,18 +8,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-type SpanData struct {
-	TraceID      string
-	SpanId       string
-	ParentSpanID string
-	Name         string
-	StartTime    time.Time
-	EndTime      time.Time
-	Attributes   map[string]interface{}
-	Resource     *ResourceData
-	Scope        *ScopeData
-}
-
 type ResourceData struct {
 	Attributes             map[string]interface{}
 	DroppedAttributesCount uint32
@@ -28,6 +16,46 @@ type ResourceData struct {
 type ScopeData struct {
 	Name                   string
 	Version                string
+	Attributes             map[string]interface{}
+	DroppedAttributesCount uint32
+}
+
+type SpanData struct {
+	TraceID    string
+	TraceState string
+
+	SpanId       string
+	ParentSpanID string
+	Name         string
+	Kind         string
+	StartTime    time.Time
+	EndTime      time.Time
+
+	Attributes map[string]interface{}
+	Events     []EventData
+	Links      []LinkData
+	Resource   *ResourceData
+	Scope      *ScopeData
+
+	DroppedAttributesCount uint32
+	DroppedEventsCount     uint32
+	DroppedLinksCount      uint32
+
+	StatusCode    string
+	StatusMessage string
+}
+
+type EventData struct {
+	Name                   string
+	Timestamp              time.Time
+	Attributes             map[string]interface{}
+	DroppedAttributesCount uint32
+}
+
+type LinkData struct {
+	TraceID                string
+	SpanID                 string
+	TraceState             string
 	Attributes             map[string]interface{}
 	DroppedAttributesCount uint32
 }
@@ -45,12 +73,32 @@ func extractSpans(_ context.Context, traces ptrace.Traces) []SpanData {
 
 			for si := 0; si < scopeSpan.Spans().Len(); si++ {
 				span := scopeSpan.Spans().At(si)
-				spanData := aggregateSpanData(span, scopeData, resourceData)
+				eventData := extractEvents(span.Events())
+				linkData := extractLinks(span.Links())
+				spanData := aggregateSpanData(span, eventData, linkData, scopeData, resourceData)
 				extractedSpans = append(extractedSpans, spanData)
 			}
 		}
 	}
 	return extractedSpans
+}
+
+func extractEvents(events ptrace.SpanEventSlice) []EventData {
+	eventDataSlice := make([]EventData, 0, events.Len())
+	for eventIndex := 0; eventIndex < events.Len(); eventIndex++ {
+		eventDataSlice = append(eventDataSlice, aggregateEventData(events.At(eventIndex)))
+	}
+
+	return eventDataSlice
+}
+
+func extractLinks(links ptrace.SpanLinkSlice) []LinkData {
+	linkDataSlice := make([]LinkData, 0, links.Len())
+	for linkIndex := 0; linkIndex < links.Len(); linkIndex++ {
+		linkDataSlice = append(linkDataSlice, aggregateLinkData(links.At(linkIndex)))
+	}
+
+	return linkDataSlice
 }
 
 func aggregateResourceData(resource pcommon.Resource) *ResourceData {
@@ -69,16 +117,48 @@ func aggregateScopeData(scope pcommon.InstrumentationScope) *ScopeData {
 	}
 }
 
-func aggregateSpanData(span ptrace.Span, scopeData *ScopeData, resourceData *ResourceData) SpanData {
+func aggregateEventData(event ptrace.SpanEvent) EventData {
+	return EventData{
+		Name:                   event.Name(),
+		Timestamp:              event.Timestamp().AsTime(),
+		Attributes:             event.Attributes().AsRaw(),
+		DroppedAttributesCount: event.DroppedAttributesCount(),
+	}
+}
+
+func aggregateLinkData(link ptrace.SpanLink) LinkData {
+	return LinkData{
+		TraceID:                link.TraceID().HexString(),
+		SpanID:                 link.SpanID().HexString(),
+		TraceState:             link.TraceState().AsRaw(),
+		Attributes:             link.Attributes().AsRaw(),
+		DroppedAttributesCount: link.DroppedAttributesCount(),
+	}
+}
+
+func aggregateSpanData(span ptrace.Span, eventData []EventData, LinkData []LinkData, scopeData *ScopeData, resourceData *ResourceData) SpanData {
 	return SpanData{
-		TraceID:      span.TraceID().HexString(),
+		TraceID:    span.TraceID().HexString(),
+		TraceState: span.TraceState().AsRaw(),
+
 		SpanId:       span.SpanID().HexString(),
 		ParentSpanID: span.ParentSpanID().HexString(),
 		Name:         span.Name(),
+		Kind:         span.Kind().String(),
 		StartTime:    span.StartTimestamp().AsTime(),
 		EndTime:      span.EndTimestamp().AsTime(),
 		Attributes:   span.Attributes().AsRaw(),
-		Scope:        scopeData,
-		Resource:     resourceData,
+
+		Events:   eventData,
+		Links:    LinkData,
+		Scope:    scopeData,
+		Resource: resourceData,
+
+		DroppedAttributesCount: span.DroppedAttributesCount(),
+		DroppedEventsCount:     span.DroppedEventsCount(),
+		DroppedLinksCount:      span.DroppedLinksCount(),
+
+		StatusCode:    span.Status().Code().String(),
+		StatusMessage: span.Status().Message(),
 	}
 }

--- a/desktop-exporter/otlp_payload_processor_test.go
+++ b/desktop-exporter/otlp_payload_processor_test.go
@@ -39,13 +39,31 @@ func TestExtractSpans(t *testing.T) {
 	expectedParentSpanID := hex.EncodeToString([]byte{0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28})
 	expectedStartTime := time.Date(2022, 10, 21, 7, 10, 2, 100, time.UTC)
 	expectedEndTime := time.Date(2020, 10, 21, 7, 10, 2, 300, time.UTC)
+	expectedEventTime := time.Date(2020, 10, 21, 7, 10, 2, 150, time.UTC)
 
 	assert.Equal(t, expectedTraceID, spans[0].TraceID)
 	assert.Equal(t, expectedSpanID, spans[0].SpanId)
 	assert.Equal(t, expectedParentSpanID, spans[0].ParentSpanID)
 	assert.Equal(t, "span", spans[0].Name)
+	assert.Equal(t, "SPAN_KIND_INTERNAL", spans[0].Kind)
 	assert.Equal(t, expectedStartTime, spans[0].StartTime)
 	assert.Equal(t, expectedEndTime, spans[0].EndTime)
+	assert.Equal(t, uint32(3), spans[0].DroppedAttributesCount)
+	assert.Equal(t, uint32(4), spans[0].DroppedEventsCount)
+	assert.Equal(t, uint32(5), spans[0].DroppedLinksCount)
+	assert.Equal(t, "STATUS_CODE_OK", spans[0].StatusCode)
+	assert.Equal(t, "status ok", spans[0].StatusMessage)
+
+	// Validate static event data
+	assert.Equal(t, "span event", spans[0].Events[0].Name)
+	assert.Equal(t, expectedEventTime, spans[0].Events[0].Timestamp)
+	assert.Equal(t, "span event attribute value", spans[0].Events[0].Attributes["span event attribute"])
+	assert.Equal(t, uint32(6), spans[0].Events[0].DroppedAttributesCount)
+
+	//Validate static link data
+	assert.Equal(t, expectedTraceID, spans[0].Links[0].TraceID)
+	assert.Equal(t, "span link attribute value", spans[0].Links[0].Attributes["span link attribute"])
+	assert.Equal(t, uint32(7), spans[0].Links[0].DroppedAttributesCount)
 
 	// Validate that the correct resource and instrumentation scope is attached to each span
 	for i, span := range spans {

--- a/desktop-exporter/otlp_payload_processor_test.go
+++ b/desktop-exporter/otlp_payload_processor_test.go
@@ -42,7 +42,7 @@ func TestExtractSpans(t *testing.T) {
 	expectedEventTime := time.Date(2020, 10, 21, 7, 10, 2, 150, time.UTC)
 
 	assert.Equal(t, expectedTraceID, spans[0].TraceID)
-	assert.Equal(t, expectedSpanID, spans[0].SpanId)
+	assert.Equal(t, expectedSpanID, spans[0].SpanID)
 	assert.Equal(t, expectedParentSpanID, spans[0].ParentSpanID)
 	assert.Equal(t, "span", spans[0].Name)
 	assert.Equal(t, "SPAN_KIND_INTERNAL", spans[0].Kind)

--- a/desktop-exporter/testdata/trace.go
+++ b/desktop-exporter/testdata/trace.go
@@ -55,6 +55,7 @@ func fillScope(scope pcommon.InstrumentationScope, scopeIndex int) {
 
 func fillSpan(span ptrace.Span, spanIndex int) {
 	span.SetName("span")
+	span.SetKind(ptrace.SpanKindInternal)
 	span.SetStartTimestamp(spanStartTimestamp)
 	span.SetEndTimestamp(spanEndTimestamp)
 	span.SetDroppedAttributesCount(3)
@@ -73,6 +74,7 @@ func fillSpan(span ptrace.Span, spanIndex int) {
 	event.SetDroppedAttributesCount(6)
 
 	link := span.Links().AppendEmpty()
+	link.SetTraceID([16]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10})
 	link.Attributes().PutStr("span link attribute", "span link attribute value")
 	link.SetDroppedAttributesCount(7)
 


### PR DESCRIPTION
Here we add fields to the SpanData struct so that it reflects the data found in ptrace.Span.

Things added: links, events, status code and message, span kind, trace state, and a dropped counter for attributes, events, and links.

The oltp_payload_processor_test was then updated to cover these additions.

