### PR TITLE
Update TraceStore.traceMap to store *TraceData

### DIFF
--- a/desktop-exporter/server.go
+++ b/desktop-exporter/server.go
@@ -20,7 +20,7 @@ func getTracesHandler(traceStore *TraceStore) func(http.ResponseWriter, *http.Re
 
 		jsonTraces, err := json.Marshal(traceStore.traceMap)
 		if err != nil {
-			panic(fmt.Errorf("error marshalling traceStore: %s\n", err))
+			fmt.Println(err)
 		} else {
 			writer.WriteHeader(http.StatusOK)
 			writer.Header().Set("Content-Type", "application/json")
@@ -37,7 +37,7 @@ func getTraceIDHandler(traceStore *TraceStore) func(http.ResponseWriter, *http.R
 		traceID := mux.Vars(request)["id"]
 		jsonTrace, err := json.Marshal(traceStore.traceMap[traceID])
 		if err != nil {
-			fmt.Printf("error marshalling trace %s: %s\n", traceID, err)
+			fmt.Println(err)
 		} else {
 			writer.WriteHeader(http.StatusOK)
 			writer.Header().Set("Content-Type", "application/json")

--- a/desktop-exporter/trace_store.go
+++ b/desktop-exporter/trace_store.go
@@ -3,7 +3,7 @@ package desktopexporter
 import (
 	"container/list"
 	"context"
-	"errors"
+	"fmt"
 	"sync"
 )
 
@@ -55,7 +55,7 @@ func (store *TraceStore) GetTraceByID(traceID string) ([]SpanData, error) {
 	trace, traceExists := store.traceMap[traceID]
 
 	if !traceExists {
-		return nil, errors.New("traceID not found")
+		return nil, ErrTraceIDNotFound
 	}
 
 	return trace, nil
@@ -67,7 +67,7 @@ func (store *TraceStore) enqueueTrace(traceID string) {
 	if traceIDExists {
 		element := store.findQueueElement(traceID)
 		if element == nil {
-			panic(errors.New("traceID mismatch between TraceStore.traceMap and TraceStore.traceQueue"))
+			fmt.Println(ErrTraceIDMismatch)
 		}
 
 		store.traceQueue.MoveToFront(element)

--- a/desktop-exporter/trace_store_test.go
+++ b/desktop-exporter/trace_store_test.go
@@ -40,12 +40,12 @@ func TestAdd(t *testing.T) {
 	// Verify that 3 unique TraceIDs are indexed in the traceMap
 	assert.Equal(t, maxQueueLength, len(store.traceMap))
 
-	for traceID, spans := range store.traceMap {
+	for traceID, trace := range store.traceMap {
 		// Verify that three spans are associaded with each TraceID
-		assert.Len(t, spans, spansPerTrace)
+		assert.Len(t, trace.Spans, spansPerTrace)
 
 		// Verify that each span has the correct traceID
-		for _, span := range spans {
+		for _, span := range trace.Spans {
 			assert.Equal(t, traceID, span.TraceID)
 		}
 	}
@@ -142,7 +142,7 @@ func TestGetTrace(t *testing.T) {
 	// Verify that we are able to retrieve every trace in the store by its TraceID
 	for i := 0; i < totalTraces; i++ {
 		trace, _ := store.GetTraceByID(strconv.Itoa(i))
-		assert.Equal(t, strconv.Itoa(i), trace[0].TraceID)
+		assert.Equal(t, strconv.Itoa(i), trace.Spans[0].TraceID)
 	}
 
 	// Verify that looking up an invalid TraceID returns the appropriate error

--- a/desktop-exporter/types.go
+++ b/desktop-exporter/types.go
@@ -1,21 +1,26 @@
 package desktopexporter
 
 import (
+	"errors"
 	"time"
 )
+
+var ErrEmptySpansSlice = errors.New("slice of spans associated with this traceID must not be empty")
+var ErrTraceIDNotFound = errors.New("traceID not found")
+var ErrTraceIDMismatch = errors.New("traceID mismatch between TraceStore.traceMap and TraceStore.traceQueue")
 
 type RecentSummaries struct {
 	TraceSummaries []TraceSummary `json:"traceSummaries"`
 }
 
 type TraceSummary struct {
-	TraceID   string `json:"traceID"`
-	SpanCount uint32 `json:"spanCount"`
+	TraceID    string `json:"traceID"`
+	SpanCount  uint32 `json:"spanCount"`
+	DurationMS int64  `json:"durationMS"`
 }
 
 type TraceData struct {
-	Spans      []SpanData `json:"spans"`
-	DurationMS int64      `json:"durationMS"`
+	Spans []SpanData `json:"spans"`
 }
 
 type ResourceData struct {


### PR DESCRIPTION
Update `TraceStore.traceMap` so that the spans associated with a traceID key are wrapped in a `TraceData` struct. This makes it both more convenient to marshal as json, and easier to extend in the future. Tests updated accordingly.