### PR TITLE
Add Typescript check to CI

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
-        cache-dependency-path: desktop-exporter/package-lock.json
+          cache-dependency-path: desktop-exporter/package-lock.json
 
       - name: Build
         run: cd desktop-exporter && npm install

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,0 +1,22 @@
+name: Typescript
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+        cache-dependency-path: desktop-exporter/package-lock.json
+
+      - name: Build
+        run: cd desktop-exporter && npm install
+
+      - name: Test
+        run: make validate-typescript


### PR DESCRIPTION
Depends on #35 

Brings type checking into the CI to enforce keeping the code base error-free

Example of failed run: https://github.com/CtrlSpice/otel-desktop-viewer/actions/runs/3555192380/jobs/5971745210

<img width="1456" alt="otel-desktop-viewer@7f4d21e 2022-11-26 12-09-05" src="https://user-images.githubusercontent.com/175496/204107209-501ea227-bc00-49b8-a7d2-2aba6ddbbde5.png">
