### PR TITLE
Fix wrapping on whitespace in duration label

### DIFF
--- a/desktop-exporter/app/components/waterfall-view/duration-bar.tsx
+++ b/desktop-exporter/app/components/waterfall-view/duration-bar.tsx
@@ -130,6 +130,7 @@ export function DurationBar(props: DurationBarProps) {
             fontWeight="700"
             paddingLeft={2}
             color={labelTextColour}
+            whiteSpace="nowrap"
           >
             {label}
           </Text>

--- a/desktop-exporter/static/main.js
+++ b/desktop-exporter/static/main.js
@@ -52678,7 +52678,8 @@ otel-cli exec --service my-service --name "curl google" curl https://google.com
       fontSize: "xs",
       fontWeight: "700",
       paddingLeft: 2,
-      color: labelTextColour
+      color: labelTextColour,
+      whiteSpace: "nowrap"
     }, label)), /* @__PURE__ */ import_react166.default.createElement(EventDotsList, {
       events: props.spanData.events,
       spanStartTimeNs,


### PR DESCRIPTION
Fixes issue #92 
-Added missing `whiteSpace="nowrap` to the duration label. It is no longer misbehaving.
![inline-duration-label](https://user-images.githubusercontent.com/56372758/219975723-94adabc0-69e2-4ae8-ab1f-0530c504a601.png)
