### PR TITLE
Add typescript annotations to make typechecking pass

### DIFF
--- a/desktop-exporter/app/components/header.tsx
+++ b/desktop-exporter/app/components/header.tsx
@@ -9,7 +9,11 @@ import {
 } from "@chakra-ui/react";
 import { SunIcon, MoonIcon } from "@chakra-ui/icons";
 
-export function Header(props) {
+type HeaderProps = {
+  traceID: string;
+};
+
+export function Header(props: HeaderProps) {
   const { colorMode, toggleColorMode } = useColorMode();
   return (
     <Flex

--- a/desktop-exporter/app/error-page.tsx
+++ b/desktop-exporter/app/error-page.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useRouteError } from "react-router-dom";
 
 export default function ErrorPage() {
-  const error = useRouteError();
+  const error = useRouteError() as Error;
   console.error(error);
 
   return (
@@ -10,7 +10,7 @@ export default function ErrorPage() {
       <h1>Oops!</h1>
       <p>Sorry, an unexpected error has occurred.</p>
       <p>
-        <i>{error.statusText || error.message}</i>
+        <i>{error.message}</i>
       </p>
     </div>
   );

--- a/desktop-exporter/app/main.tsx
+++ b/desktop-exporter/app/main.tsx
@@ -24,12 +24,14 @@ const router = createBrowserRouter([
 ]);
 
 const container = document.getElementById("root");
-const root = createRoot(container);
+if (!!container) {
+  const root = createRoot(container);
 
-root.render(
-  <React.StrictMode>
-    <ChakraProvider>
-      <RouterProvider router={router} />
-    </ChakraProvider>
-  </React.StrictMode>,
-);
+  root.render(
+    <React.StrictMode>
+      <ChakraProvider>
+        <RouterProvider router={router} />
+      </ChakraProvider>
+    </React.StrictMode>,
+  );
+}

--- a/desktop-exporter/app/routes/main-view.tsx
+++ b/desktop-exporter/app/routes/main-view.tsx
@@ -3,13 +3,21 @@ import { Outlet, NavLink, useLoaderData } from "react-router-dom";
 import { FixedSizeList } from "react-window";
 import { useToggle } from "usehooks-ts";
 
+import { TraceSummaries, TraceSummary } from "../types/api-types";
+
 export async function mainLoader() {
   const response = await fetch("/api/traces");
   const traceSummaries = await response.json();
   return traceSummaries;
 }
 
-function Row({ index, style, data }) {
+type RowProps = {
+  index: number;
+  style: Object;
+  data: TraceSummary[];
+};
+
+function Row({ index, style, data }: RowProps) {
   return (
     <NavLink
       to={`traces/${data[index].traceID}`}
@@ -20,7 +28,12 @@ function Row({ index, style, data }) {
   );
 }
 
-function Sidebar(props) {
+type SidebarProps = {
+  isClosed: boolean;
+  toggle: () => void;
+};
+
+function Sidebar(props: SidebarProps) {
   if (props.isClosed) {
     return (
       <div className="sidebar closed">
@@ -34,7 +47,7 @@ function Sidebar(props) {
     );
   }
 
-  const { traceSummaries } = useLoaderData();
+  const { traceSummaries } = useLoaderData() as TraceSummaries;
   return (
     <div className="sidebar">
       <button

--- a/desktop-exporter/app/routes/trace-view.tsx
+++ b/desktop-exporter/app/routes/trace-view.tsx
@@ -13,7 +13,7 @@ export async function traceLoader({ params }: any) {
 
 type WaterfallRowProps = {
   index: number;
-  style: {};
+  style: React.CSSProperties;
   data: WaterfallViewProps;
 };
 

--- a/desktop-exporter/app/routes/trace-view.tsx
+++ b/desktop-exporter/app/routes/trace-view.tsx
@@ -3,14 +3,21 @@ import { useLoaderData } from "react-router-dom";
 import { FixedSizeList } from "react-window";
 
 import { Header } from "../components/header";
+import { SpanData, TraceData } from "../types/api-types";
 
-export async function traceLoader({ params }) {
+export async function traceLoader({ params }: any) {
   const response = await fetch(`/api/traces/${params.traceID}`);
   const traceData = await response.json();
   return traceData;
 }
 
-function WaterfallRow({ index, style, data }) {
+type WaterfallRowProps = {
+  index: number;
+  style: {};
+  data: WaterfallViewProps;
+};
+
+function WaterfallRow({ index, style, data }: WaterfallRowProps) {
   let { spans, selectedSpanID, setSelectedSpanID } = data;
   let span = spans[index];
 
@@ -31,7 +38,13 @@ function WaterfallRow({ index, style, data }) {
   );
 }
 
-function WaterfallView(props) {
+type WaterfallViewProps = {
+  spans: SpanData[];
+  selectedSpanID: string | undefined;
+  setSelectedSpanID: (spanID: string) => void;
+};
+
+function WaterfallView(props: WaterfallViewProps) {
   return (
     <FixedSizeList
       className="List"
@@ -46,7 +59,11 @@ function WaterfallView(props) {
   );
 }
 
-function DetailView(props) {
+type DetailViewProps = {
+  span: SpanData | undefined;
+};
+
+function DetailView(props: DetailViewProps) {
   let { span } = props;
   if (!span) {
     return <div className="detail"></div>;
@@ -64,10 +81,10 @@ End: ${span.endTime}
 }
 
 export default function TraceView() {
-  const traceData = useLoaderData();
-  const [selectedSpanID, setSelectedSpanID] = React.useState(
-    traceData.spans[0].spanID,
-  );
+  const traceData = useLoaderData() as TraceData;
+  const [selectedSpanID, setSelectedSpanID] = React.useState<
+    string | undefined
+  >(traceData.spans[0].spanID);
 
   // if we get a new trace because the route changed, reset the selected span
   React.useEffect(() => {

--- a/desktop-exporter/app/routes/trace-view.tsx
+++ b/desktop-exporter/app/routes/trace-view.tsx
@@ -82,9 +82,9 @@ End: ${span.endTime}
 
 export default function TraceView() {
   const traceData = useLoaderData() as TraceData;
-  const [selectedSpanID, setSelectedSpanID] = React.useState<
-    string | undefined
-  >(traceData.spans[0].spanID);
+  const [selectedSpanID, setSelectedSpanID] = React.useState<string>(
+    traceData.spans.length ? traceData.spans[0].spanID : "",
+  );
 
   // if we get a new trace because the route changed, reset the selected span
   React.useEffect(() => {

--- a/desktop-exporter/app/types/api-types.ts
+++ b/desktop-exporter/app/types/api-types.ts
@@ -1,0 +1,66 @@
+export type TraceSummary = {
+  traceID: string;
+  spanCount: number;
+  durationMS: number;
+};
+
+export type TraceSummaries = {
+  traceSummaries: TraceSummary[];
+};
+
+export type TraceData = {
+  traceID: string;
+  spans: SpanData[];
+};
+
+export type SpanData = {
+  traceID: string;
+  traceState: string;
+  spanID: string;
+  parentSpanID: string;
+
+  name: string;
+  kind: string;
+  startTime: string;
+  endTime: string;
+
+  attributes: { [key: string]: number | string | boolean };
+  events: EventData[];
+  links: LinkData[];
+  resource: ResourceData;
+  scope: ScopeData;
+
+  droppedAttributesCount: number;
+  droppedEventsCount: number;
+  droppedLinksCount: number;
+
+  statusCode: string;
+  statusMessage: string;
+};
+
+export type ResourceData = {
+  attributes: { [key: string]: number | string | boolean };
+  droppedAttributesCount: number;
+};
+
+export type ScopeData = {
+  name: string;
+  version: string;
+  attributes: { [key: string]: number | string | boolean };
+  droppedAttributesCount: number;
+};
+
+export type EventData = {
+  name: string;
+  timestamp: string;
+  attributes: { [key: string]: number | string | boolean };
+  droppedAttributeCount: number;
+};
+
+export type LinkData = {
+  traceID: string;
+  spanID: string;
+  traceState: string;
+  attributes: { [key: string]: number | string | boolean };
+  droppedAttributesCount: number;
+};

--- a/desktop-exporter/app/types/api-types.ts
+++ b/desktop-exporter/app/types/api-types.ts
@@ -24,7 +24,7 @@ export type SpanData = {
   startTime: string;
   endTime: string;
 
-  attributes: { [key: string]: number | string | boolean };
+  attributes: { [key: string]: number | string | boolean | null };
   events: EventData[];
   links: LinkData[];
   resource: ResourceData;
@@ -39,21 +39,21 @@ export type SpanData = {
 };
 
 export type ResourceData = {
-  attributes: { [key: string]: number | string | boolean };
+  attributes: { [key: string]: number | string | boolean | null };
   droppedAttributesCount: number;
 };
 
 export type ScopeData = {
   name: string;
   version: string;
-  attributes: { [key: string]: number | string | boolean };
+  attributes: { [key: string]: number | string | boolean | null };
   droppedAttributesCount: number;
 };
 
 export type EventData = {
   name: string;
   timestamp: string;
-  attributes: { [key: string]: number | string | boolean };
+  attributes: { [key: string]: number | string | boolean | null };
   droppedAttributeCount: number;
 };
 
@@ -61,6 +61,6 @@ export type LinkData = {
   traceID: string;
   spanID: string;
   traceState: string;
-  attributes: { [key: string]: number | string | boolean };
+  attributes: { [key: string]: number | string | boolean | null };
   droppedAttributesCount: number;
 };


### PR DESCRIPTION
Depends on #34 

- Adds annotations for the API responses in `desktop-exporter/app/types/api-types.ts`
- Adds annotations for each react component props
- Makes type checking pass

```
otel-desktop-viewer git/add-typescript-annotations
❯ make validate-typescript
cd desktop-exporter; npx tsc --noEmit

```