### PR TITLE
remove references to the logging tool 

### DIFF
--- a/desktop-exporter/config.go
+++ b/desktop-exporter/config.go
@@ -2,21 +2,11 @@ package desktopexporter
 
 import (
 	"go.opentelemetry.io/collector/config"
-	"go.uber.org/zap/zapcore"
 )
 
 // Config defines configuration for logging exporter.
 type Config struct {
 	config.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
-
-	// LogLevel defines log level of the logging exporter; options are debug, info, warn, error.
-	LogLevel zapcore.Level `mapstructure:"loglevel"`
-
-	// SamplingInitial defines how many samples are initially logged during each second.
-	SamplingInitial int `mapstructure:"sampling_initial"`
-
-	// SamplingThereafter defines the sampling rate after the initial samples are logged.
-	SamplingThereafter int `mapstructure:"sampling_thereafter"`
 }
 
 var _ config.Exporter = (*Config)(nil)

--- a/desktop-exporter/desktop_exporter.go
+++ b/desktop-exporter/desktop_exporter.go
@@ -5,7 +5,6 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.uber.org/zap"
 )
 
 const (
@@ -13,7 +12,6 @@ const (
 )
 
 type desktopExporter struct {
-	logger          *zap.Logger
 	traceStore      *TraceStore
 	tracesMarshaler ptrace.Marshaler
 }
@@ -23,14 +21,12 @@ func (exporter *desktopExporter) pushTraces(ctx context.Context, traces ptrace.T
 	for _, span := range spans {
 		exporter.traceStore.Add(ctx, span)
 	}
-
 	return nil
 }
 
-func newDesktopExporter(logger *zap.Logger) *desktopExporter {
+func newDesktopExporter() *desktopExporter {
 
 	return &desktopExporter{
-		logger:          logger,
 		traceStore:      NewTraceStore(MAX_QUEUE_LENGTH),
 		tracesMarshaler: ptrace.NewJSONMarshaler(),
 	}

--- a/desktop-exporter/factory.go
+++ b/desktop-exporter/factory.go
@@ -2,10 +2,6 @@ package desktopexporter
 
 import (
 	"context"
-	"time"
-
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
@@ -14,9 +10,7 @@ import (
 )
 
 const (
-	typeStr                   = "desktop"
-	defaultSamplingInitial    = 2
-	defaultSamplingThereafter = 500
+	typeStr = "desktop"
 )
 
 func NewFactory() component.ExporterFactory {
@@ -29,17 +23,13 @@ func NewFactory() component.ExporterFactory {
 
 func createDefaultConfig() config.Exporter {
 	return &Config{
-		ExporterSettings:   config.NewExporterSettings(config.NewComponentID(typeStr)),
-		LogLevel:           zapcore.InfoLevel,
-		SamplingInitial:    defaultSamplingInitial,
-		SamplingThereafter: defaultSamplingThereafter,
+		ExporterSettings: config.NewExporterSettings(config.NewComponentID(typeStr)),
 	}
 }
 
 func createTracesExporter(ctx context.Context, set component.ExporterCreateSettings, config config.Exporter) (component.TracesExporter, error) {
 	cfg := config.(*Config)
-	exporterLogger := createLogger(cfg, set.TelemetrySettings.Logger)
-	desktopExporter := newDesktopExporter(exporterLogger)
+	desktopExporter := newDesktopExporter()
 	return exporterhelper.NewTracesExporter(ctx, set, cfg,
 		desktopExporter.pushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
@@ -50,15 +40,4 @@ func createTracesExporter(ctx context.Context, set component.ExporterCreateSetti
 		exporterhelper.WithStart(desktopExporter.Start),
 		exporterhelper.WithShutdown(desktopExporter.Shutdown),
 	)
-}
-
-func createLogger(cfg *Config, logger *zap.Logger) *zap.Logger {
-	core := zapcore.NewSamplerWithOptions(
-		logger.Core(),
-		1*time.Second,
-		cfg.SamplingInitial,
-		cfg.SamplingThereafter,
-	)
-
-	return zap.New(core)
 }


### PR DESCRIPTION
These were artefacts from the log exporter I used as a basis for the structure of this project, and are no longer in use. Deleting them lets me have a clean slate for my server config.