### PR TITLE
Fix truncated detail view

### DIFF
--- a/desktop-exporter/app/components/detail-view/detail-view.tsx
+++ b/desktop-exporter/app/components/detail-view/detail-view.tsx
@@ -23,11 +23,12 @@ export function DetailView(props: DetailViewProps) {
       shrink="1"
       basis="350px"
       height="100vh"
+      paddingTop="30px"
+      overflowY="scroll"
     >
       <Tabs
         colorScheme="pink"
         margin={3}
-        overflowY="scroll"
         size="sm"
         variant="soft-rounded"
         width="100vw"

--- a/desktop-exporter/app/routes/trace-view.tsx
+++ b/desktop-exporter/app/routes/trace-view.tsx
@@ -54,7 +54,7 @@ export default function TraceView() {
 
   return (
     <Grid
-      templateAreas={`"header header"
+      templateAreas={`"header detail"
                        "main detail"`}
       gridTemplateColumns={"1fr 350px"}
       gridTemplateRows={"100px 1fr"}

--- a/desktop-exporter/static/main.js
+++ b/desktop-exporter/static/main.js
@@ -52571,11 +52571,12 @@ otel-cli exec --service my-service --name "curl google" curl https://google.com
       grow: "0",
       shrink: "1",
       basis: "350px",
-      height: "100vh"
+      height: "100vh",
+      paddingTop: "30px",
+      overflowY: "scroll"
     }, /* @__PURE__ */ import_react164.default.createElement(Tabs, {
       colorScheme: "pink",
       margin: 3,
-      overflowY: "scroll",
       size: "sm",
       variant: "soft-rounded",
       width: "100vw"
@@ -52946,7 +52947,7 @@ otel-cli exec --service my-service --name "curl google" curl https://google.com
       (span) => span.spanID === selectedSpanID
     );
     return /* @__PURE__ */ import_react174.default.createElement(Grid, {
-      templateAreas: `"header header"
+      templateAreas: `"header detail"
                        "main detail"`,
       gridTemplateColumns: "1fr 350px",
       gridTemplateRows: "100px 1fr",


### PR DESCRIPTION
Fixed Issue #84 
- Pulled the `detail-view` up a bit, because having it under the empty bit of header was wasteful in terms of screen space
- Fixed the scrolling bug, since everything has the correct height now

![untruncate-detail-view](https://user-images.githubusercontent.com/56372758/219909115-3350c9f0-5477-4a94-9720-76963fb904a2.gif)
 
