### PR TITLE
Style tracelist

### DIFF
--- a/desktop-exporter/app/components/sidebar.tsx
+++ b/desktop-exporter/app/components/sidebar.tsx
@@ -19,7 +19,7 @@ export function Sidebar(props: SidebarProps) {
   let traceList = <></>;
 
   if (props.isFullWidth) {
-    sidebarWidth = "250px";
+    sidebarWidth = "450px";
     buttonIcon = <ArrowLeftIcon />;
     traceList = <TraceList traceSummaries={props.traceSummaries} />;
   }

--- a/desktop-exporter/app/components/traceList.tsx
+++ b/desktop-exporter/app/components/traceList.tsx
@@ -13,70 +13,73 @@ import { useSize } from "@chakra-ui/react-use-size";
 
 import { TraceSummary } from "../types/api-types";
 
-type RowProps = {
-  index: number;
-  style: Object;
-  data: TraceSummary[];
-};
+ const listItemHeight = 100;
+ const listItemTopMargin = 10;
 
-function Row({ index, style, data }: RowProps) {
-  let isSelected = useMatch(`traces/${data[index].traceID}`);
+ type RowProps = {
+   index: number;
+   style: Object;
+   data: TraceSummary[];
+ };
 
-  let backgroundColour = isSelected
-    ? useColorModeValue("teal.100", "teal.700")
-    : useColorModeValue("whiteAlpha.700", "whiteAlpha.400");
+ function Row({ index, style, data }: RowProps) {
+   let isSelected = useMatch(`traces/${data[index].traceID}`);
 
-  return (
-    <div style={style}>
-      <LinkBox
-        bgColor={backgroundColour}
-        height="100px"
-        padding="10px"
-        marginX="10px"
-        marginTop="10px"
-        rounded="md"
-      >
-        <Heading
-          marginY="1"
-          noOfLines={1}
-          size="sm"
-        >
-          <LinkOverlay
-            as={NavLink}
-            to={`traces/${data[index].traceID}`}
-          >
-            {data[index].traceID}
-          </LinkOverlay>
-        </Heading>
-        <Text>Number of spans: {data[index].spanCount}</Text>
-        <Text>Duration: {data[index].durationMS} ms</Text>
-      </LinkBox>
-    </div>
-  );
-}
+   let backgroundColour = isSelected
+     ? useColorModeValue("teal.100", "teal.700")
+     : useColorModeValue("whiteAlpha.700", "whiteAlpha.400");
 
-type TraceListProps = {
-  traceSummaries: TraceSummary[];
-};
+   return (
+     <div style={style}>
+       <LinkBox
+         bgColor={backgroundColour}
+         height="100px"
+         padding="10px"
+         marginX="10px"
+         marginTop={`${listItemTopMargin}px`}
+         rounded="md"
+       >
+         <Heading
+           marginY="1"
+           noOfLines={1}
+           size="sm"
+         >
+           <LinkOverlay
+             as={NavLink}
+             to={`traces/${data[index].traceID}`}
+           >
+             {data[index].traceID}
+           </LinkOverlay>
+         </Heading>
+         <Text>Number of spans: {data[index].spanCount}</Text>
+         <Text>Duration: {data[index].durationMS} ms</Text>
+       </LinkBox>
+     </div>
+   );
+ }
 
-export function TraceList(props: TraceListProps) {
-  const ref = useRef(null);
-  const size = useSize(ref);
+ type TraceListProps = {
+   traceSummaries: TraceSummary[];
+ };
 
-  return (
-    <Flex
-      ref={ref}
-      height="100%"
-    >
-      <FixedSizeList
-        height={size ? size.height : 0}
-        itemData={props.traceSummaries}
-        itemCount={props.traceSummaries.length}
-        itemSize={110}
-        width="100%"
-      >
-        {Row}
-      </FixedSizeList>
-    </Flex>
-  );
-}
+ export function TraceList(props: TraceListProps) {
+   const ref = useRef(null);
+   const size = useSize(ref);
+
+   return (
+     <Flex
+       ref={ref}
+       height="100%"
+     >
+       <FixedSizeList
+         height={size ? size.height : 0}
+         itemData={props.traceSummaries}
+         itemCount={props.traceSummaries.length}
+         itemSize={listItemHeight + listItemTopMargin}
+         width="100%"
+       >
+         {Row}
+       </FixedSizeList>
+     </Flex>
+   );
+ }

--- a/desktop-exporter/app/components/traceList.tsx
+++ b/desktop-exporter/app/components/traceList.tsx
@@ -1,16 +1,11 @@
 import React, { useRef } from "react";
 import { FixedSizeList } from "react-window";
-import { NavLink } from "react-router-dom";
+import { NavLink, useMatch } from "react-router-dom";
 import {
-  Box,
-  Card,
-  CardBody,
   Flex,
   Heading,
   LinkBox,
   LinkOverlay,
-  Stack,
-  StackDivider,
   Text,
   useColorModeValue,
 } from "@chakra-ui/react";
@@ -25,12 +20,11 @@ type RowProps = {
 };
 
 function Row({ index, style, data }: RowProps) {
-  const backgroundColour = useColorModeValue(
-    "whiteAlpha.700",
-    "whiteAlpha.400",
-  );
+  let isSelected = useMatch(`traces/${data[index].traceID}`);
 
-  const selectedColour = useColorModeValue("teal.100", "teal.900");
+  let backgroundColour = isSelected
+    ? useColorModeValue("teal.100", "teal.700")
+    : useColorModeValue("whiteAlpha.700", "whiteAlpha.400");
 
   return (
     <div style={style}>
@@ -41,7 +35,6 @@ function Row({ index, style, data }: RowProps) {
         marginX="10px"
         marginTop="10px"
         rounded="md"
-        _selected={{ bgColor: { selectedColour } }} // This is too much curlies
       >
         <Heading
           marginY="1"
@@ -56,7 +49,7 @@ function Row({ index, style, data }: RowProps) {
           </LinkOverlay>
         </Heading>
         <Text>Number of spans: {data[index].spanCount}</Text>
-        <Text>Duration: {data[index].spanCount}</Text>
+        <Text>Duration: {data[index].durationMS} ms</Text>
       </LinkBox>
     </div>
   );

--- a/desktop-exporter/app/components/traceList.tsx
+++ b/desktop-exporter/app/components/traceList.tsx
@@ -1,7 +1,19 @@
 import React, { useRef } from "react";
 import { FixedSizeList } from "react-window";
 import { NavLink } from "react-router-dom";
-import { Flex } from "@chakra-ui/react";
+import {
+  Box,
+  Card,
+  CardBody,
+  Flex,
+  Heading,
+  LinkBox,
+  LinkOverlay,
+  Stack,
+  StackDivider,
+  Text,
+  useColorModeValue,
+} from "@chakra-ui/react";
 import { useSize } from "@chakra-ui/react-use-size";
 
 import { TraceSummary } from "../types/api-types";
@@ -13,13 +25,40 @@ type RowProps = {
 };
 
 function Row({ index, style, data }: RowProps) {
+  const backgroundColour = useColorModeValue(
+    "whiteAlpha.700",
+    "whiteAlpha.400",
+  );
+
+  const selectedColour = useColorModeValue("teal.100", "teal.900");
+
   return (
-    <NavLink
-      to={`traces/${data[index].traceID}`}
-      style={style}
-    >
-      {data[index].traceID}
-    </NavLink>
+    <div style={style}>
+      <LinkBox
+        bgColor={backgroundColour}
+        height="100px"
+        padding="10px"
+        marginX="10px"
+        marginTop="10px"
+        rounded="md"
+        _selected={{ bgColor: { selectedColour } }} // This is too much curlies
+      >
+        <Heading
+          marginY="1"
+          noOfLines={1}
+          size="sm"
+        >
+          <LinkOverlay
+            as={NavLink}
+            to={`traces/${data[index].traceID}`}
+          >
+            {data[index].traceID}
+          </LinkOverlay>
+        </Heading>
+        <Text>Number of spans: {data[index].spanCount}</Text>
+        <Text>Duration: {data[index].spanCount}</Text>
+      </LinkBox>
+    </div>
   );
 }
 
@@ -40,7 +79,7 @@ export function TraceList(props: TraceListProps) {
         height={size ? size.height : 0}
         itemData={props.traceSummaries}
         itemCount={props.traceSummaries.length}
-        itemSize={50}
+        itemSize={110}
         width="100%"
       >
         {Row}


### PR DESCRIPTION
- Style the list of traces in the sidebar to display their traceID and summaries
- Make the background colour of the `LinkBox` reflect which trace is currently selected.
![sidebar-select](https://user-images.githubusercontent.com/56372758/206548569-4567e2bc-ec25-4a50-890d-551da604afb6.jpg)
![sidebar-select-dark](https://user-images.githubusercontent.com/56372758/206548595-d58eb65f-4d51-4974-b1b3-f0a028285da4.jpg)
