### PR TITLE
style the base layout for waterfall view

### DIFF
--- a/desktop-exporter/app/components/waterfall-view/waterfall-view.tsx
+++ b/desktop-exporter/app/components/waterfall-view/waterfall-view.tsx
@@ -1,0 +1,130 @@
+import React, { useRef } from "react";
+import { FixedSizeList } from "react-window";
+import {
+  Text,
+  Flex,
+  Heading,
+  Spacer,
+  useColorModeValue,
+} from "@chakra-ui/react";
+import { useSize } from "@chakra-ui/react-use-size";
+
+import { SpanData } from "../../types/api-types";
+
+const waterfallItemHeight = 50;
+
+type WaterfallRowProps = {
+  index: number;
+  style: React.CSSProperties;
+  data: WaterfallViewProps;
+};
+
+function WaterfallRow({ index, style, data }: WaterfallRowProps) {
+  let { spans, selectedSpanID, setSelectedSpanID } = data;
+  let span = spans[index];
+
+  // Add zero-width space after forward slashes, dashes, and dots
+  // to indicate line breaking opportunity
+  let nameLabel = span.name.replaceAll("/", "/\u200B");
+  nameLabel = span.name.replaceAll("-", "-\u200B");
+  nameLabel = span.name.replaceAll(".", ".\u200B");
+
+  // Set the background colour to make the list striped.
+  let backgroundColour =
+    index % 2 ? "" : useColorModeValue("gray.50", "gray.700");
+  let borderLeft = "none";
+
+  //Set the style for the selected item
+  if (!!selectedSpanID && selectedSpanID === span.spanID) {
+    backgroundColour = useColorModeValue("pink.50", "pink.900");
+    borderLeft = "5px solid";
+  }
+
+  return (
+    <Flex
+      style={style}
+      bgColor={backgroundColour}
+      borderLeft={borderLeft}
+      borderColor="pink.500"
+      onClick={() => setSelectedSpanID(span.spanID)}
+    >
+      <Flex
+        width={244}
+        alignItems="center"
+        paddingStart={2}
+      >
+        <Text
+          noOfLines={2}
+          fontSize="sm"
+        >
+          {nameLabel}
+        </Text>
+      </Flex>
+      <Flex
+        width={120}
+        alignItems="center"
+        paddingStart={3}
+      >
+        <Text fontSize="sm">{span.resource.attributes["service.name"]}</Text>
+      </Flex>
+      <Spacer />
+    </Flex>
+  );
+}
+
+function HeaderRow() {
+  return (
+    <Flex height="30px">
+      <Flex
+        width={244}
+        alignItems="center"
+      >
+        <Heading
+          paddingStart={2}
+          size="sm"
+        >
+          name
+        </Heading>
+      </Flex>
+      <Flex
+        width={120}
+        alignItems="center"
+        paddingStart={3}
+      >
+        <Heading size="sm">service.name</Heading>
+      </Flex>
+      <Spacer />
+    </Flex>
+  );
+}
+
+type WaterfallViewProps = {
+  spans: SpanData[];
+  selectedSpanID: string | undefined;
+  setSelectedSpanID: (spanID: string) => void;
+};
+
+export function WaterfallView(props: WaterfallViewProps) {
+  const ref = useRef(null);
+  const size = useSize(ref);
+
+  return (
+    <Flex
+      direction="column"
+      ref={ref}
+      height="100%"
+    >
+      <HeaderRow />
+      <FixedSizeList
+        className="List"
+        height={size ? size.height - waterfallItemHeight : 0}
+        itemData={props}
+        itemCount={props.spans.length}
+        itemSize={waterfallItemHeight}
+        width={"100%"}
+      >
+        {WaterfallRow}
+      </FixedSizeList>
+    </Flex>
+  );
+}

