### PR TITLE
Handle orphan spans in WaterfallView

### DIFF
--- a/desktop-exporter/app/components/waterfall-view/waterfall-row.tsx
+++ b/desktop-exporter/app/components/waterfall-view/waterfall-row.tsx
@@ -25,7 +25,7 @@ export function WaterfallRow({ index, style, data }: WaterfallRowProps) {
     selectedSpanID,
     setSelectedSpanID,
   } = data;
-  let span = orderedSpans[index].span;
+  let { spanID, spanData } = orderedSpans[index];
   let spanDepth = orderedSpans[index].metadata.depth;
 
   // Set the background colour to make the list striped.
@@ -34,7 +34,7 @@ export function WaterfallRow({ index, style, data }: WaterfallRowProps) {
   let selectedColour = useColorModeValue("pink.50", "pink.900");
 
   //Set the style for the selected item
-  if (!!selectedSpanID && selectedSpanID === span.spanID) {
+  if (!!selectedSpanID && selectedSpanID === spanID) {
     backgroundColour = selectedColour;
   }
 
@@ -43,17 +43,22 @@ export function WaterfallRow({ index, style, data }: WaterfallRowProps) {
 
   // Add zero-width space after forward slashes, dashes, and dots
   // to indicate line breaking opportunity
-  let nameLabel = span.name
-    .replaceAll("/", "/\u200B")
-    .replaceAll("-", "-\u200B")
-    .replaceAll(".", ".\u200B");
+  let nameLabel = spanData
+    ? spanData.name
+        .replaceAll("/", "/\u200B")
+        .replaceAll("-", "-\u200B")
+        .replaceAll(".", ".\u200B")
+    : "missing span";
 
+  let resourceLabel = spanData
+    ? spanData.resource.attributes["service.name"]
+    : "";
   return (
     <Flex
       style={style}
       bgColor={backgroundColour}
       paddingLeft={`${paddingLeft}px`}
-      onClick={() => setSelectedSpanID(span.spanID)}
+      onClick={() => setSelectedSpanID(spanID)}
     >
       <Flex
         width={spanNameColumnWidth - paddingLeft}
@@ -72,7 +77,7 @@ export function WaterfallRow({ index, style, data }: WaterfallRowProps) {
         alignItems="center"
         paddingStart={3}
       >
-        <Text fontSize="sm">{span.resource.attributes["service.name"]}</Text>
+        <Text fontSize="sm">{}</Text>
       </Flex>
       <Spacer />
     </Flex>

--- a/desktop-exporter/app/components/waterfall-view/waterfall-row.tsx
+++ b/desktop-exporter/app/components/waterfall-view/waterfall-row.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Text, Flex, Spacer, useColorModeValue } from "@chakra-ui/react";
+import { WarningTwoIcon } from "@chakra-ui/icons";
 
-import { SpanWithUIData } from "../../types/metadata-types";
+import { SpanDataStatus, SpanWithUIData } from "../../types/metadata-types";
 
 type WaterfallRowData = {
   orderedSpans: SpanWithUIData[];
@@ -32,61 +33,65 @@ export function WaterfallRow({ index, style, data }: WaterfallRowProps) {
   // Set the background colour to make the list striped.
   let backgroundColour =
     index % 2 ? "" : useColorModeValue("gray.50", "gray.700");
-  let missingColour = useColorModeValue("orange.100", "orange.700");
   let selectedColour = useColorModeValue("pink.50", "pink.900");
 
-  // Set the padding to indicate parent/children relationship between spans
-  let paddingLeft = depth * 25;
+  if (span.status === SpanDataStatus.present) {
+    // Set the padding to indicate parent/children relationship between spans
+    let paddingLeft = depth * 25;
 
-  let nameLabel;
-  let resourceLabel;
-
-  if (span.status) {
     //Set the style for the selected item
     if (!!selectedSpanID && selectedSpanID === spanID) {
       backgroundColour = selectedColour;
     }
     // Add zero-width space after forward slashes, dashes, and dots
     // to indicate line breaking opportunity
-    nameLabel = span.spanData.name
+    let nameLabel = span.spanData.name
       .replaceAll("/", "/\u200B")
       .replaceAll("-", "-\u200B")
       .replaceAll(".", ".\u200B");
 
-    resourceLabel = span.spanData.resource.attributes["service.name"];
-  } else {
-    backgroundColour = missingColour;
-    nameLabel = `missing span [${spanID}]`;
-    resourceLabel = "";
-  }
+    let resourceLabel = span.spanData.resource.attributes["service.name"];
 
+    return (
+      <Flex
+        style={style}
+        bgColor={backgroundColour}
+        paddingLeft={`${paddingLeft}px`}
+        onClick={() => setSelectedSpanID(spanID)}
+      >
+        <Flex
+          width={spanNameColumnWidth - paddingLeft}
+          alignItems="center"
+          paddingStart={2}
+        >
+          <Text
+            noOfLines={2}
+            fontSize="sm"
+          >
+            {nameLabel}
+          </Text>
+        </Flex>
+        <Flex
+          width={serviceNameColumnWidth}
+          alignItems="center"
+          paddingStart={3}
+        >
+          <Text fontSize="sm">{resourceLabel}</Text>
+        </Flex>
+        <Spacer />
+      </Flex>
+    );
+  }
   return (
     <Flex
       style={style}
+      alignItems="center"
       bgColor={backgroundColour}
-      paddingLeft={`${paddingLeft}px`}
-      onClick={() => (span.status ? setSelectedSpanID(spanID) : "")}
+      paddingStart={2}
+      experimental_spaceX={2}
     >
-      <Flex
-        width={spanNameColumnWidth - paddingLeft}
-        alignItems="center"
-        paddingStart={2}
-      >
-        <Text
-          noOfLines={2}
-          fontSize="sm"
-        >
-          {nameLabel}
-        </Text>
-      </Flex>
-      <Flex
-        width={serviceNameColumnWidth}
-        alignItems="center"
-        paddingStart={3}
-      >
-        <Text fontSize="sm">{}</Text>
-      </Flex>
-      <Spacer />
+      <WarningTwoIcon color="orange.500" />
+      <Text fontSize="sm">{`Missing Span [Span ID:${spanID}]`}</Text>
     </Flex>
   );
 }

--- a/desktop-exporter/app/components/waterfall-view/waterfall-row.tsx
+++ b/desktop-exporter/app/components/waterfall-view/waterfall-row.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Text, Flex, Spacer, useColorModeValue } from "@chakra-ui/react";
 
-import { SpanWithMetadata } from "../../types/metadata-types";
+import { SpanWithUIData } from "../../types/metadata-types";
 
 type WaterfallRowData = {
-  orderedSpans: SpanWithMetadata[];
+  orderedSpans: SpanWithUIData[];
   spanNameColumnWidth: number;
   serviceNameColumnWidth: number;
   selectedSpanID: string | undefined;
@@ -25,40 +25,47 @@ export function WaterfallRow({ index, style, data }: WaterfallRowProps) {
     selectedSpanID,
     setSelectedSpanID,
   } = data;
-  let { spanID, spanData } = orderedSpans[index];
-  let spanDepth = orderedSpans[index].metadata.depth;
+
+  let span = orderedSpans[index];
+  let { spanID, depth } = span.metadata;
 
   // Set the background colour to make the list striped.
   let backgroundColour =
     index % 2 ? "" : useColorModeValue("gray.50", "gray.700");
+  let missingColour = useColorModeValue("orange.100", "orange.700");
   let selectedColour = useColorModeValue("pink.50", "pink.900");
 
-  //Set the style for the selected item
-  if (!!selectedSpanID && selectedSpanID === spanID) {
-    backgroundColour = selectedColour;
+  // Set the padding to indicate parent/children relationship between spans
+  let paddingLeft = depth * 25;
+
+  let nameLabel;
+  let resourceLabel;
+
+  if (span.status) {
+    //Set the style for the selected item
+    if (!!selectedSpanID && selectedSpanID === spanID) {
+      backgroundColour = selectedColour;
+    }
+    // Add zero-width space after forward slashes, dashes, and dots
+    // to indicate line breaking opportunity
+    nameLabel = span.spanData.name
+      .replaceAll("/", "/\u200B")
+      .replaceAll("-", "-\u200B")
+      .replaceAll(".", ".\u200B");
+
+    resourceLabel = span.spanData.resource.attributes["service.name"];
+  } else {
+    backgroundColour = missingColour;
+    nameLabel = `missing span [${spanID}]`;
+    resourceLabel = "";
   }
 
-  // Set the padding to indicate parent/children relationship between spans
-  let paddingLeft = spanDepth ? spanDepth * 25 : 0;
-
-  // Add zero-width space after forward slashes, dashes, and dots
-  // to indicate line breaking opportunity
-  let nameLabel = spanData
-    ? spanData.name
-        .replaceAll("/", "/\u200B")
-        .replaceAll("-", "-\u200B")
-        .replaceAll(".", ".\u200B")
-    : "missing span";
-
-  let resourceLabel = spanData
-    ? spanData.resource.attributes["service.name"]
-    : "";
   return (
     <Flex
       style={style}
       bgColor={backgroundColour}
       paddingLeft={`${paddingLeft}px`}
-      onClick={() => setSelectedSpanID(spanID)}
+      onClick={() => (span.status ? setSelectedSpanID(spanID) : "")}
     >
       <Flex
         width={spanNameColumnWidth - paddingLeft}

--- a/desktop-exporter/app/components/waterfall-view/waterfall-view.tsx
+++ b/desktop-exporter/app/components/waterfall-view/waterfall-view.tsx
@@ -3,12 +3,12 @@ import { FixedSizeList } from "react-window";
 import { Flex } from "@chakra-ui/react";
 import { useSize } from "@chakra-ui/react-use-size";
 
-import { SpanWithMetadata } from "../../types/metadata-types";
+import { SpanWithUIData } from "../../types/metadata-types";
 import { WaterfallRow } from "./waterfall-row";
 import { HeaderRow } from "./header-row";
 
 type WaterfallViewProps = {
-  orderedSpans: SpanWithMetadata[];
+  orderedSpans: SpanWithUIData[];
   traceDurationNs: number;
   selectedSpanID: string | undefined;
   setSelectedSpanID: (spanID: string) => void;

--- a/desktop-exporter/app/routes/trace-view.tsx
+++ b/desktop-exporter/app/routes/trace-view.tsx
@@ -24,7 +24,6 @@ export default function TraceView() {
   let spanTree: TreeItem[] = [];
 
   spanTree = arrayToTree(traceData.spans);
-  console.log(spanTree);
 
   for (let root of spanTree) {
     let stack = [

--- a/desktop-exporter/app/types/metadata-types.ts
+++ b/desktop-exporter/app/types/metadata-types.ts
@@ -1,8 +1,8 @@
 import { SpanData } from "./api-types";
 
 export enum SpanDataStatus {
-  missing,
-  present,
+  missing = "missing",
+  present = "present",
 }
 
 export type SpanUIData = {

--- a/desktop-exporter/app/types/metadata-types.ts
+++ b/desktop-exporter/app/types/metadata-types.ts
@@ -1,11 +1,22 @@
 import { SpanData } from "./api-types";
 
-export type SpanMetaData = {
+export enum SpanDataStatus {
+  missing,
+  present,
+}
+
+export type SpanUIData = {
   depth: number;
+  spanID: string;
 };
 
-export type SpanWithMetadata = {
-  spanID: string;
-  spanData: SpanData | null;
-  metadata: SpanMetaData;
-};
+export type SpanWithUIData =
+  | {
+      status: SpanDataStatus.present;
+      spanData: SpanData;
+      metadata: SpanUIData;
+    }
+  | {
+      status: SpanDataStatus.missing;
+      metadata: SpanUIData;
+    };

--- a/desktop-exporter/app/types/metadata-types.ts
+++ b/desktop-exporter/app/types/metadata-types.ts
@@ -5,6 +5,7 @@ export type SpanMetaData = {
 };
 
 export type SpanWithMetadata = {
-  span: SpanData;
+  spanID: string;
+  spanData: SpanData | null;
   metadata: SpanMetaData;
 };

--- a/desktop-exporter/app/utils/array-to-tree.ts
+++ b/desktop-exporter/app/utils/array-to-tree.ts
@@ -1,45 +1,73 @@
 import { SpanData } from "../types/api-types";
+import { SpanDataStatus } from "../types/metadata-types";
 
-export interface TreeItem {
-  span: { spanID: string; spanData: SpanData | null };
-  children: TreeItem[];
-}
+export type TreeItem =
+  | {
+      status: SpanDataStatus.present;
+      spanData: SpanData;
+      children: TreeItem[];
+    }
+  | {
+      status: SpanDataStatus.missing;
+      spanID: string;
+      children: TreeItem[];
+    };
 
 export function arrayToTree(spans: SpanData[]): TreeItem[] {
   let rootItems: TreeItem[] = [];
   let lookup: { [spanID: string]: TreeItem } = {};
   let missingSpanIDs: Set<string> = new Set();
 
-  for (let span of spans) {
-    let { spanID, parentSpanID } = span;
+  for (let spanData of spans) {
+    let { spanID, parentSpanID } = spanData;
 
+    // If the span is not in the lookup structure yet, add it
     if (!lookup[spanID]) {
       lookup[spanID] = {
-        span: { spanID: spanID, spanData: span },
+        status: SpanDataStatus.present,
+        spanData: spanData,
         children: [],
       };
-    } else if (!lookup[spanID].span.spanData) {
-      lookup[spanID].span.spanData = span;
     }
 
-    missingSpanIDs.delete(spanID);
+    // If the span has been added to the lookup structure as a missing/incomplete parent
+    // on a previous pass, update it and mark it present, and remove it from the missing set.
+    // (See comment on next block of code - line 52ish)
+    if (lookup[spanID].status === SpanDataStatus.missing) {
+      let children = lookup[spanID].children;
+      lookup[spanID] = {
+        status: SpanDataStatus.present,
+        spanData: spanData,
+        children: children,
+      };
+      missingSpanIDs.delete(spanID);
+    }
 
     let treeItem = lookup[spanID];
 
+    // If the current span has no parentSpanID, add it to the rootItems
     if (!parentSpanID) {
       rootItems.push(treeItem);
     } else {
+      // If the current span's parentSpanID is not in the lookup structure yet, add it
+      // as a missing/incomplete span, to be updated in a subsequent loop if found
+      // (See comment on previous block of code - line 33ish)
       if (!lookup[parentSpanID]) {
         lookup[parentSpanID] = {
-          span: { spanID: parentSpanID, spanData: null },
+          status: SpanDataStatus.missing,
+          spanID: parentSpanID,
           children: [],
         };
+        // Add the partial span to the missing set.
         missingSpanIDs.add(parentSpanID);
       }
+
+      // Finally, add the current span to its parent's children array.
       lookup[parentSpanID].children.push(treeItem);
     }
   }
 
+  // In order to handle incomplete traces, the missing spans get added to rootItems
   for (let spanID of missingSpanIDs) {
     rootItems.push(lookup[spanID]);
   }

--- a/desktop-exporter/app/utils/array-to-tree.ts
+++ b/desktop-exporter/app/utils/array-to-tree.ts
@@ -1,0 +1,48 @@
+import { SpanData } from "../types/api-types";
+
+export interface TreeItem {
+  span: { spanID: string; spanData: SpanData | null };
+  children: TreeItem[];
+}
+
+export function arrayToTree(spans: SpanData[]): TreeItem[] {
+  let rootItems: TreeItem[] = [];
+  let lookup: { [spanID: string]: TreeItem } = {};
+  let missingSpanIDs: Set<string> = new Set();
+
+  for (let span of spans) {
+    let { spanID, parentSpanID } = span;
+
+    if (!lookup[spanID]) {
+      lookup[spanID] = {
+        span: { spanID: spanID, spanData: span },
+        children: [],
+      };
+    } else if (!lookup[spanID].span.spanData) {
+      lookup[spanID].span.spanData = span;
+    }
+
+    missingSpanIDs.delete(spanID);
+
+    let treeItem = lookup[spanID];
+
+    if (!parentSpanID) {
+      rootItems.push(treeItem);
+    } else {
+      if (!lookup[parentSpanID]) {
+        lookup[parentSpanID] = {
+          span: { spanID: parentSpanID, spanData: null },
+          children: [],
+        };
+        missingSpanIDs.add(parentSpanID);
+      }
+      lookup[parentSpanID].children.push(treeItem);
+    }
+  }
+
+  for (let spanID of missingSpanIDs) {
+    rootItems.push(lookup[spanID]);
+  }
+
+  return rootItems;
+}

--- a/desktop-exporter/app/utils/array-to-tree.ts
+++ b/desktop-exporter/app/utils/array-to-tree.ts
@@ -30,9 +30,9 @@ export function arrayToTree(spans: SpanData[]): TreeItem[] {
       };
     }
 
+    // Note A:
     // If the span has been added to the lookup structure as a missing/incomplete parent
-    // on a previous pass, update it and mark it present, and remove it from the missing set.
-    // (See comment on next block of code - line 52ish)
+    // on a previous pass (see Note B), update it and mark it present, and remove it from the missing set.
     if (lookup[spanID].status === SpanDataStatus.missing) {
       let children = lookup[spanID].children;
       lookup[spanID] = {
@@ -49,9 +49,9 @@ export function arrayToTree(spans: SpanData[]): TreeItem[] {
     if (!parentSpanID) {
       rootItems.push(treeItem);
     } else {
+      // Note B:
       // If the current span's parentSpanID is not in the lookup structure yet, add it
-      // as a missing/incomplete span, to be updated in a subsequent loop if found
-      // (See comment on previous block of code - line 33ish)
+      // as a missing/incomplete span, to be updated in a subsequent loop if found (see note A)
       if (!lookup[parentSpanID]) {
         lookup[parentSpanID] = {
           status: SpanDataStatus.missing,
@@ -67,7 +67,8 @@ export function arrayToTree(spans: SpanData[]): TreeItem[] {
     }
   }
 
-  // In order to handle incomplete traces, the missing spans get added to rootItems
+  // In order to handle incomplete traces, the missing spans get appended to the end of the rootItems array
+  // This way we make sure that the root span is added first (if present), followed by any missing spans
   for (let spanID of missingSpanIDs) {
     rootItems.push(lookup[spanID]);
   }


### PR DESCRIPTION
Here, we write our own simplified implementation of [performant-array-to-tree](https://github.com/philipstanislaus/performant-array-to-tree) and modify it to handle incomplete traces where a span's parent is missing.

Note: I have to give further thought about how to visually represent the missing span (not clickable? empty detail view? different colour maybe?) so these things will be handled in another PR.

Also, I'm pretty sure I deleted all the batman jokes from the code before committing, but if not I'm sorry and let me know. 

![missingParent](https://user-images.githubusercontent.com/56372758/211176168-4b6336ad-93ef-4035-b568-801729980c0a.jpg)
