### PR TITLE
esbuild needs JSX to be compiled away and respects the tsconfig.json

### DIFF
--- a/desktop-exporter/tsconfig.json
+++ b/desktop-exporter/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Language and Environment */
     "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "jsx": "preserve",                                   /* Specify what JSX code is generated. */
+    "jsx": "react",                                   /* Specify what JSX code is generated. */
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */


### PR DESCRIPTION
Small fix from @jmorrell's changes. We need to set this value so that the JSX syntax gets compiled away.