### PR TITLE
First Pass at Ordering Spans for Display in Waterfall View

### DIFF
--- a/desktop-exporter/app/components/waterfall-view/waterfall-row.tsx
+++ b/desktop-exporter/app/components/waterfall-view/waterfall-row.tsx
@@ -37,6 +37,9 @@ export function WaterfallRow({ index, style, data }: WaterfallRowProps) {
     backgroundColour = selectedColour;
   }
 
+  // Set the padding to indicate parent/children relationship between spans
+  let paddingLeft = span.depth ? span.depth * 25 : 0;
+
   // Add zero-width space after forward slashes, dashes, and dots
   // to indicate line breaking opportunity
   let nameLabel = span.name
@@ -48,10 +51,11 @@ export function WaterfallRow({ index, style, data }: WaterfallRowProps) {
     <Flex
       style={style}
       bgColor={backgroundColour}
+      paddingLeft={`${paddingLeft}px`}
       onClick={() => setSelectedSpanID(span.spanID)}
     >
       <Flex
-        width={spanNameColumnWidth}
+        width={spanNameColumnWidth - paddingLeft}
         alignItems="center"
         paddingStart={2}
       >

--- a/desktop-exporter/app/components/waterfall-view/waterfall-row.tsx
+++ b/desktop-exporter/app/components/waterfall-view/waterfall-row.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Text, Flex, Spacer, useColorModeValue } from "@chakra-ui/react";
 
