### PR TITLE
Update TraceSummary on the back-end in preparation for sidebar rework

### DIFF
--- a/desktop-exporter/server.go
+++ b/desktop-exporter/server.go
@@ -31,7 +31,7 @@ func tracesHandler(store *TraceStore) func(http.ResponseWriter, *http.Request) {
 
 		// Generate a summary for each trace
 		for _, trace := range traces {
-			summary, err := trace.GetTraceSummary()
+			summary := trace.GetTraceSummary()
 			if err != nil {
 				fmt.Println(err)
 			} else {

--- a/desktop-exporter/trace_data.go
+++ b/desktop-exporter/trace_data.go
@@ -1,40 +1,38 @@
 package desktopexporter
 
-import (
-	"time"
-)
+import "time"
 
-func (trace *TraceData) GetTraceSummary() (TraceSummary, error) {
-	duration, err := trace.getTraceDuration()
-	if err != nil {
-		return TraceSummary{}, err
+func (trace *TraceData) GetTraceSummary() (TraceSummary) {
+	rootSpan, err := trace.getRootSpan()
+	
+	if err == ErrMissingRootSpan {
+		return TraceSummary{
+			HasRootSpan:     false,
+			RootServiceName: "",
+			RootName:        "",
+			RootStartTime:   time.Time{},
+			RootEndTime:	 time.Time{},
+			SpanCount:       uint32(len(trace.Spans)),
+			TraceID:         trace.TraceID,
+		}
 	}
 
 	return TraceSummary{
-		TraceID:    trace.TraceID,
-		SpanCount:  uint32(len(trace.Spans)),
-		DurationMS: duration.Milliseconds(),
-	}, nil
-
+		HasRootSpan:     true,
+		RootServiceName: rootSpan.Attributes["service.name"].(string),
+		RootName:        rootSpan.Name,
+		RootStartTime:   rootSpan.StartTime,
+		RootEndTime:	 rootSpan.EndTime,
+		SpanCount:       uint32(len(trace.Spans)),
+		TraceID:         trace.TraceID,
+	}
 }
 
-func (trace *TraceData) getTraceDuration() (time.Duration, error) {
-	if len(trace.Spans) < 1 {
-		return 0, ErrEmptySpansSlice
-	}
-
-	// Determine the total duration of the trace
-	traceStartTime := trace.Spans[0].StartTime
-	traceEndTime := trace.Spans[0].EndTime
-	for i := 1; i < len(trace.Spans); i++ {
-
-		if trace.Spans[i].StartTime.Before(traceStartTime) {
-			traceStartTime = trace.Spans[i].StartTime
-		}
-
-		if trace.Spans[i].EndTime.After(traceEndTime) {
-			traceEndTime = trace.Spans[i].EndTime
+func (trace *TraceData) getRootSpan()(SpanData, error){
+	for i := 0; i < len(trace.Spans); i++ {
+		if trace.Spans[i].ParentSpanID == "" {
+			return trace.Spans[i], nil
 		}
 	}
-	return traceEndTime.Sub(traceStartTime), nil
+	return SpanData{}, ErrMissingRootSpan
 }

--- a/desktop-exporter/trace_data_test.go
+++ b/desktop-exporter/trace_data_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetTraceSummary(t *testing.T) {
+func TestGetTraceSummaryWithRootSpan(t *testing.T) {
 	maxQueueLength := 1
 	spansPerTrace := 3
 
@@ -18,22 +18,56 @@ func TestGetTraceSummary(t *testing.T) {
 	store := NewTraceStore(maxQueueLength)
 	spans := extractSpans(ctx, traces)
 
-	// Assign each span start and end time before adding it to the store
-	// These timestamps are used to validate the summary's durationMS
 	for i, span := range spans {
 		span.TraceID = "1"
-		span.StartTime = time.Date(2022, 10, 10, 0, 0, i, 0, time.UTC)
-		span.EndTime = time.Date(2022, 10, 10, 0, 0, i+1, 0, time.UTC)
+		span.SpanID = string(rune(i));
+		// make 0 the root span.
+		if i == 0 {
+			span.Name = "rootSpan"
+			span.ParentSpanID = ""
+			span.Attributes["service.name"] = "service name"
+		} else {
+			span.ParentSpanID = "0";
+		}
 		store.Add(ctx, span)
 	}
 
 	trace, err := store.GetTrace("1")
 	assert.NoError(t, err)
 
-	summary, err := trace.GetTraceSummary()
+	summary := trace.GetTraceSummary()
+	assert.True(t, summary.HasRootSpan)
+	assert.Equal(t, "service name", summary.RootServiceName)
+	assert.Equal(t, "rootSpan", summary.RootName)
+	assert.Equal(t, time.Date(2022, 10, 21, 7, 10, 2, 100, time.UTC), summary.RootStartTime)
+	assert.Equal(t, time.Date(2020, 10, 21, 7, 10, 2, 300, time.UTC), summary.RootEndTime)
+	assert.Equal(t, uint32(spansPerTrace), summary.SpanCount)
+	assert.Equal(t, "1", summary.TraceID)
+}
+
+func TestGetTraceSummaryMissingRootSpan(t *testing.T) {
+	maxQueueLength := 1
+	spansPerTrace := 3
+
+	traces := testdata.GenerateOTLPPayload(1, 1, maxQueueLength*spansPerTrace)
+	ctx := context.Background()
+	store := NewTraceStore(maxQueueLength)
+	spans := extractSpans(ctx, traces)
+
+	for _, span := range spans {
+		span.TraceID = "1"
+		store.Add(ctx, span)
+	}
+
+	trace, err := store.GetTrace("1")
 	assert.NoError(t, err)
 
-	assert.Equal(t, "1", summary.TraceID)
+	summary := trace.GetTraceSummary()
+	assert.False(t, summary.HasRootSpan)
+	assert.Equal(t, "", summary.RootServiceName)
+	assert.Equal(t, "", summary.RootName)
+	assert.True(t, time.Time.IsZero(summary.RootStartTime))
+	assert.True(t, time.Time.IsZero(summary.RootEndTime))
 	assert.Equal(t, uint32(spansPerTrace), summary.SpanCount)
-	assert.Equal(t, int64(3000), summary.DurationMS)
+	assert.Equal(t, "1", summary.TraceID)
 }

--- a/desktop-exporter/types.go
+++ b/desktop-exporter/types.go
@@ -8,15 +8,22 @@ import (
 var ErrEmptySpansSlice = errors.New("slice of spans associated with this traceID must not be empty")
 var ErrTraceIDNotFound = errors.New("traceID not found")
 var ErrTraceIDMismatch = errors.New("traceID mismatch between TraceStore.traceMap and TraceStore.traceQueue")
+var ErrMissingRootSpan = errors.New("trace is incomplete - no root span found")
 
 type RecentSummaries struct {
 	TraceSummaries []TraceSummary `json:"traceSummaries"`
 }
 
 type TraceSummary struct {
-	TraceID    string `json:"traceID"`
-	SpanCount  uint32 `json:"spanCount"`
-	DurationMS int64  `json:"durationMS"`
+	HasRootSpan 	bool	`json:"hasRootSpan"`
+
+	RootServiceName string		`json:"rootServiceName"`
+	RootName 		string		`json:"rootName"`
+	RootStartTime 	time.Time	`json:"rootStartTime"`
+	RootEndTime   	time.Time	`json:"rootEndTime"`
+	
+	SpanCount  		uint32	`json:"spanCount"`
+	TraceID    		string	`json:"traceID"`
 }
 
 type TraceData struct {


### PR DESCRIPTION
TraceSummary is now structured as follows:

- HasRootSpan (bool)
- RootServiceName (string)
- RootName (string)
- RootStartTime (time.Time)
- RootEndTime  (time.Time)
- SpanCount  (uint32)
- TraceID  (string)

I covered the possibility of a partial trace with no root span, and will reflect this on the front-end.

Tests and types were updated accordingly.

I opted for a start and end time for the root span rather than durationMS because we already have a good setup on the front-end to calculate duration and output it in the most human-readable time unit depending on its value, so it doesn't make sense to duplicate the functionality and limit it to milliseconds. 
