### PR TITLE
Show the most recent available trace by default

### DIFF
--- a/desktop-exporter/app/components/sidebar-view/trace-list.tsx
+++ b/desktop-exporter/app/components/sidebar-view/trace-list.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 import { VariableSizeList } from "react-window";
-import { NavLink, useLocation } from "react-router-dom";
+import { NavLink, useHref, useLocation } from "react-router-dom";
 import {
   Flex,
   LinkBox,
@@ -148,7 +148,15 @@ export function TraceList(props: TraceListProps) {
   let location = useLocation();
   let { traceSummaries } = props;
 
-  let selectedTraceID = location ? location.pathname.split("/")[2] : "";
+  // Default to the first trace in the list if none are selected
+  let selectedTraceID = "";
+  if (location.pathname.includes("/traces/")) {
+    selectedTraceID = location.pathname.split("/")[2];
+  } else {
+    selectedTraceID = traceSummaries[0].traceID;
+    window.location.href = `/traces/${selectedTraceID}`;
+  }
+
   let itemData = {
     selectedTraceID: selectedTraceID,
     traceSummaries: traceSummaries,

--- a/desktop-exporter/static/main.js
+++ b/desktop-exporter/static/main.js
@@ -51277,7 +51277,13 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
     let size3 = useSize(ref);
     let location = useLocation();
     let { traceSummaries } = props;
-    let selectedTraceID = location ? location.pathname.split("/")[2] : "";
+    let selectedTraceID = "";
+    if (location.pathname.includes("/traces/")) {
+      selectedTraceID = location.pathname.split("/")[2];
+    } else {
+      selectedTraceID = traceSummaries[0].traceID;
+      window.location.href = `/traces/${selectedTraceID}`;
+    }
     let itemData = {
       selectedTraceID,
       traceSummaries


### PR DESCRIPTION
When the application receives trace data, it now loads navigates to the most recent available trace by default if no traces are selected in the sidebar. This behaviour avoids a blank screen on load, thus providing a better user experience.

![autoshow](https://user-images.githubusercontent.com/56372758/216795375-02a4378d-6229-4ed2-acba-06d45c3c8c3d.gif)