-import { SpanData } from "../../types/api-types";
+import { SpanWithMetadata } from "../../types/metadata-types";
 
 type WaterfallRowData = {
-  spans: SpanData[];
+  orderedSpans: SpanWithMetadata[];
   spanNameColumnWidth: number;
   serviceNameColumnWidth: number;
   selectedSpanID: string | undefined;
@@ -19,13 +19,14 @@ type WaterfallRowProps = {
 
 export function WaterfallRow({ index, style, data }: WaterfallRowProps) {
   let {
-    spans,
+    orderedSpans,
     spanNameColumnWidth,
     serviceNameColumnWidth,
     selectedSpanID,
     setSelectedSpanID,
   } = data;
-  let span = spans[index];
+  let span = orderedSpans[index].span;
+  let spanDepth = orderedSpans[index].metadata.depth;
 
   // Set the background colour to make the list striped.
   let backgroundColour =
@@ -38,7 +39,7 @@ export function WaterfallRow({ index, style, data }: WaterfallRowProps) {
   }
 
   // Set the padding to indicate parent/children relationship between spans
-  let paddingLeft = span.depth ? span.depth * 25 : 0;
+  let paddingLeft = spanDepth ? spanDepth * 25 : 0;
 
   // Add zero-width space after forward slashes, dashes, and dots
   // to indicate line breaking opportunity

--- a/desktop-exporter/app/components/waterfall-view/waterfall-view.tsx
+++ b/desktop-exporter/app/components/waterfall-view/waterfall-view.tsx
@@ -20,8 +20,8 @@ export function WaterfallView(props: WaterfallViewProps) {
 
   const waterfallItemHeight = 50;
   const headerRowHeight = 30;
-  const spanNameColumnWidth = 244;
-  const serviceNameColumnWidth = 120;
+  const spanNameColumnWidth = 250;
+  const serviceNameColumnWidth = 250;
 
   let traceDuration = getTraceDuration(props.spans);
 
@@ -71,3 +71,4 @@ function stripZeroWidthSpacesOnCopyCallback(
   e.clipboardData?.setData("text/plain", text);
   e.preventDefault();
 }
+

--- a/desktop-exporter/app/components/waterfall-view/waterfall-view.tsx
+++ b/desktop-exporter/app/components/waterfall-view/waterfall-view.tsx
@@ -3,13 +3,13 @@ import { FixedSizeList } from "react-window";
 import { Flex } from "@chakra-ui/react";
 import { useSize } from "@chakra-ui/react-use-size";
 
-import { getTraceDuration } from "../../utils/duration";
-import { SpanData } from "../../types/api-types";
+import { SpanWithMetadata } from "../../types/metadata-types";
 import { WaterfallRow } from "./waterfall-row";
 import { HeaderRow } from "./header-row";
 
 type WaterfallViewProps = {
-  spans: SpanData[];
+  orderedSpans: SpanWithMetadata[];
+  traceDurationNs: number;
   selectedSpanID: string | undefined;
   setSelectedSpanID: (spanID: string) => void;
 };
@@ -23,10 +23,8 @@ export function WaterfallView(props: WaterfallViewProps) {
   const spanNameColumnWidth = 250;
   const serviceNameColumnWidth = 250;
 
-  let traceDuration = getTraceDuration(props.spans);
-
   let rowData = {
-    spans: props.spans,
+    orderedSpans: props.orderedSpans,
     spanNameColumnWidth: spanNameColumnWidth,
     serviceNameColumnWidth: serviceNameColumnWidth,
     selectedSpanID: props.selectedSpanID,
@@ -44,13 +42,13 @@ export function WaterfallView(props: WaterfallViewProps) {
         headerRowHeight={headerRowHeight}
         spanNameColumnWidth={spanNameColumnWidth}
         serviceNameColumnWidth={serviceNameColumnWidth}
-        traceDuration={traceDuration}
+        traceDuration={props.traceDurationNs}
       />
       <FixedSizeList
         className="List"
         height={size ? size.height - headerRowHeight : 0}
         itemData={rowData}
-        itemCount={props.spans.length}
+        itemCount={props.orderedSpans.length}
         itemSize={waterfallItemHeight}
         width={"100%"}
       >

--- a/desktop-exporter/app/routes/trace-view.tsx
+++ b/desktop-exporter/app/routes/trace-view.tsx
@@ -1,32 +1,37 @@
 import React from "react";
 import { useLoaderData } from "react-router-dom";
 import { Grid, GridItem } from "@chakra-ui/react";
+import { arrayToTree, TreeItem } from "performant-array-to-tree";
 
 import { Header } from "../components/header";
 import { DetailView } from "../components/detail-view/detail-view";
 import { WaterfallView } from "../components/waterfall-view/waterfall-view";
-import { TraceData } from "../types/api-types";
+import { getNsFromString } from "../utils/duration";
+import { TraceData, SpanData } from "../types/api-types";
 
 export async function traceLoader({ params }: any) {
-  const response = await fetch(`/api/traces/${params.traceID}`);
-  const traceData = await response.json();
+  let response = await fetch(`/api/traces/${params.traceID}`);
+  let traceData = await response.json();
   return traceData;
 }
 
-
-
 export default function TraceView() {
-  const traceData = useLoaderData() as TraceData;
-  const [selectedSpanID, setSelectedSpanID] = React.useState<string>(
-    traceData.spans.length ? traceData.spans[0].spanID : "",
+  let traceData = useLoaderData() as TraceData;
+  let spanTree = arrayToTree(traceData.spans, {
+    id: "spanID",
+    parentId: "parentSpanID",
+  });
+  let orderedSpans = orderSpans(spanTree[0], 0, []);
+  let [selectedSpanID, setSelectedSpanID] = React.useState<string>(
+    orderedSpans.length ? orderedSpans[0].spanID : "",
   );
 
   // if we get a new trace because the route changed, reset the selected span
   React.useEffect(() => {
-    setSelectedSpanID(traceData.spans[0].spanID);
+    setSelectedSpanID(orderedSpans[0].spanID);
   }, [traceData]);
 
-  const selectedSpan = traceData.spans.find(
+  let selectedSpan = traceData.spans.find(
     (span) => span.spanID === selectedSpanID,
   );
 
@@ -48,7 +53,7 @@ export default function TraceView() {
         marginLeft="20px"
       >
         <WaterfallView
-          spans={traceData.spans}
+          spans={orderedSpans}
           selectedSpanID={selectedSpanID}
           setSelectedSpanID={setSelectedSpanID}
         />
@@ -58,4 +63,26 @@ export default function TraceView() {
       </GridItem>
     </Grid>
   );
+}
+
+function orderSpans(
+  parentNode: TreeItem,
+  depth: number,
+  orderedSpans: SpanData[],
+) {
+  let parentSpan = parentNode.data;
+  parentSpan.depth = depth;
+  orderedSpans.push(parentSpan);
+
+  let children = parentNode.children.sort(
+    // Not sure if this is how you write this in typescript, but I did my best
+    (a: { data: { startTime: string } }, b: { data: { startTime: string } }) =>
+      getNsFromString(a.data.startTime) - getNsFromString(b.data.startTime),
+  );
+
+  children.forEach((node: TreeItem) => {
+    orderedSpans = orderSpans(node, depth + 1, orderedSpans);
+  });
+
+  return orderedSpans;
 }

--- a/desktop-exporter/app/types/api-types.ts
+++ b/desktop-exporter/app/types/api-types.ts
@@ -36,8 +36,6 @@ export type SpanData = {
 
   statusCode: string;
   statusMessage: string;
-
-  depth?: number;
 };
 
 export type ResourceData = {

--- a/desktop-exporter/app/types/api-types.ts
+++ b/desktop-exporter/app/types/api-types.ts
@@ -36,6 +36,8 @@ export type SpanData = {
 
   statusCode: string;
   statusMessage: string;
+
+  depth?: number;
 };
 
 export type ResourceData = {

--- a/desktop-exporter/app/types/metadata-types.ts
+++ b/desktop-exporter/app/types/metadata-types.ts
@@ -1,0 +1,10 @@
+import { SpanData } from "./api-types";
+
+export type SpanMetaData = {
+  depth: number;
+};
+
+export type SpanWithMetadata = {
+  span: SpanData;
+  metadata: SpanMetaData;
+};

--- a/desktop-exporter/app/utils/duration.ts
+++ b/desktop-exporter/app/utils/duration.ts
@@ -46,7 +46,7 @@ export function getSpanDurationString(
   return `${durationNs} ns`;
 }
 
-export function getTraceDuration(spans: SpanData[]) {
+export function getTraceDurationNs(spans: SpanData[]) {
   if (!spans.length) {
     return 0;
   }

--- a/desktop-exporter/app/utils/duration.ts
+++ b/desktop-exporter/app/utils/duration.ts
@@ -69,7 +69,7 @@ export function getTraceDuration(spans: SpanData[]) {
   return latestEndTime - earliestStartTime;
 }
 
-function getNsFromString(timestampString: string) {
+export function getNsFromString(timestampString: string) {
   let milliseconds = Date.parse(timestampString.split(".")[0]);
   let nanoseconds =
     milliseconds * 1e6 + Timestamp.fromString(timestampString).getNano();

--- a/desktop-exporter/package-lock.json
+++ b/desktop-exporter/package-lock.json
@@ -8,7 +8,7 @@
             "name": "desktop-exporter",
             "version": "1.0.0",
             "dependencies": {
-                "timestamp-nano": "^1.0.0"
+                "performant-array-to-tree": "^1.11.0"
             },
             "devDependencies": {
                 "@chakra-ui/icons": "^2.0.12",
@@ -25,6 +25,7 @@
                 "react-dom": "^18.2.0",
                 "react-router-dom": "^6.4.3",
                 "react-window": "^1.8.8",
+                "timestamp-nano": "^1.0.0",
                 "typescript": "^4.9.3"
             }
         },
@@ -2933,6 +2934,11 @@
                 "node": ">=8"
             }
         },
+        "node_modules/performant-array-to-tree": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/performant-array-to-tree/-/performant-array-to-tree-1.11.0.tgz",
+            "integrity": "sha512-YwCqIDvnaebXaKuKQhI5yJD6ryDc3FxvoeX/5ougXTKDUWb7s5S2BuBgIyftCa4sBe1+ZU5Kmi4RJy+pjjjrpw=="
+        },
         "node_modules/picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -3294,6 +3300,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.0.tgz",
             "integrity": "sha512-NO/1CZigzlCWQiWdIGv8ebXt6Uk77zdLz2NE7KcZRU5Egj2+947lzUpk30xQUQlq5dRY25j7ZulG4RfA2DHYfA==",
+            "dev": true,
             "engines": {
                 "node": ">= 4.5.0"
             }
@@ -5580,6 +5587,11 @@
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true
         },
+        "performant-array-to-tree": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/performant-array-to-tree/-/performant-array-to-tree-1.11.0.tgz",
+            "integrity": "sha512-YwCqIDvnaebXaKuKQhI5yJD6ryDc3FxvoeX/5ougXTKDUWb7s5S2BuBgIyftCa4sBe1+ZU5Kmi4RJy+pjjjrpw=="
+        },
         "picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -5837,7 +5849,8 @@
         "timestamp-nano": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.0.tgz",
-            "integrity": "sha512-NO/1CZigzlCWQiWdIGv8ebXt6Uk77zdLz2NE7KcZRU5Egj2+947lzUpk30xQUQlq5dRY25j7ZulG4RfA2DHYfA=="
+            "integrity": "sha512-NO/1CZigzlCWQiWdIGv8ebXt6Uk77zdLz2NE7KcZRU5Egj2+947lzUpk30xQUQlq5dRY25j7ZulG4RfA2DHYfA==",
+            "dev": true
         },
         "tiny-invariant": {
             "version": "1.3.1",

--- a/desktop-exporter/package.json
+++ b/desktop-exporter/package.json
@@ -21,7 +21,7 @@
         "react-window": "^1.8.8",
         "timestamp-nano": "^1.0.0",
         "typescript": "^4.9.3",
-         "performant-array-to-tree": "^1.11.0"
+        "performant-array-to-tree": "^1.11.0"
     },
     "prettier": {
         "jsxSingleQuote": false,

--- a/desktop-exporter/package.json
+++ b/desktop-exporter/package.json
@@ -20,7 +20,8 @@
         "react-router-dom": "^6.4.3",
         "react-window": "^1.8.8",
         "timestamp-nano": "^1.0.0",
-        "typescript": "^4.9.3"
+        "typescript": "^4.9.3",
+         "performant-array-to-tree": "^1.11.0"
     },
     "prettier": {
         "jsxSingleQuote": false,


### PR DESCRIPTION
Spans are ordered according to their parent/child relationships. Additionally, spans that share a `parentSpanID` are sorted by earliest start time. 

This is being done in `TraceView` rather than `WaterfallView` because that is where we set the `selectedSpanID` when changing routes. It was simpler to pull the whole thing up and pass the sorted array to `WaterfallView`. 

Currently, orphan spans and incomplete trees aren't handled. I will do this thing in my next PR.

Also, the depth is visually represented with padding, which is not very clear. I will find a better solution once I have taken care of the orphans. I'm aware that I sound like a supervillain. This is fine. 

![OrderedSpansPass1](https://user-images.githubusercontent.com/56372758/210431385-29b4cc73-9822-4383-ab4c-25412729910e.jpg)
