### PR TITLE
Render duration labels

### DIFF
--- a/desktop-exporter/app/components/waterfall-view/duration-bar.tsx
+++ b/desktop-exporter/app/components/waterfall-view/duration-bar.tsx
@@ -19,10 +19,7 @@ type DurationBarProps = {
 export function DurationBar(props: DurationBarProps) {
   const ref = useRef(null);
   const size = useSize(ref);
-<<<<<<< HEAD
-=======
 
->>>>>>> 8c656b9 (Add comments based on feedback)
   // approximate width of the label in pixels
   const labelWidth = 80;
 

--- a/desktop-exporter/app/components/waterfall-view/duration-bar.tsx
+++ b/desktop-exporter/app/components/waterfall-view/duration-bar.tsx
@@ -19,6 +19,10 @@ type DurationBarProps = {
 export function DurationBar(props: DurationBarProps) {
   const ref = useRef(null);
   const size = useSize(ref);
+<<<<<<< HEAD
+=======
+
+>>>>>>> 8c656b9 (Add comments based on feedback)
   // approximate width of the label in pixels
   const labelWidth = 80;
 
@@ -29,20 +33,23 @@ export function DurationBar(props: DurationBarProps) {
   let spanStartTimeNs = getNsFromString(props.spanStartTimestamp);
   let spanEndTimeNs = getNsFromString(props.spanEndTimestamp);
 
-  let barOffset = Math.floor(
+  let barOffsetPercent = Math.floor(
     ((spanStartTimeNs - traceStartTimeNS) / traceDurationNS) * 100,
   );
-  let barWidth = Math.round(
+  let barWidthPercent = Math.round(
     ((spanEndTimeNs - spanStartTimeNs) / traceDurationNS) * 100,
   );
 
   let labelOffset;
   if (size && size.width >= labelWidth) {
+    // Label is inside the bar
     labelOffset = "0px";
     labelTextColour = "white";
-  } else if (size && barOffset < 50) {
+  } else if (size && barOffsetPercent < 50) {
+    // Label is left of the bar
     labelOffset = `${Math.floor(size.width)}px`;
   } else {
+    // Label is right of the bar
     labelOffset = `${Math.floor(-labelWidth)}px`;
   }
 
@@ -60,8 +67,8 @@ export function DurationBar(props: DurationBarProps) {
         borderRadius="md"
         overflow="visible"
         position="relative"
-        left={`${barOffset}%`}
-        width={`${barWidth}%`}
+        left={`${barOffsetPercent}%`}
+        width={`${barWidthPercent}%`}
         minWidth="2px"
         ref={ref}
       >

--- a/desktop-exporter/app/components/waterfall-view/duration-bar.tsx
+++ b/desktop-exporter/app/components/waterfall-view/duration-bar.tsx
@@ -19,6 +19,7 @@ type DurationBarProps = {
 export function DurationBar(props: DurationBarProps) {
   const ref = useRef(null);
   const size = useSize(ref);
+  // approximate width of the label in pixels
   const labelWidth = 80;
 
   let durationBarColour = useColorModeValue("cyan.800", "cyan.700");

--- a/desktop-exporter/app/components/waterfall-view/duration-bar.tsx
+++ b/desktop-exporter/app/components/waterfall-view/duration-bar.tsx
@@ -1,7 +1,12 @@
-import React from "react";
-import { Box, Flex, useColorModeValue } from "@chakra-ui/react";
+import React, { useRef } from "react";
+import { Box, Flex, Text, useColorModeValue } from "@chakra-ui/react";
+import { useSize } from "@chakra-ui/react-use-size";
 
-import { getNsFromString, TraceTiming } from "../../utils/duration";
+import {
+  getDurationString,
+  getNsFromString,
+  TraceTiming,
+} from "../../utils/duration";
 import { SpanData } from "../../types/api-types";
 
 type DurationBarProps = {
@@ -12,18 +17,35 @@ type DurationBarProps = {
 };
 
 export function DurationBar(props: DurationBarProps) {
+  const ref = useRef(null);
+  const size = useSize(ref);
+  const labelWidth = 80;
+
   let durationBarColour = useColorModeValue("cyan.800", "cyan.700");
+  let labelTextColour = useColorModeValue("blackAlpha.800", "white");
 
   let { traceStartTimeNS, traceDurationNS } = props.traceTimeAttributes;
   let spanStartTimeNs = getNsFromString(props.spanStartTimestamp);
   let spanEndTimeNs = getNsFromString(props.spanEndTimestamp);
 
-  let offsetStart = Math.floor(
+  let barOffset = Math.floor(
     ((spanStartTimeNs - traceStartTimeNS) / traceDurationNS) * 100,
   );
-  let durationBarWidth = Math.round(
+  let barWidth = Math.round(
     ((spanEndTimeNs - spanStartTimeNs) / traceDurationNS) * 100,
   );
+
+  let labelOffset;
+  if (size && size.width >= labelWidth) {
+    labelOffset = "0px";
+    labelTextColour = "white";
+  } else if (size && barOffset < 50) {
+    labelOffset = `${Math.floor(size.width)}px`;
+  } else {
+    labelOffset = `${Math.floor(-labelWidth)}px`;
+  }
+
+  let label = getDurationString(spanEndTimeNs - spanStartTimeNs);
   return (
     <Flex
       border="0"
@@ -35,11 +57,25 @@ export function DurationBar(props: DurationBarProps) {
       <Box
         bgColor={durationBarColour}
         borderRadius="md"
+        overflow="visible"
         position="relative"
-        left={`${offsetStart}%`}
-        width={`${durationBarWidth}%`}
-        minWidth="5px"
-      />
+        left={`${barOffset}%`}
+        width={`${barWidth}%`}
+        minWidth="2px"
+        ref={ref}
+      >
+        <Text
+          fontSize="xs"
+          fontWeight="700"
+          paddingLeft={2}
+          color={labelTextColour}
+          position="absolute"
+          width={`${labelWidth}px`}
+          left={labelOffset}
+        >
+          {label}
+        </Text>
+      </Box>
     </Flex>
   );
 }

--- a/desktop-exporter/app/utils/duration.ts
+++ b/desktop-exporter/app/utils/duration.ts
@@ -56,17 +56,17 @@ export function getDurationString(durationNs: number) {
 
   // Label in seconds
   if (durationNs >= 1e9) {
-    return `${durationNs / 1e9} s`;
+    return `${(durationNs / 1e9).toFixed(3)} s`;
   }
 
   // Label in milliseconds
   if (durationNs >= 1e6) {
-    return `${durationNs / 1e6} ms`;
+    return `${(durationNs / 1e6).toFixed(3)} ms`;
   }
 
   // Label in microseconds
   if (durationNs >= 1e3) {
-    return `${durationNs / 1e3} μs`;
+    return `${(durationNs / 1e3).toFixed(3)} μs`;
   }
 
   // Label in nanoseconds


### PR DESCRIPTION
With appropriate time units inside or beside the duration bars, depending on the duration bar's width.
 
![DurationLabelLight](https://user-images.githubusercontent.com/56372758/211939991-54f72898-01d6-47b0-977d-afdd8083503b.jpg)
![DurationLabelDark](https://user-images.githubusercontent.com/56372758/211939998-0005f8af-d4b0-48e5-8b20-dbfc973f2ec1.jpg)
