### PR TITLE
Refactor tree node types

### DIFF
--- a/desktop-exporter/app/routes/trace-view.tsx
+++ b/desktop-exporter/app/routes/trace-view.tsx
@@ -8,7 +8,7 @@ import { SpanDataStatus, SpanWithUIData } from "../types/ui-types";
 import { Header } from "../components/header-view/header";
 import { DetailView } from "../components/detail-view/detail-view";
 import { WaterfallView } from "../components/waterfall-view/waterfall-view";
-import { arrayToTree, TreeItem } from "../utils/array-to-tree";
+import { arrayToTree, TreeItem, RootTreeItem } from "../utils/array-to-tree";
 import { getNsFromString, calculateTraceTiming } from "../utils/duration";
 
 export async function traceLoader({ params }: any) {
@@ -20,7 +20,7 @@ export async function traceLoader({ params }: any) {
 export default function TraceView() {
   let traceData = useLoaderData() as TraceData;
   let traceTimeAttributes = calculateTraceTiming(traceData.spans);
-  let spanTree: TreeItem[] = arrayToTree(traceData.spans);
+  let spanTree: RootTreeItem[] = arrayToTree(traceData.spans);
   let orderedSpans = orderSpans(spanTree);
 
   let [selectedSpanID, setSelectedSpanID] = React.useState<string>(() => {
@@ -93,7 +93,7 @@ export default function TraceView() {
 // We are sorting each set of children, but not the set of root nodes we are starting with,
 // as the array-to-tree implementation is such that the root span (if one is present)
 // is displayed first and all missing spans come after
-function orderSpans(spanTree: TreeItem[]): SpanWithUIData[] {
+function orderSpans(spanTree: RootTreeItem[]): SpanWithUIData[] {
   let orderedSpans: SpanWithUIData[] = [];
 
   for (let root of spanTree) {

--- a/desktop-exporter/app/utils/array-to-tree.ts
+++ b/desktop-exporter/app/utils/array-to-tree.ts
@@ -2,21 +2,25 @@ import { SpanData } from "../types/api-types";
 import { SpanDataStatus } from "../types/ui-types";
 import { getNsFromString } from "./duration";
 
-export type TreeItem =
-  | {
-      status: SpanDataStatus.present;
-      spanData: SpanData;
-      children: TreeItem[];
-    }
-  | {
-      status: SpanDataStatus.missing;
-      spanID: string;
-      children: TreeItem[];
-    };
+export type TreeItem = {
+  status: SpanDataStatus.present;
+  spanData: SpanData;
+  children: TreeItem[];
+};
 
-export function arrayToTree(spans: SpanData[]): TreeItem[] {
-  let rootItems: TreeItem[] = [];
-  let lookup: { [spanID: string]: TreeItem } = {};
+export type MissingTreeItem = {
+  status: SpanDataStatus.missing;
+  spanID: string;
+  children: TreeItem[];
+};
+
+export type RootTreeItem =
+  | TreeItem
+  | MissingTreeItem;
+
+export function arrayToTree(spans: SpanData[]): RootTreeItem[] {
+  let rootItems: RootTreeItem[] = [];
+  let lookup: { [spanID: string]: RootTreeItem } = {};
   let missingSpanIDs: Set<string> = new Set();
 
   for (let spanData of spans) {
@@ -31,20 +35,22 @@ export function arrayToTree(spans: SpanData[]): TreeItem[] {
       };
     }
 
+    let treeItem = lookup[spanID];
+
     // Note A:
     // If the span has been added to the lookup structure as a missing/incomplete parent
     // on a previous pass (see Note B), update it and mark it present, and remove it from the missing set.
-    if (lookup[spanID].status === SpanDataStatus.missing) {
-      let children = lookup[spanID].children;
-      lookup[spanID] = {
+    // After this if statement, the type system knows that treeItem can only be a TreeItem
+    if (treeItem.status === SpanDataStatus.missing) {
+      let children = treeItem.children;
+      treeItem = {
         status: SpanDataStatus.present,
         spanData: spanData,
         children: children,
       };
+      lookup[spanID] = treeItem
       missingSpanIDs.delete(spanID);
     }
-
-    let treeItem = lookup[spanID];
 
     // If the current span has no parentSpanID, add it to the rootItems
     if (!parentSpanID) {
@@ -99,14 +105,6 @@ function getEarliestStartTime(children: TreeItem[]): number {
   }
 
   let startTimes = children.map((treeItem) => {
-    if (treeItem.status === SpanDataStatus.missing) {
-      throw new Error(
-        // This should also happen in this implementation, since that the child span
-        // must have SpanData (minimally a parentSpanID) in order for the parent span to be created.
-        "Unexpected type: A child of a 'missing' parent span appears to have no SpanData.",
-      );
-    }
-
     return getNsFromString(treeItem.spanData.startTime);
   });
 

--- a/desktop-exporter/app/utils/array-to-tree.ts
+++ b/desktop-exporter/app/utils/array-to-tree.ts
@@ -41,14 +41,14 @@ export function arrayToTree(spans: SpanData[]): RootTreeItem[] {
     // If the span has been added to the lookup structure as a missing/incomplete parent
     // on a previous pass (see Note B), update it and mark it present, and remove it from the missing set.
     if (treeItem.status === SpanDataStatus.missing) {
-      let children = treeItem.children;
       // Re-assign treeItem as a TreeItem type so that after this if statement,
       // the type system knows that treeItem can only be a TreeItem
       treeItem = {
         status: SpanDataStatus.present,
         spanData: spanData,
-        children: children,
+        children: treeItem.children,
       };
+      // overwrite the stored version since now we know it is present
       lookup[spanID] = treeItem
       missingSpanIDs.delete(spanID);
     }

--- a/desktop-exporter/app/utils/array-to-tree.ts
+++ b/desktop-exporter/app/utils/array-to-tree.ts
@@ -40,9 +40,10 @@ export function arrayToTree(spans: SpanData[]): RootTreeItem[] {
     // Note A:
     // If the span has been added to the lookup structure as a missing/incomplete parent
     // on a previous pass (see Note B), update it and mark it present, and remove it from the missing set.
-    // After this if statement, the type system knows that treeItem can only be a TreeItem
     if (treeItem.status === SpanDataStatus.missing) {
       let children = treeItem.children;
+      // Re-assign treeItem as a TreeItem type so that after this if statement,
+      // the type system knows that treeItem can only be a TreeItem
       treeItem = {
         status: SpanDataStatus.present,
         spanData: spanData,

--- a/desktop-exporter/package-lock.json
+++ b/desktop-exporter/package-lock.json
@@ -7,9 +7,6 @@
         "": {
             "name": "desktop-exporter",
             "version": "1.0.0",
-            "dependencies": {
-                "react-icons": "^4.7.1"
-            },
             "devDependencies": {
                 "@chakra-ui/icons": "^2.0.12",
                 "@chakra-ui/react": "^2.4.1",
@@ -24,6 +21,7 @@
                 "prettier": "^2.8.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
+                "react-icons": "^4.7.1",
                 "react-router-dom": "^6.4.3",
                 "react-window": "^1.8.8",
                 "timestamp-nano": "^1.0.0",
@@ -2802,7 +2800,8 @@
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
         },
         "node_modules/jsesc": {
             "version": "2.5.2",
@@ -2852,6 +2851,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             },
@@ -3003,6 +3003,7 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
             "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -3068,6 +3069,7 @@
             "version": "4.7.1",
             "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.7.1.tgz",
             "integrity": "sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==",
+            "dev": true,
             "peerDependencies": {
                 "react": "*"
             }
@@ -5491,7 +5493,8 @@
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
         },
         "jsesc": {
             "version": "2.5.2",
@@ -5529,6 +5532,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
             "requires": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             }
@@ -5655,6 +5659,7 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
             "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0"
             }
@@ -5702,6 +5707,7 @@
             "version": "4.7.1",
             "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.7.1.tgz",
             "integrity": "sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==",
+            "dev": true,
             "requires": {}
         },
         "react-is": {

--- a/desktop-exporter/static/main.js
+++ b/desktop-exporter/static/main.js
@@ -52889,16 +52889,17 @@ otel-cli exec --service my-service --name "curl google" curl https://google.com
           children: []
         };
       }
-      if (lookup[spanID].status === "missing" /* missing */) {
-        let children = lookup[spanID].children;
-        lookup[spanID] = {
+      let treeItem = lookup[spanID];
+      if (treeItem.status === "missing" /* missing */) {
+        let children = treeItem.children;
+        treeItem = {
           status: "present" /* present */,
           spanData,
           children
         };
+        lookup[spanID] = treeItem;
         missingSpanIDs.delete(spanID);
       }
-      let treeItem = lookup[spanID];
       if (!parentSpanID) {
         rootItems.push(treeItem);
       } else {
@@ -52932,11 +52933,6 @@ otel-cli exec --service my-service --name "curl google" curl https://google.com
       );
     }
     let startTimes = children.map((treeItem) => {
-      if (treeItem.status === "missing" /* missing */) {
-        throw new Error(
-          "Unexpected type: A child of a 'missing' parent span appears to have no SpanData."
-        );
-      }
       return getNsFromString(treeItem.spanData.startTime);
     });
     return Math.min(...startTimes);


### PR DESCRIPTION
I nerd-sniped myself with [this comment](https://github.com/CtrlSpice/otel-desktop-viewer/pull/95#discussion_r1112302232) and wanted to see if I could refactor the types this way.

This splits the type `TreeItem` into 2 different named types: `TreeItem` and `MissingTreeItem` which get unified as `RootTreeItem`. 

`RootTreeItem` can be either a `TreeItem` (present) or a `MissingTreeItem` (missing), but in either case it has to have `TreeItem` as children.

This enforces in the type system that missing spans can *only* appear at the root of the tree

https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html#discriminating-unions