### PR TITLE
Fix boolean attributes display bug

### DIFF
--- a/desktop-exporter/app/components/detail-view/span-field.tsx
+++ b/desktop-exporter/app/components/detail-view/span-field.tsx
@@ -21,15 +21,24 @@ export function SpanField(props: SpanFieldProps) {
   if (hidden) {
     return null;
   }
+  let typeOfFieldValue = typeof fieldValue;
 
   switch (fieldValue) {
+    case true:
+      fieldValue = "true";
+      break;
+    case false:
+      fieldValue = "false";
+      break;
     case null:
       fieldValue = "null";
       break;
     case undefined:
       fieldValue = "undefined";
+      break;
     case "":
       fieldValue = '""';
+      break;
   }
 
   return (
@@ -41,7 +50,7 @@ export function SpanField(props: SpanFieldProps) {
             variant="outline"
             colorScheme="cyan"
           >
-            <TagLabel fontSize="xs">{typeof fieldValue}</TagLabel>
+            <TagLabel fontSize="xs">{typeOfFieldValue}</TagLabel>
           </Tag>
           <Text
             textColor={fieldNameColour}

--- a/desktop-exporter/static/main.js
+++ b/desktop-exporter/static/main.js
@@ -52145,14 +52145,23 @@ otel-cli exec --service my-service --name "curl google" curl https://google.com
     if (hidden) {
       return null;
     }
+    let typeOfFieldValue = typeof fieldValue;
     switch (fieldValue) {
+      case true:
+        fieldValue = "true";
+        break;
+      case false:
+        fieldValue = "false";
+        break;
       case null:
         fieldValue = "null";
         break;
       case void 0:
         fieldValue = "undefined";
+        break;
       case "":
         fieldValue = '""';
+        break;
     }
     return /* @__PURE__ */ import_react152.default.createElement(Box, {
       paddingTop: 2
@@ -52164,7 +52173,7 @@ otel-cli exec --service my-service --name "curl google" curl https://google.com
       colorScheme: "cyan"
     }, /* @__PURE__ */ import_react152.default.createElement(TagLabel, {
       fontSize: "xs"
-    }, typeof fieldValue)), /* @__PURE__ */ import_react152.default.createElement(Text, {
+    }, typeOfFieldValue)), /* @__PURE__ */ import_react152.default.createElement(Text, {
       textColor: fieldNameColour,
       fontSize: "sm"
     }, fieldName))), /* @__PURE__ */ import_react152.default.createElement("dd", null, /* @__PURE__ */ import_react152.default.createElement(Text, {


### PR DESCRIPTION
- Fixed the bug where boolean attributes were displayed as an empty string
- Also fixed the bug where the type of the attribute was checked after conversion and was always `string`

![boolean-attributes](https://user-images.githubusercontent.com/56372758/217935258-b83e8958-8279-450e-98bc-9c0b594282a7.png)
