### PR TITLE
Add refresh functionality and countdown timer to alert

### DIFF
--- a/desktop-exporter/app/components/empty-state-view/empty-state-view.tsx
+++ b/desktop-exporter/app/components/empty-state-view/empty-state-view.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import {
   Alert,
+  AlertDescription,
   AlertIcon,
+  AlertTitle,
   Box,
   Button,
   Card,
@@ -18,8 +20,42 @@ import {
   useColorModeValue,
 } from "@chakra-ui/react";
 
-export function EmptyStateView() {
+function RefreshAlert() {
   let alertColour = useColorModeValue("cyan.700", "cyan.300");
+  let [secondsToRefresh, setSecondsToRefresh] = useState(10);
+  useEffect(() => {
+    setTimeout(() => {
+      if (secondsToRefresh > 0) {
+        setSecondsToRefresh(secondsToRefresh - 1);
+      } else {
+        window.location.reload();
+      }
+    }, 1000);
+  });
+
+  let alertText = "";
+  if (secondsToRefresh > 1) {
+    alertText = `No data yet. Refreshing in ${secondsToRefresh} seconds...`;
+  } else if (secondsToRefresh === 1) {
+    alertText = `No data yet. Refreshing in ${secondsToRefresh} second...`;
+  } else {
+    alertText = "No data yet. Refreshing now!";
+  }
+
+  return (
+    <Alert
+      status="info"
+      variant="solid"
+      minHeight="64px"
+      backgroundColor={alertColour}
+    >
+      <AlertIcon boxSize="24px" />
+      <AlertTitle fontSize="md">{alertText}</AlertTitle>
+    </Alert>
+  );
+}
+
+export function EmptyStateView() {
   return (
     <Flex
       flexDirection="column"
@@ -27,15 +63,7 @@ export function EmptyStateView() {
       width="100%"
       overflowY="scroll"
     >
-      <Alert
-        status="info"
-        variant="solid"
-        minHeight="30px"
-        backgroundColor={alertColour}
-      >
-        <AlertIcon />
-        No data yet. Refreshing in 5 seconds...
-      </Alert>
+      <RefreshAlert />
       <Card
         align="center"
         width="50%"

--- a/desktop-exporter/static/main.js
+++ b/desktop-exporter/static/main.js
@@ -1001,7 +1001,7 @@
             }
             return dispatcher.useContext(Context);
           }
-          function useState20(initialState2) {
+          function useState21(initialState2) {
             var dispatcher = resolveDispatcher();
             return dispatcher.useState(initialState2);
           }
@@ -1013,7 +1013,7 @@
             var dispatcher = resolveDispatcher();
             return dispatcher.useRef(initialValue);
           }
-          function useEffect35(create, deps) {
+          function useEffect36(create, deps) {
             var dispatcher = resolveDispatcher();
             return dispatcher.useEffect(create, deps);
           }
@@ -1793,7 +1793,7 @@
           exports.useContext = useContext16;
           exports.useDebugValue = useDebugValue2;
           exports.useDeferredValue = useDeferredValue;
-          exports.useEffect = useEffect35;
+          exports.useEffect = useEffect36;
           exports.useId = useId8;
           exports.useImperativeHandle = useImperativeHandle;
           exports.useInsertionEffect = useInsertionEffect2;
@@ -1801,7 +1801,7 @@
           exports.useMemo = useMemo19;
           exports.useReducer = useReducer;
           exports.useRef = useRef28;
-          exports.useState = useState20;
+          exports.useState = useState21;
           exports.useSyncExternalStore = useSyncExternalStore3;
           exports.useTransition = useTransition;
           exports.version = ReactVersion;
@@ -51806,19 +51806,44 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
 
   // app/components/empty-state-view/empty-state-view.tsx
   var import_react146 = __toESM(require_react());
-  function EmptyStateView() {
+  function RefreshAlert() {
     let alertColour = useColorModeValue("cyan.700", "cyan.300");
+    let [secondsToRefresh, setSecondsToRefresh] = (0, import_react146.useState)(10);
+    (0, import_react146.useEffect)(() => {
+      setTimeout(() => {
+        if (secondsToRefresh > 0) {
+          setSecondsToRefresh(secondsToRefresh - 1);
+        } else {
+          window.location.reload();
+        }
+      }, 1e3);
+    });
+    let alertText = "";
+    if (secondsToRefresh > 1) {
+      alertText = `No data yet. Refreshing in ${secondsToRefresh} seconds...`;
+    } else if (secondsToRefresh === 1) {
+      alertText = `No data yet. Refreshing in ${secondsToRefresh} second...`;
+    } else {
+      alertText = "No data yet. Refreshing now!";
+    }
+    return /* @__PURE__ */ import_react146.default.createElement(Alert, {
+      status: "info",
+      variant: "solid",
+      minHeight: "64px",
+      backgroundColor: alertColour
+    }, /* @__PURE__ */ import_react146.default.createElement(AlertIcon, {
+      boxSize: "24px"
+    }), /* @__PURE__ */ import_react146.default.createElement(AlertTitle, {
+      fontSize: "md"
+    }, alertText));
+  }
+  function EmptyStateView() {
     return /* @__PURE__ */ import_react146.default.createElement(Flex, {
       flexDirection: "column",
       align: "center",
       width: "100%",
       overflowY: "scroll"
-    }, /* @__PURE__ */ import_react146.default.createElement(Alert, {
-      status: "info",
-      variant: "solid",
-      minHeight: "30px",
-      backgroundColor: alertColour
-    }, /* @__PURE__ */ import_react146.default.createElement(AlertIcon, null), "No data yet. Refreshing in 5 seconds..."), /* @__PURE__ */ import_react146.default.createElement(Card, {
+    }, /* @__PURE__ */ import_react146.default.createElement(RefreshAlert, null), /* @__PURE__ */ import_react146.default.createElement(Card, {
       align: "center",
       width: "50%",
       maxWidth: "700px",


### PR DESCRIPTION
It counts down from 10 seconds (because 5 seemed a little fast to me, but I'll change it back if you want), and then refreshes the page.

It stops rendering the empty state components when it receives trace summaries, like it's supposed to. 😁  