### PR TITLE
Fetch and log individual traceData

### DIFF
--- a/desktop-exporter/app/main.jsx
+++ b/desktop-exporter/app/main.jsx
@@ -7,7 +7,7 @@ import {
   Route,
 } from "react-router-dom";
 import MainView, { mainLoader } from './routes/main-view';
-import TraceView from "./routes/trace-view";
+import TraceView, { traceLoader } from "./routes/trace-view";
 import ErrorPage from './error-page';
 
 const router = createBrowserRouter([
@@ -20,6 +20,7 @@ const router = createBrowserRouter([
   {
     path: "traces/:traceID",
     element: <TraceView />,
+    loader: traceLoader,
     errorElement: <ErrorPage />,
   }
 ]);

--- a/desktop-exporter/app/routes/main-view.jsx
+++ b/desktop-exporter/app/routes/main-view.jsx
@@ -9,7 +9,6 @@ export async function mainLoader() {
 
 export default function MainView() {
     const { traceSummaries } = useLoaderData();
-    console.log(traceSummaries);
 
     const summaries = traceSummaries.map((summary) => (
         <tr key={summary.traceID}>

--- a/desktop-exporter/app/routes/trace-view.jsx
+++ b/desktop-exporter/app/routes/trace-view.jsx
@@ -1,13 +1,20 @@
 import React from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useLoaderData } from 'react-router-dom';
+
+export async function traceLoader({ params }) {
+    const response = await fetch(`/traces/${params.traceID}`);
+    const traceData = await response.json();
+    return traceData;
+}
 
 
 export default function TraceView() {
-    let { traceID } = useParams();
+    const { spans } = useLoaderData();
+    console.log(spans);
     return (
         <>
             <Link to={"/"}>Back</Link>
-            <p>I am Item {traceID}</p>
+            <p>I am Item {spans[0].traceID}</p>
         </>
     )
 }


### PR DESCRIPTION
- When you click on a trace id in the `MainView` summary table, the `traceLoader` retrieves the `TraceData` associated with this id from the server.
- In this iteration, we display the traceID from the first span and log the rest, like so:

![traces:{traceID}](https://user-images.githubusercontent.com/56372758/202524544-992cbe59-ce3c-48f0-8b69-978c34fc2fa1.jpg)
