### PR TITLE
Create file for TraceData-related functions

### DIFF
--- a/desktop-exporter/trace_data.go
+++ b/desktop-exporter/trace_data.go
@@ -4,13 +4,13 @@ import (
 	"time"
 )
 
-func (trace *TraceData) GetTraceSummary() (*TraceSummary, error) {
+func (trace *TraceData) GetTraceSummary() (TraceSummary, error) {
 	duration, err := trace.getTraceDuration()
 	if err != nil {
-		return nil, err
+		return TraceSummary{}, err
 	}
 
-	return &TraceSummary{
+	return TraceSummary{
 		TraceID:    trace.Spans[0].TraceID,
 		SpanCount:  uint32(len(trace.Spans)),
 		DurationMS: duration.Milliseconds(),

--- a/desktop-exporter/trace_data.go
+++ b/desktop-exporter/trace_data.go
@@ -1,0 +1,40 @@
+package desktopexporter
+
+import (
+	"time"
+)
+
+func (trace *TraceData) GetTraceSummary() (*TraceSummary, error) {
+	duration, err := trace.getTraceDuration()
+	if err != nil {
+		return nil, err
+	}
+
+	return &TraceSummary{
+		TraceID:    trace.Spans[0].TraceID,
+		SpanCount:  uint32(len(trace.Spans)),
+		DurationMS: duration.Milliseconds(),
+	}, nil
+
+}
+
+func (trace *TraceData) getTraceDuration() (time.Duration, error) {
+	if len(trace.Spans) < 1 {
+		return 0, ErrEmptySpansSlice
+	}
+
+	// Determine the total duration of the trace
+	traceStartTime := trace.Spans[0].StartTime
+	traceEndTime := trace.Spans[0].EndTime
+	for i := 1; i < len(trace.Spans); i++ {
+
+		if trace.Spans[i].StartTime.Before(traceStartTime) {
+			traceStartTime = trace.Spans[i].StartTime
+		}
+
+		if trace.Spans[i].EndTime.After(traceEndTime) {
+			traceEndTime = trace.Spans[i].EndTime
+		}
+	}
+	return traceEndTime.Sub(traceStartTime), nil
+}

--- a/desktop-exporter/trace_data_test.go
+++ b/desktop-exporter/trace_data_test.go
@@ -27,9 +27,12 @@ func TestGetTraceSummary(t *testing.T) {
 		store.Add(ctx, span)
 	}
 
-	trace := store.traceMap["1"]
+	trace, err := store.GetTraceByID("1")
+	assert.NoError(t, err)
+
 	summary, err := trace.GetTraceSummary()
 	assert.NoError(t, err)
+
 	assert.Equal(t, "1", summary.TraceID)
 	assert.Equal(t, uint32(spansPerTrace), summary.SpanCount)
 	assert.Equal(t, int64(3000), summary.DurationMS)

--- a/desktop-exporter/trace_data_test.go
+++ b/desktop-exporter/trace_data_test.go
@@ -1,0 +1,36 @@
+package desktopexporter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/CtrlSpice/desktop-collector/desktop-exporter/testdata"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTraceSummary(t *testing.T) {
+	maxQueueLength := 1
+	spansPerTrace := 3
+
+	traces := testdata.GenerateOTLPPayload(1, 1, maxQueueLength*spansPerTrace)
+	ctx := context.Background()
+	store := NewTraceStore(maxQueueLength)
+	spans := extractSpans(ctx, traces)
+
+	// Assign each span start and end time before adding it to the store
+	// These timestamps are used to validate the summary's durationMS
+	for i, span := range spans {
+		span.TraceID = "1"
+		span.StartTime = time.Date(2022, 10, 10, 0, 0, i, 0, time.UTC)
+		span.EndTime = time.Date(2022, 10, 10, 0, 0, i+1, 0, time.UTC)
+		store.Add(ctx, span)
+	}
+
+	trace := store.traceMap["1"]
+	summary, err := trace.GetTraceSummary()
+	assert.NoError(t, err)
+	assert.Equal(t, "1", summary.TraceID)
+	assert.Equal(t, uint32(spansPerTrace), summary.SpanCount)
+	assert.Equal(t, int64(3000), summary.DurationMS)
+}


### PR DESCRIPTION
`GetTraceSummary` creates a `TraceSummary` struct from its `TraceData` and `getTraceDuration` calculates the duration for this trace.  
`TestGetTraceSummary` covers both functions.