### PR TITLE
Serve json representation of traceMap and log it to console on the client side

### DIFF
--- a/desktop-exporter/app/main.jsx
+++ b/desktop-exporter/app/main.jsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import ReactDOM from 'react-dom'
+import {createRoot} from 'react-dom/client'
 
 function App() {
   return (
@@ -9,4 +9,9 @@ function App() {
   );
 }
 
-ReactDOM.render(<App />, document.querySelector('#root'));
+// ReactDOM.render is no longer supported in React 18 - using createRoot instead
+const container = document.getElementById('root')
+const root = createRoot(container)
+root.render(<App />)
+
+fetch("/traces").then(response => response.json()).then(data => console.log(data))

--- a/desktop-exporter/app/main.jsx
+++ b/desktop-exporter/app/main.jsx
@@ -9,7 +9,6 @@ function App() {
   );
 }
 
-// ReactDOM.render is no longer supported in React 18 - using createRoot instead
 const container = document.getElementById('root')
 const root = createRoot(container)
 root.render(<App />)

--- a/desktop-exporter/server.go
+++ b/desktop-exporter/server.go
@@ -22,7 +22,7 @@ func getTracesHandler(traceStore *TraceStore) func(http.ResponseWriter, *http.Re
 		if err != nil {
 			panic(fmt.Errorf("error marshalling traceStore: %s\n", err))
 		} else {
-			writer.WriteHeader(http.StatusCreated)
+			writer.WriteHeader(http.StatusOK)
 			writer.Header().Set("Content-Type", "application/json")
 			writer.Write(jsonTraces)
 		}
@@ -34,14 +34,12 @@ func getTraceIDHandler(traceStore *TraceStore) func(http.ResponseWriter, *http.R
 		traceStore.mut.Lock()
 		defer traceStore.mut.Unlock()
 
-		writer.WriteHeader(http.StatusOK)
-
 		traceID := mux.Vars(request)["id"]
 		jsonTrace, err := json.Marshal(traceStore.traceMap[traceID])
 		if err != nil {
 			fmt.Printf("error marshalling trace %s: %s\n", traceID, err)
 		} else {
-			writer.WriteHeader(http.StatusCreated)
+			writer.WriteHeader(http.StatusOK)
 			writer.Header().Set("Content-Type", "application/json")
 			writer.Write(jsonTrace)
 		}

--- a/desktop-exporter/static/main.css
+++ b/desktop-exporter/static/main.css
@@ -1,3 +1,0 @@
-p {
-    color: red;
-}

--- a/desktop-exporter/static/main.js
+++ b/desktop-exporter/static/main.js
@@ -1,1 +1,0 @@
-alert("Hello World!")


### PR DESCRIPTION
- In server, set header Content-Type to "application/json" to make sure the client expects json in response
- Update from ReactDOM.render to root.render, as the latter is no longer supported as of [React v18.](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis)
- Log the contents of traceMap to the console

![json-response](https://user-images.githubusercontent.com/56372758/199832966-e95f690b-6dbc-44f8-be76-e915ebfc5630.jpg)
