### PR TITLE
Add small delays

### DIFF
--- a/desktop-exporter/app/components/empty-state-view/empty-state-view.tsx
+++ b/desktop-exporter/app/components/empty-state-view/empty-state-view.tsx
@@ -65,7 +65,9 @@ async function pollTraceCount() {
   } else {
     let { traceSummaries } = (await response.json()) as TraceSummaries;
     if (traceSummaries.length > 0) {
-      window.location.reload();
+      setTimeout(() => {
+        window.location.reload();
+      }, 500);
     }
   }
 }

--- a/desktop-exporter/app/components/empty-state-view/empty-state-view.tsx
+++ b/desktop-exporter/app/components/empty-state-view/empty-state-view.tsx
@@ -65,9 +65,7 @@ async function pollTraceCount() {
   } else {
     let { traceSummaries } = (await response.json()) as TraceSummaries;
     if (traceSummaries.length > 0) {
-      setTimeout(() => {
-        window.location.reload();
-      }, 500);
+      setTimeout(window.location.reload, 500);
     }
   }
 }

--- a/desktop-exporter/server.go
+++ b/desktop-exporter/server.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/browser"
@@ -130,7 +131,11 @@ func NewServer(traceStore *TraceStore) *Server {
 }
 
 func (s Server) Start() error {
-	browser.OpenURL("http://localhost:8000/")
+	go func() {
+		// Wait a bit for the server to come up to avoid a 404 as a first experience
+		time.Sleep(250 * time.Millisecond)
+		browser.OpenURL("http://localhost:8000/")
+	}()
 	return s.server.ListenAndServe()
 }
 

--- a/desktop-exporter/static/main.js
+++ b/desktop-exporter/static/main.js
@@ -51881,9 +51881,7 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
     } else {
       let { traceSummaries } = await response.json();
       if (traceSummaries.length > 0) {
-        setTimeout(() => {
-          window.location.reload();
-        }, 500);
+        setTimeout(window.location.reload, 500);
       }
     }
   }

--- a/desktop-exporter/static/main.js
+++ b/desktop-exporter/static/main.js
@@ -51881,7 +51881,9 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
     } else {
       let { traceSummaries } = await response.json();
       if (traceSummaries.length > 0) {
-        window.location.reload();
+        setTimeout(() => {
+          window.location.reload();
+        }, 500);
       }
     }
   }


### PR DESCRIPTION
- before launching the browser to let the server start and avoid a 404 as the first user experience (250ms)
- before reloading the window when we receive traces in order to let more than one payload come through and to have more complete traces to look at (500ms)