### PR TITLE
Update Api Endpoints

### DIFF
--- a/desktop-exporter/trace_store_test.go
+++ b/desktop-exporter/trace_store_test.go
@@ -147,5 +147,5 @@ func TestGetTrace(t *testing.T) {
 
 	// Verify that looking up an invalid TraceID returns the appropriate error
 	_, err := store.GetSpansByTraceID(strconv.Itoa(-1))
-	assert.EqualError(t, err, "traceID not found: -1")
+	assert.EqualError(t, err, "traceID not found")
 }

--- a/desktop-exporter/trace_store_test.go
+++ b/desktop-exporter/trace_store_test.go
@@ -106,7 +106,7 @@ func TestGetRecentTraceIDs(t *testing.T) {
 		store.Add(ctx, span)
 	}
 
-	recentTraceIDs := store.GetRecentTraceIDs(numRecentTraceIDs)
+	recentTraceIDs := store.getRecentTraceIDs(numRecentTraceIDs)
 
 	// Validate that the number of IDs returned is equal to the lesser value of:
 	// - The number of IDs requested or
@@ -141,11 +141,11 @@ func TestGetTrace(t *testing.T) {
 
 	// Verify that we are able to retrieve every trace in the store by its TraceID
 	for i := 0; i < totalTraces; i++ {
-		trace, _ := store.GetTraceByID(strconv.Itoa(i))
+		trace, _ := store.GetSpansByTraceID(strconv.Itoa(i))
 		assert.Equal(t, strconv.Itoa(i), trace[0].TraceID)
 	}
 
 	// Verify that looking up an invalid TraceID returns the appropriate error
-	_, err := store.GetTraceByID(strconv.Itoa(-1))
-	assert.EqualError(t, err, "traceID not found")
+	_, err := store.GetSpansByTraceID(strconv.Itoa(-1))
+	assert.EqualError(t, err, "traceID not found: -1")
 }

--- a/desktop-exporter/types.go
+++ b/desktop-exporter/types.go
@@ -4,18 +4,14 @@ import (
 	"time"
 )
 
-type RecentSummaries struct {
-	TraceSummaries []TraceSummary `json:"traceSummaries"`
-}
-
 type TraceSummary struct {
-	TraceID   string `json:"traceID"`
-	SpanCount uint32 `json:"spanCount"`
+	TraceID    string `json:"traceID"`
+	SpanCount  uint32 `json:"spanCount"`
+	DurationMS int64  `json:"durationMS"`
 }
 
 type TraceData struct {
-	Spans      []SpanData `json:"spans"`
-	DurationMS int64      `json:"durationMS"`
+	Spans []SpanData `json:"spans"`
 }
 
 type ResourceData struct {

--- a/desktop-exporter/types.go
+++ b/desktop-exporter/types.go
@@ -1,8 +1,17 @@
 package desktopexporter
 
 import (
+	"errors"
 	"time"
 )
+
+var ErrEmptySpanSlice = errors.New("slice of spans associated with this traceID must not be empty")
+var ErrTraceIDNotFound = errors.New("traceID not found")
+var ErrTraceIDMismatch = errors.New("traceID mismatch between TraceStore.traceMap and TraceStore.traceQueue")
+
+type TraceSummaries struct {
+	Summaries []TraceSummary `json:"traceSummaries"`
+}
 
 type TraceSummary struct {
 	TraceID    string `json:"traceID"`


### PR DESCRIPTION
In server.go
- Added functions to create new `TraceData` and `TraceSummary` structs
- Updated handler functions to marshal and send `TraceData` and `TraceSummaries`
- Added a function to calculate the duration of a trace. 

In trace_store.go:
- Added getter functions `GetSpansByTraceID` and `GetRecentTraces`
- Cleaned up error output a bit

In types.go:
- Factored out some error types
- Added a `TraceSummaries` struct to wrap the `TraceSummary` slice for json marshalling
- Moved DurationMS from `TraceData` to `TraceSummary`