### PR TITLE
Add TraceID field to TraceData struct

### DIFF
--- a/desktop-exporter/trace_data.go
+++ b/desktop-exporter/trace_data.go
@@ -11,7 +11,7 @@ func (trace *TraceData) GetTraceSummary() (TraceSummary, error) {
 	}
 
 	return TraceSummary{
-		TraceID:    trace.Spans[0].TraceID,
+		TraceID:    trace.TraceID,
 		SpanCount:  uint32(len(trace.Spans)),
 		DurationMS: duration.Milliseconds(),
 	}, nil

--- a/desktop-exporter/trace_store.go
+++ b/desktop-exporter/trace_store.go
@@ -32,6 +32,7 @@ func (store *TraceStore) Add(_ context.Context, spanData SpanData) {
 	traceData, traceExists := store.traceMap[spanData.TraceID]
 	if !traceExists {
 		traceData = TraceData{
+			TraceID: spanData.TraceID,
 			Spans: []SpanData{},
 		}
 	}

--- a/desktop-exporter/trace_store_test.go
+++ b/desktop-exporter/trace_store_test.go
@@ -120,7 +120,7 @@ func TestGetRecentTraces(t *testing.T) {
 	// Validate the order of the traces based of their ID
 	for i, trace := range recentTraces {
 		expectedTraceID := strconv.Itoa(totalTraces - (i + 1))
-		assert.Equal(t, expectedTraceID, trace.Spans[0].TraceID)
+		assert.Equal(t, expectedTraceID, trace.TraceID)
 	}
 }
 
@@ -142,7 +142,7 @@ func TestGetTrace(t *testing.T) {
 	// Verify that we are able to retrieve every trace in the store by its TraceID
 	for i := 0; i < totalTraces; i++ {
 		trace, _ := store.GetTrace(strconv.Itoa(i))
-		assert.Equal(t, strconv.Itoa(i), trace.Spans[0].TraceID)
+		assert.Equal(t, strconv.Itoa(i), trace.TraceID)
 	}
 
 	// Verify that looking up an invalid TraceID returns the appropriate error

--- a/desktop-exporter/types.go
+++ b/desktop-exporter/types.go
@@ -20,7 +20,8 @@ type TraceSummary struct {
 }
 
 type TraceData struct {
-	Spans []SpanData `json:"spans"`
+	TraceID string     `json:"traceID"`
+	Spans   []SpanData `json:"spans"`
 }
 
 type ResourceData struct {


### PR DESCRIPTION
So we don't need to do `trace.Spans[0].TraceID` to access it anymore.