### PR TITLE
Fix compilation on windows

### DIFF
--- a/main_windows.go
+++ b/main_windows.go
@@ -11,10 +11,10 @@ import (
 
 	"golang.org/x/sys/windows/svc"
 
-	"go.opentelemetry.io/collector/service"
+	"go.opentelemetry.io/collector/otelcol"
 )
 
-func run(params service.CollectorSettings) error {
+func run(params otelcol.CollectorSettings) error {
 	if useInteractiveMode, err := checkUseInteractiveMode(); err != nil {
 		return err
 	} else if useInteractiveMode {
@@ -33,16 +33,16 @@ func checkUseInteractiveMode() (bool, error) {
 		return true, nil
 	}
 
-	isInteractiveSession, err := svc.IsAnInteractiveSession()
+	isWindowsService, err := svc.IsWindowsService()
 	if err != nil {
 		return false, fmt.Errorf("failed to determine if we are running in an interactive session: %w", err)
 	}
-	return isInteractiveSession, nil
+	return !isWindowsService, nil
 }
 
-func runService(params service.CollectorSettings) error {
+func runService(params otelcol.CollectorSettings) error {
 	// do not need to supply service name when startup is invoked through Service Control Manager directly
-	if err := svc.Run("", service.NewSvcHandler(params)); err != nil {
+	if err := svc.Run("", otelcol.NewSvcHandler(params)); err != nil {
 		return fmt.Errorf("failed to start collector server: %w", err)
 	}
 


### PR DESCRIPTION
Looks like the Windows shims weren't using the same API as the other platforms, and so refused to compile:

```
14:12:54 ❯ go install -v github.com/CtrlSpice/otel-desktop-viewer@latest
github.com/CtrlSpice/otel-desktop-viewer
# github.com/CtrlSpice/otel-desktop-viewer
C:\Users\chusk\go\pkg\mod\github.com\!ctrl!spice\otel-desktop-viewer@v0.1.0\main_windows.go:17:25: undefined: service.CollectorSettings
C:\Users\chusk\go\pkg\mod\github.com\!ctrl!spice\otel-desktop-viewer@v0.1.0\main_windows.go:43:32: undefined: service.CollectorSettings
C:\Users\chusk\go\pkg\mod\github.com\!ctrl!spice\otel-desktop-viewer@v0.1.0\main_windows.go:45:32: undefined: service.NewSvcHandler
```

Just needed some import changes to get brought up to date:

```
14:17:29 ❯ otel-desktop-viewer.exe
2023-02-21T14:17:34.422-0600    info    service/telemetry.go:92 Setting up own telemetry...
2023-02-21T14:17:34.422-0600    info    service/telemetry.go:118        Serving Prometheus metrics      {"address": ":8888", "level": "Basic"}
2023-02-21T14:17:34.422-0600    info    exporter/exporter.go:290        Development component. May change in the future.        {"kind": "exporter", "data_type": "traces", "name": "desktop"}
2023-02-21T14:17:34.423-0600    info    service/service.go:123  Starting otel-desktop-viewer... {"Version": "0.0.2", "NumCPU": 16}
2023-02-21T14:17:34.423-0600    info    extensions/extensions.go:42     Starting extensions...
2023-02-21T14:17:34.423-0600    info    service/pipelines.go:77 Starting exporters...
2023-02-21T14:17:34.423-0600    info    service/pipelines.go:81 Exporter is starting... {"kind": "exporter", "data_type": "traces", "name": "desktop"}
2023-02-21T14:17:34.423-0600    info    service/pipelines.go:85 Exporter started.       {"kind": "exporter", "data_type": "traces", "name": "desktop"}
2023-02-21T14:17:34.423-0600    info    service/pipelines.go:89 Starting processors...
2023-02-21T14:17:34.424-0600    info    service/pipelines.go:101        Starting receivers...
2023-02-21T14:17:34.424-0600    info    service/pipelines.go:105        Receiver is starting... {"kind": "receiver", "name": "otlp", "pipeline": "traces"}
2023-02-21T14:17:34.424-0600    info    otlpreceiver@v0.69.1/otlp.go:94 Starting GRPC server    {"kind": "receiver", "name": "otlp", "pipeline": "traces", "endpoint": "localhost:4317"}
2023-02-21T14:17:34.426-0600    info    otlpreceiver@v0.69.1/otlp.go:112        Starting HTTP server    {"kind": "receiver", "name": "otlp", "pipeline": "traces", "endpoint": "localhost:4318"}
2023-02-21T14:17:34.426-0600    info    service/pipelines.go:109        Receiver started.       {"kind": "receiver", "name": "otlp", "pipeline": "traces"}
2023-02-21T14:17:34.426-0600    info    service/service.go:140  Everything is ready. Begin running and processing data.
2023-02-21T14:17:39.750-0600    info    otelcol/collector.go:234        Received signal from OS {"signal": "interrupt"}
2023-02-21T14:17:39.750-0600    info    service/service.go:149  Starting shutdown...
2023-02-21T14:17:39.750-0600    info    service/pipelines.go:121        Stopping receivers...
2023-02-21T14:17:39.751-0600    info    service/pipelines.go:128        Stopping processors...
2023-02-21T14:17:39.751-0600    info    service/pipelines.go:135        Stopping exporters...
2023-02-21T14:17:39.751-0600    info    extensions/extensions.go:56     Stopping extensions...
2023-02-21T14:17:39.751-0600    info    service/service.go:163  Shutdown complete.
```