### PR TITLE
Use Chackra UI's grid system to lay out components

### DIFF
--- a/desktop-exporter/app/components/header.tsx
+++ b/desktop-exporter/app/components/header.tsx
@@ -20,6 +20,7 @@ export function Header(props: HeaderProps) {
       className="header"
       bg={useColorModeValue("gray.100", "gray.900")}
       align="center"
+      h={"60px"}
       px={2}
     >
       <Heading

--- a/desktop-exporter/app/main.css
+++ b/desktop-exporter/app/main.css
@@ -22,27 +22,7 @@ body {
   width: 50px;
 }
 
-.traceview {
-  height: 100vh;
-  width: 100vw;
-  display: grid;
-  grid-gap: 0px;
-  grid-template-columns: 3fr 200px;
-  grid-template-rows: 60px 1fr;
-  grid-template-areas:
-    "header  header"
-    "content detail";
-}
 
-.header {
-  grid-area: header;
-  background-color: #698474;
-}
-
-.main {
-  grid-area: content;
-  background-color: #fcf8f3;
-}
 
 .detail {
   grid-area: detail;

--- a/desktop-exporter/app/routes/trace-view.tsx
+++ b/desktop-exporter/app/routes/trace-view.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useLoaderData } from "react-router-dom";
 import { FixedSizeList } from "react-window";
+import { Grid, GridItem } from "@chakra-ui/react";
 
 import { Header } from "../components/header";
 import { SpanData, TraceData } from "../types/api-types";
@@ -96,14 +97,28 @@ export default function TraceView() {
   );
 
   return (
-    <div className="traceview">
-      <Header traceID={traceData.traceID} />
-      <WaterfallView
-        spans={traceData.spans}
-        selectedSpanID={selectedSpanID}
-        setSelectedSpanID={setSelectedSpanID}
-      />
-      <DetailView span={selectedSpan} />
-    </div>
+    <Grid
+      templateAreas={`"header header"
+                       "main detail"`}
+      gridTemplateColumns={"1fr 250px"}
+      gridTemplateRows={"60px 1fr"}
+      gap={"0"}
+      h={"100vh"}
+      w={"100vw"}
+    >
+      <GridItem area={"header"}>
+        <Header traceID={traceData.traceID} />
+      </GridItem>
+      <GridItem area={"main"}>
+        <WaterfallView
+          spans={traceData.spans}
+          selectedSpanID={selectedSpanID}
+          setSelectedSpanID={setSelectedSpanID}
+        />
+      </GridItem>
+      <GridItem area={"detail"}>
+        <DetailView span={selectedSpan} />
+      </GridItem>
+    </Grid>
   );
 }


### PR DESCRIPTION
The goal is to keep custom css for custom components as much as possible, and rely on Chakra UI to do the layout, as it will hopefully make waterfall view easier to debug. 
![DALL·E 2022-11-28 12 44 41 - a grid of corgi in the style of architectural drawing](https://user-images.githubusercontent.com/56372758/204377396-944c5235-055c-454f-a317-dcb1e75fe6e4.png)