--- a/desktop-exporter/app/components/waterfall-view/waterfall-view.tsx
+++ b/desktop-exporter/app/components/waterfall-view/waterfall-view.tsx
@@ -43,16 +43,6 @@ function WaterfallRow({ index, style, data }: WaterfallRowProps) {
     .replaceAll("-", "-\u200B")
     .replaceAll(".", ".\u200B");
 
-  let stripZeroWidthSpaces = (e: ClipboardEvent<HTMLParagraphElement>) => {
-    let selection = window.getSelection();
-    if (!selection) {
-      return;
-    }
-    let text = selection.toString().replaceAll("\u200B", "");
-    e.clipboardData?.setData("text/plain", text);
-    e.preventDefault();
-  };
-
   return (
     <Flex
       style={style}
@@ -67,7 +57,6 @@ function WaterfallRow({ index, style, data }: WaterfallRowProps) {
         <Text
           noOfLines={2}
           fontSize="sm"
-          onCopy={(e) => stripZeroWidthSpaces(e)}
         >
           {nameLabel}
         </Text>
@@ -125,6 +114,7 @@ export function WaterfallView(props: WaterfallViewProps) {
       direction="column"
       ref={ref}
       height="100%"
+      onCopy={stripZeroWidthSpacesOnCopyCallback}
     >
       <HeaderRow />
       <FixedSizeList
@@ -139,4 +129,16 @@ export function WaterfallView(props: WaterfallViewProps) {
       </FixedSizeList>
     </Flex>
   );
+}
+
+function stripZeroWidthSpacesOnCopyCallback(
+  e: ClipboardEvent<HTMLParagraphElement>,
+) {
+  let selection = window.getSelection();
+  if (!selection) {
+    return;
+  }
+  let text = selection.toString().replaceAll("\u200B", "");
+  e.clipboardData?.setData("text/plain", text);
+  e.preventDefault();
 }

--- a/desktop-exporter/app/routes/trace-view.tsx
+++ b/desktop-exporter/app/routes/trace-view.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { useLoaderData } from "react-router-dom";
-import { FixedSizeList } from "react-window";
 import { Grid, GridItem } from "@chakra-ui/react";
 
 import { Header } from "../components/header";
 import { DetailView } from "../components/detail-view/detail-view";
-import { SpanData, TraceData } from "../types/api-types";
+import { WaterfallView } from "../components/waterfall-view/waterfall-view";
+import { TraceData } from "../types/api-types";
 
 export async function traceLoader({ params }: any) {
   const response = await fetch(`/api/traces/${params.traceID}`);
@@ -13,53 +13,7 @@ export async function traceLoader({ params }: any) {
   return traceData;
 }
 
-type WaterfallRowProps = {
-  index: number;
-  style: React.CSSProperties;
-  data: WaterfallViewProps;
-};
 
-function WaterfallRow({ index, style, data }: WaterfallRowProps) {
-  let { spans, selectedSpanID, setSelectedSpanID } = data;
-  let span = spans[index];
-
-  let className = "waterfall-item";
-  className += index % 2 ? " odd" : " even";
-  if (!!selectedSpanID) {
-    className += span.spanID === selectedSpanID ? " active" : "";
-  }
-
-  return (
-    <div
-      className={className}
-      style={style}
-      onClick={() => setSelectedSpanID(span.spanID)}
-    >
-      Name: {span.name} SpanID: {span.spanID}
-    </div>
-  );
-}
-
-type WaterfallViewProps = {
-  spans: SpanData[];
-  selectedSpanID: string | undefined;
-  setSelectedSpanID: (spanID: string) => void;
-};
-
-function WaterfallView(props: WaterfallViewProps) {
-  return (
-    <FixedSizeList
-      className="List"
-      height={300}
-      itemData={props}
-      itemCount={props.spans.length}
-      itemSize={30}
-      width={"100%"}
-    >
-      {WaterfallRow}
-    </FixedSizeList>
-  );
-}
 
 export default function TraceView() {
   const traceData = useLoaderData() as TraceData;
@@ -89,7 +43,10 @@ export default function TraceView() {
       <GridItem area={"header"}>
         <Header traceID={traceData.traceID} />
       </GridItem>
-      <GridItem area={"main"}>
+      <GridItem
+        area={"main"}
+        marginLeft="20px"
+      >
         <WaterfallView
           spans={traceData.spans}
           selectedSpanID={selectedSpanID}


### PR DESCRIPTION
This is only the base of what the waterfall view will eventually look like. The list is unordered, unindented, and doesn't include the duration bars.

It does set the height of the list, create a header, and define the selection style and behaviour for each span.

![waterfall-unsorted-no-bars](https://user-images.githubusercontent.com/56372758/208554007-7698f75d-b743-42d2-a09d-a80396ab79a7.jpg)
![waterfall-unsorted-no-bars-dark](https://user-images.githubusercontent.com/56372758/208554020-41a341c9-3b72-4d53-a235-56e94d4178c8.jpg)
