### PR TITLE
Draw event circles on the duration bar -draft

### DIFF
--- a/desktop-exporter/app/components/waterfall-view/duration-bar.tsx
+++ b/desktop-exporter/app/components/waterfall-view/duration-bar.tsx
@@ -15,7 +15,49 @@ import {
   getNsFromString,
   TraceTiming,
 } from "../../utils/duration";
-import { SpanData } from "../../types/api-types";
+import { EventData, SpanData } from "../../types/api-types";
+
+type EventDotsListProps = {
+  events: EventData[];
+  spanStartTimeNs: number;
+  spanEndTimeNs: number;
+};
+
+function EventDotsList(props: EventDotsListProps) {
+  let { events, spanStartTimeNs, spanEndTimeNs } = props;
+
+  let eventDotsList = events.map((eventData) => {
+    let eventName = eventData.name;
+    let eventTimeNs = getNsFromString(eventData.timestamp);
+    let spanDurationNS = spanEndTimeNs - spanStartTimeNs;
+    let eventOffsetPercent = Math.floor(
+      ((eventTimeNs - spanStartTimeNs) / spanDurationNS) * 100,
+    );
+
+    return (
+      <li key={`${eventName}-${eventData.timestamp}`}>
+        <Tooltip
+          hasArrow
+          label={eventName}
+          placement="top"
+        >
+          <Circle
+            size="18px"
+            bg="whiteAlpha.400"
+            border="solid 1px"
+            borderColor="cyan.800"
+            position="absolute"
+            left={`${eventOffsetPercent}%`}
+            transformOrigin="center"
+            transform="translate(-50%)"
+          />
+        </Tooltip>
+      </li>
+    );
+  });
+
+  return <List>{eventDotsList}</List>;
+}
 
 type DurationBarProps = {
   spanData: SpanData;
@@ -60,35 +102,6 @@ export function DurationBar(props: DurationBarProps) {
 
   let label = getDurationString(spanEndTimeNs - spanStartTimeNs);
 
-  let eventCircles = props.spanData.events.map((eventData, index) => {
-    let eventName = eventData.name;
-    let eventTimeNs = getNsFromString(eventData.timestamp);
-    let spanDurationNS = spanEndTimeNs - spanStartTimeNs;
-    let eventOffsetPercent = Math.floor(
-      ((eventTimeNs - spanStartTimeNs) / spanDurationNS) * 100,
-    );
-
-    return (
-      <li key={index}>
-        <Tooltip
-          hasArrow
-          label={eventName}
-          placement="top"
-        >
-          <Circle
-            size="18px"
-            bg="whiteAlpha.400"
-            border="solid 1px"
-            borderColor="cyan.800"
-            position="absolute"
-            left={`${eventOffsetPercent}%`}
-            transformOrigin="center"
-            transform="translate(-50%)"
-          />
-        </Tooltip>
-      </li>
-    );
-  });
   return (
     <Flex
       border="0"
@@ -121,7 +134,11 @@ export function DurationBar(props: DurationBarProps) {
             {label}
           </Text>
         </Flex>
-        <List>{eventCircles}</List>
+        <EventDotsList
+          events={props.spanData.events}
+          spanStartTimeNs={spanStartTimeNs}
+          spanEndTimeNs={spanEndTimeNs}
+        />
       </Box>
     </Flex>
   );

--- a/desktop-exporter/app/components/waterfall-view/duration-bar.tsx
+++ b/desktop-exporter/app/components/waterfall-view/duration-bar.tsx
@@ -1,5 +1,13 @@
 import React, { useRef } from "react";
-import { Box, Flex, Text, useColorModeValue } from "@chakra-ui/react";
+import {
+  Box,
+  Circle,
+  Flex,
+  LightMode,
+  List,
+  Text,
+  useColorModeValue,
+} from "@chakra-ui/react";
 import { useSize } from "@chakra-ui/react-use-size";
 
 import {
@@ -51,6 +59,29 @@ export function DurationBar(props: DurationBarProps) {
   }
 
   let label = getDurationString(spanEndTimeNs - spanStartTimeNs);
+
+  let eventCircles = props.spanData.events.map((eventData, index) => {
+    let eventTimeNs = getNsFromString(eventData.timestamp);
+    let spanDurationNS = spanEndTimeNs - spanStartTimeNs;
+    let eventOffsetPercent = Math.floor(
+      ((eventTimeNs - spanStartTimeNs) / spanDurationNS) * 100,
+    );
+
+    return (
+      <li key={index}>
+        <Circle
+          size="18px"
+          bg="whiteAlpha.400"
+          border="solid 1px"
+          borderColor="cyan.800"
+          position="absolute"
+          left={`${eventOffsetPercent}%`}
+          transformOrigin="center"
+          transform="translate(-50%)"
+        />
+      </li>
+    );
+  });
   return (
     <Flex
       border="0"
@@ -69,6 +100,7 @@ export function DurationBar(props: DurationBarProps) {
         minWidth="2px"
         ref={ref}
       >
+        <List>{eventCircles}</List>
         <Text
           fontSize="xs"
           fontWeight="700"

--- a/desktop-exporter/app/components/waterfall-view/duration-bar.tsx
+++ b/desktop-exporter/app/components/waterfall-view/duration-bar.tsx
@@ -3,9 +3,9 @@ import {
   Box,
   Circle,
   Flex,
-  LightMode,
   List,
   Text,
+  Tooltip,
   useColorModeValue,
 } from "@chakra-ui/react";
 import { useSize } from "@chakra-ui/react-use-size";
@@ -61,6 +61,7 @@ export function DurationBar(props: DurationBarProps) {
   let label = getDurationString(spanEndTimeNs - spanStartTimeNs);
 
   let eventCircles = props.spanData.events.map((eventData, index) => {
+    let eventName = eventData.name;
     let eventTimeNs = getNsFromString(eventData.timestamp);
     let spanDurationNS = spanEndTimeNs - spanStartTimeNs;
     let eventOffsetPercent = Math.floor(
@@ -69,16 +70,22 @@ export function DurationBar(props: DurationBarProps) {
 
     return (
       <li key={index}>
-        <Circle
-          size="18px"
-          bg="whiteAlpha.400"
-          border="solid 1px"
-          borderColor="cyan.800"
-          position="absolute"
-          left={`${eventOffsetPercent}%`}
-          transformOrigin="center"
-          transform="translate(-50%)"
-        />
+        <Tooltip
+          hasArrow
+          label={eventName}
+          placement="top"
+        >
+          <Circle
+            size="18px"
+            bg="whiteAlpha.400"
+            border="solid 1px"
+            borderColor="cyan.800"
+            position="absolute"
+            left={`${eventOffsetPercent}%`}
+            transformOrigin="center"
+            transform="translate(-50%)"
+          />
+        </Tooltip>
       </li>
     );
   });
@@ -87,7 +94,6 @@ export function DurationBar(props: DurationBarProps) {
       border="0"
       marginX={2}
       marginY="16px"
-      overflow="hidden"
       width="100%"
     >
       <Box
@@ -100,18 +106,22 @@ export function DurationBar(props: DurationBarProps) {
         minWidth="2px"
         ref={ref}
       >
-        <List>{eventCircles}</List>
-        <Text
-          fontSize="xs"
-          fontWeight="700"
-          paddingLeft={2}
-          color={labelTextColour}
+        <Flex
           position="absolute"
           width={`${labelWidth}px`}
           left={labelOffset}
+          justifyContent="center"
         >
-          {label}
-        </Text>
+          <Text
+            fontSize="xs"
+            fontWeight="700"
+            paddingLeft={2}
+            color={labelTextColour}
+          >
+            {label}
+          </Text>
+        </Flex>
+        <List>{eventCircles}</List>
       </Box>
     </Flex>
   );


### PR DESCRIPTION
I need a bit of design help for this one, especially when the duration labels and the event indicators overlap and become illegible. And just about their look in general because I don't like them but don't know how to fix them.


![eventIndicatorsDraft](https://user-images.githubusercontent.com/56372758/212408188-3e0c375f-4728-4d82-90e9-1a31ffe575fa.jpg)
