### PR TITLE
refactor getter functions in TraceStore and fix their tests

### DIFF
--- a/desktop-exporter/trace_data_test.go
+++ b/desktop-exporter/trace_data_test.go
@@ -27,7 +27,7 @@ func TestGetTraceSummary(t *testing.T) {
 		store.Add(ctx, span)
 	}
 
-	trace, err := store.GetTraceByID("1")
+	trace, err := store.GetTrace("1")
 	assert.NoError(t, err)
 
 	summary, err := trace.GetTraceSummary()


### PR DESCRIPTION
- Removed a pointer: `traceMap` values are now `TraceData` instead of `*TraceData`
- Refactored  `GetTraceByID` and renamed it `GetTrace`
- Created `GetRecentTraces` to avoid decoupling map and queue operations
- Made `getRecentTraceIDs` internal 
- Fixed tests accordingly
-
Also I moved stuff around and now the diff is all messy I'm sorry
>(^ ᗜ ^)<  [ sorry ] 