### PR TITLE
Allow configuration of the port on which we expose our frontend

### DIFF
--- a/desktop-exporter/config.go
+++ b/desktop-exporter/config.go
@@ -8,7 +8,7 @@ import (
 
 // Config defines configuration for logging exporter.
 type Config struct {
-	// Endpoint defines where we expose our frontend.
+	// Endpoint defines where we serve our frontend app
 	Endpoint string `mapstructure:"endpoint"`
 }
 

--- a/desktop-exporter/config.go
+++ b/desktop-exporter/config.go
@@ -1,16 +1,24 @@
 package desktopexporter
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/component"
 )
 
 // Config defines configuration for logging exporter.
 type Config struct {
+	// Endpoint defines where we expose our frontend.
+	Endpoint string `mapstructure:"endpoint"`
 }
 
 var _ component.Config = (*Config)(nil)
 
 // Validate checks if the exporter configuration is valid
 func (cfg *Config) Validate() error {
+	if cfg.Endpoint == "localhost:8888" {
+		return fmt.Errorf("port 8888 is not supported as it is used internally")
+	}
+
 	return nil
 }

--- a/desktop-exporter/desktop_exporter.go
+++ b/desktop-exporter/desktop_exporter.go
@@ -27,9 +27,9 @@ func (exporter *desktopExporter) pushTraces(ctx context.Context, traces ptrace.T
 	return nil
 }
 
-func newDesktopExporter() *desktopExporter {
+func newDesktopExporter(cfg *Config) *desktopExporter {
 	traceStore := NewTraceStore(MAX_QUEUE_LENGTH)
-	server := NewServer(traceStore)
+	server := NewServer(traceStore, cfg.Endpoint)
 	return &desktopExporter{
 		traceStore: traceStore,
 		server:     server,

--- a/desktop-exporter/factory.go
+++ b/desktop-exporter/factory.go
@@ -28,7 +28,12 @@ func createDefaultConfig() component.Config {
 
 func createTracesExporter(ctx context.Context, set exporter.CreateSettings, config component.Config) (exporter.Traces, error) {
 	cfg := config.(*Config)
-	desktopExporter := newDesktopExporter()
+	err := cfg.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	desktopExporter := newDesktopExporter(cfg)
 	return exporterhelper.NewTracesExporter(ctx, set, cfg,
 		desktopExporter.pushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),

--- a/desktop-exporter/server.go
+++ b/desktop-exporter/server.go
@@ -106,7 +106,7 @@ func indexHandler(writer http.ResponseWriter, request *http.Request) {
 	}
 }
 
-func NewServer(traceStore *TraceStore) *Server {
+func NewServer(traceStore *TraceStore, endpoint string) *Server {
 	router := mux.NewRouter()
 	router.HandleFunc("/api/traces", tracesHandler(traceStore))
 	router.HandleFunc("/api/traces/{id}", traceIDHandler(traceStore))
@@ -123,7 +123,7 @@ func NewServer(traceStore *TraceStore) *Server {
 	}
 	return &Server{
 		server: http.Server{
-			Addr:    "localhost:8000",
+			Addr:    endpoint,
 			Handler: router,
 		},
 		traceStore: traceStore,
@@ -134,7 +134,8 @@ func (s Server) Start() error {
 	go func() {
 		// Wait a bit for the server to come up to avoid a 404 as a first experience
 		time.Sleep(250 * time.Millisecond)
-		browser.OpenURL("http://localhost:8000/")
+		endpoint := s.server.Addr
+		browser.OpenURL("http://" + endpoint + "/")
 	}()
 	return s.server.ListenAndServe()
 }

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ processors:
 
 exporters:
   desktop:
-    endpoint: localhost:8880
+    endpoint: localhost:8000
 
 service:
   pipelines:

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ processors:
 
 exporters:
   desktop:
+    endpoint: localhost:8880
 
 service:
   pipelines:
@@ -60,8 +61,8 @@ service:
 	}
 
 	settings := otelcol.CollectorSettings{
-		BuildInfo: info,
-		Factories: factories,
+		BuildInfo:      info,
+		Factories:      factories,
 		ConfigProvider: configProvider,
 	}
 


### PR DESCRIPTION
- Allow configuration of the port on which we expose our data via the yaml string defined in `main.go`
- This is done in preparation for allowing this port to be configured via command line

Look at Lulu, happily chilling on port 8880:
![ConfigureFrontendPort](https://user-images.githubusercontent.com/56372758/220775064-25ce50d1-27e9-4ed0-b11c-be73fe7ba2bb.png)
