### PR TITLE
Rename the base module to match the repo name

### DIFF
--- a/components.go
+++ b/components.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	desktopexporter "github.com/CtrlSpice/desktop-collector/desktop-exporter"
+	desktopexporter "github.com/CtrlSpice/otel-desktop-viewer/desktop-exporter"
 	"go.opentelemetry.io/collector/component"
 	batchprocessor "go.opentelemetry.io/collector/processor/batchprocessor"
 	otlpreceiver "go.opentelemetry.io/collector/receiver/otlpreceiver"

--- a/desktop-exporter/otlp_payload_processor.go
+++ b/desktop-exporter/otlp_payload_processor.go
@@ -2,6 +2,7 @@ package desktopexporter
 
 import (
 	"context"
+	"encoding/hex"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -74,9 +75,11 @@ func aggregateEventData(event ptrace.SpanEvent) EventData {
 }
 
 func aggregateLinkData(link ptrace.SpanLink) LinkData {
+	traceID := link.TraceID()
+	spanID := link.SpanID()
 	return LinkData{
-		TraceID:                link.TraceID().HexString(),
-		SpanID:                 link.SpanID().HexString(),
+		TraceID:                hex.EncodeToString(traceID[:]),
+		SpanID:                 hex.EncodeToString(spanID[:]),
 		TraceState:             link.TraceState().AsRaw(),
 		Attributes:             link.Attributes().AsRaw(),
 		DroppedAttributesCount: link.DroppedAttributesCount(),
@@ -84,12 +87,15 @@ func aggregateLinkData(link ptrace.SpanLink) LinkData {
 }
 
 func aggregateSpanData(span ptrace.Span, eventData []EventData, LinkData []LinkData, scopeData *ScopeData, resourceData *ResourceData) SpanData {
+	traceID := span.TraceID()
+	spanID := span.SpanID()
+	parentSpanID := span.ParentSpanID()
 	return SpanData{
-		TraceID:    span.TraceID().HexString(),
+		TraceID:    hex.EncodeToString(traceID[:]),
 		TraceState: span.TraceState().AsRaw(),
 
-		SpanID:       span.SpanID().HexString(),
-		ParentSpanID: span.ParentSpanID().HexString(),
+		SpanID:       hex.EncodeToString(spanID[:]),
+		ParentSpanID: hex.EncodeToString(parentSpanID[:]),
 		Name:         span.Name(),
 		Kind:         span.Kind().String(),
 		StartTime:    span.StartTimestamp().AsTime(),

--- a/desktop-exporter/otlp_payload_processor_test.go
+++ b/desktop-exporter/otlp_payload_processor_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CtrlSpice/desktop-collector/desktop-exporter/testdata"
+	"github.com/CtrlSpice/otel-desktop-viewer/desktop-exporter/testdata"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/desktop-exporter/trace_data_test.go
+++ b/desktop-exporter/trace_data_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CtrlSpice/desktop-collector/desktop-exporter/testdata"
+	"github.com/CtrlSpice/otel-desktop-viewer/desktop-exporter/testdata"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/desktop-exporter/trace_store_test.go
+++ b/desktop-exporter/trace_store_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/CtrlSpice/desktop-collector/desktop-exporter/testdata"
+	"github.com/CtrlSpice/otel-desktop-viewer/desktop-exporter/testdata"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/CtrlSpice/desktop-collector
+module github.com/CtrlSpice/otel-desktop-viewer
 
 go 1.19
 


### PR DESCRIPTION
At some point the repo and `go.mod` drifted out-of-sync, and the names don't match. This brings them back in line.