### PR TITLE
Add server-side handler for /traces/{id}

### DIFF
--- a/desktop-exporter/server.go
+++ b/desktop-exporter/server.go
@@ -75,10 +75,15 @@ func traceIDHandler(store *TraceStore) func(http.ResponseWriter, *http.Request) 
 	}
 }
 
+func indexHandler(writer http.ResponseWriter, request *http.Request){
+	http.ServeFile(writer, request, "./desktop-exporter/static/index.html")
+}
+
 func NewServer(traceStore *TraceStore) *Server {
 	router := mux.NewRouter()
 	router.HandleFunc("/api/traces", tracesHandler(traceStore))
 	router.HandleFunc("/api/traces/{id}", traceIDHandler(traceStore))
+	router.HandleFunc("/traces/{id}", indexHandler)
 	router.PathPrefix("/").Handler(http.FileServer(http.Dir("./desktop-exporter/static/")))
 
 	return &Server{

--- a/desktop-exporter/static/index.html
+++ b/desktop-exporter/static/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset=utf-8>
   <title>Title Here</title>
-  <link rel="stylesheet" href="main.css"/>
+  <link rel="stylesheet" href="/main.css"/>
 </head>
 <body>
   <div id="root"></div>
 
-  <script src="main.js"></script>
+  <script src="/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
...that serves index.html and lets the client populate the data. This means refreshing the page doesn't break it anymore 🥳 