### PR TITLE
make the maximum trace store queue length configurable via argument

### DIFF
--- a/desktop-exporter/desktop_exporter.go
+++ b/desktop-exporter/desktop_exporter.go
@@ -8,6 +8,10 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	MAX_QUEUE_LENGTH = 10000
+)
+
 type desktopExporter struct {
 	logger          *zap.Logger
 	traceStore      *TraceStore
@@ -27,7 +31,7 @@ func newDesktopExporter(logger *zap.Logger) *desktopExporter {
 
 	return &desktopExporter{
 		logger:          logger,
-		traceStore:      NewTraceStore(),
+		traceStore:      NewTraceStore(MAX_QUEUE_LENGTH),
 		tracesMarshaler: ptrace.NewJSONMarshaler(),
 	}
 }

--- a/desktop-exporter/trace_store.go
+++ b/desktop-exporter/trace_store.go
@@ -7,21 +7,19 @@ import (
 	"sync"
 )
 
-const (
-	MAX_QUEUE_SIZE = 10000
-)
-
 type TraceStore struct {
-	mut        sync.Mutex
-	traceQueue *list.List
-	traceMap   map[string][]SpanData
+	maxQueueSize int
+	mut          sync.Mutex
+	traceQueue   *list.List
+	traceMap     map[string][]SpanData
 }
 
-func NewTraceStore() *TraceStore {
+func NewTraceStore(maxQueueSize int) *TraceStore {
 	return &TraceStore{
-		mut:        sync.Mutex{},
-		traceQueue: list.New(),
-		traceMap:   map[string][]SpanData{},
+		maxQueueSize: maxQueueSize,
+		mut:          sync.Mutex{},
+		traceQueue:   list.New(),
+		traceMap:     map[string][]SpanData{},
 	}
 }
 
@@ -37,7 +35,7 @@ func (store *TraceStore) Add(_ context.Context, spanData SpanData) {
 func (store *TraceStore) enqueueTrace(traceID string) {
 	// If we have exceeded the maximum number of traces we plan to store
 	// make room for the trace in the queue by deleting the oldest trace
-	for store.traceQueue.Len() >= MAX_QUEUE_SIZE {
+	for store.traceQueue.Len() >= store.maxQueueSize {
 		store.dequeueTrace()
 	}
 


### PR DESCRIPTION
There are 2 reasons for this change:

1. Being able to test the trace store with a manageably short queue
2. In preparation for making the trace queue configurable via the config.yaml file in a future update