### PR TITLE
rename api paths

### DIFF
--- a/desktop-exporter/app/routes/main-view.jsx
+++ b/desktop-exporter/app/routes/main-view.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link, useLoaderData } from "react-router-dom";
 
 export async function mainLoader() {
-    const response = await fetch("/traces");
+    const response = await fetch("/api/traces");
     const traceSummaries = await response.json();
     return traceSummaries;
 }

--- a/desktop-exporter/app/routes/trace-view.jsx
+++ b/desktop-exporter/app/routes/trace-view.jsx
@@ -4,7 +4,7 @@ import { FixedSizeList } from 'react-window';
 
 
 export async function traceLoader({ params }) {
-    const response = await fetch(`/traces/${params.traceID}`);
+    const response = await fetch(`/api/traces/${params.traceID}`);
     const traceData = await response.json();
     return traceData;
 }

--- a/desktop-exporter/server.go
+++ b/desktop-exporter/server.go
@@ -77,8 +77,8 @@ func traceIDHandler(store *TraceStore) func(http.ResponseWriter, *http.Request) 
 
 func NewServer(traceStore *TraceStore) *Server {
 	router := mux.NewRouter()
-	router.HandleFunc("/traces", tracesHandler(traceStore))
-	router.HandleFunc("/traces/{id}", traceIDHandler(traceStore))
+	router.HandleFunc("/api/traces", tracesHandler(traceStore))
+	router.HandleFunc("/api/traces/{id}", traceIDHandler(traceStore))
 	router.PathPrefix("/").Handler(http.FileServer(http.Dir("./desktop-exporter/static/")))
 
 	return &Server{


### PR DESCRIPTION
Renamed api paths to `api/traces` and `api/traces/{traceID}` to avoid conflict with the app's routes