### PR TITLE
Update CI to include integration test

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,10 +12,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        include:
-          - os: windows-latest
-            env: 
-              NO_WINDOWS_SERVICE: 1
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,3 +29,4 @@ jobs:
 
     - name: Integration
       run: ./.github/workflows/integration.sh
+      

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,6 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: windows-latest
+            env: 
+              NO_WINDOWS_SERVICE: 1
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,8 @@ jobs:
 
     - name: Build
       run: go build -v ./...
-      uses: actions/upload-artifact@v3
+      
+    - uses: actions/upload-artifact@v3
       with:
         name: otel-desktop-viewer
         path: ./otel-desktop-viewer    

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,10 +23,19 @@ jobs:
 
     - name: Build
       run: go build -v ./...
+      uses: actions/upload-artifact@v3
+      with:
+        name: otel-desktop-viewer
+        path: ./otel-desktop-viewer    
 
     - name: Test
       run: go test -v ./...
 
+    - name: List Files
+      run: ls -la
+
     - name: Integration
       run: ./.github/workflows/integration.sh
       shell: bash
+      env:
+        CI: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: List Files
       run: ls -la
-      pwd
+
     # - uses: actions/upload-artifact@v3
     #   with:
     #     name: otel-desktop-viewer

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,8 +36,8 @@ jobs:
     - name: Test
       run: go test -v ./...
 
-    # - name: Integration
-    #   run: ./.github/workflows/integration.sh
-    #   shell: bash
-    #   env:
-    #     CI: true
+    - name: Integration
+      run: ./.github/workflows/integration.sh
+      shell: bash
+      env:
+        CI: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,10 +22,11 @@ jobs:
         go-version: 1.18
 
     - name: Build
-      run: go build -v ./...
+      run: go build -v
 
     - name: List Files
       run: ls -la
+      shell: bash
 
     # - uses: actions/upload-artifact@v3
     #   with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,16 +23,7 @@ jobs:
 
     - name: Build
       run: go build -v
-
-    - name: List Files
-      run: ls -la
-      shell: bash
-
-    # - uses: actions/upload-artifact@v3
-    #   with:
-    #     name: otel-desktop-viewer
-    #     path: ./otel-desktop-viewer    
-
+ 
     - name: Test
       run: go test -v ./...
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,4 +29,4 @@ jobs:
 
     - name: Integration
       run: ./.github/workflows/integration.sh
-      
+      shell: bash

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,3 +26,6 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+    - name: Integration
+      run: ./.github/workflows/integration.sh

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,11 @@ on: push
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,20 +23,20 @@ jobs:
 
     - name: Build
       run: go build -v ./...
-      
-    - uses: actions/upload-artifact@v3
-      with:
-        name: otel-desktop-viewer
-        path: ./otel-desktop-viewer    
+
+    - name: List Files
+      run: ls -la
+      pwd
+    # - uses: actions/upload-artifact@v3
+    #   with:
+    #     name: otel-desktop-viewer
+    #     path: ./otel-desktop-viewer    
 
     - name: Test
       run: go test -v ./...
 
-    - name: List Files
-      run: ls -la
-
-    - name: Integration
-      run: ./.github/workflows/integration.sh
-      shell: bash
-      env:
-        CI: true
+    # - name: Integration
+    #   run: ./.github/workflows/integration.sh
+    #   shell: bash
+    #   env:
+    #     CI: true

--- a/.github/workflows/integration.sh
+++ b/.github/workflows/integration.sh
@@ -10,26 +10,26 @@ pwd
 
 ls -la
 
-# # Wait a second for everything to boot up
-# sleep 5
+# Wait a second for everything to boot up
+sleep 2
 
-# # Send an example trace
-# curl -i http://localhost:4318/v1/traces -X POST -H "Content-Type: application/json" -d @./span.json
+# Send an example trace
+curl -i http://localhost:4318/v1/traces -X POST -H "Content-Type: application/json" -d @./.github/workflows/span.json
 
-# sleep 1
+sleep 1
 
-# # Check that a trace summary has been created, and the rootServiceName is correct
-# response=$(curl 'http://localhost:8000/api/traces' -H "Content-Type: application/json")
+# Check that a trace summary has been created, and the rootServiceName is correct
+response=$(curl 'http://localhost:8000/api/traces' -H "Content-Type: application/json")
 
-# rootServiceName=$(jq '.traceSummaries[0].rootServiceName' <<< $response)
+rootServiceName=$(jq '.traceSummaries[0].rootServiceName' <<< $response)
 
-# if [ $rootServiceName == '"test-with-curl"' ]
-# then
-#     echo 'Exit status 0: All good.'
-#     kill -15 $pid
-#     exit 0
-# else
-#     echo 'Exit status 1: unexpected rootServiceName ' + $rootServiceName
-#     kill -15 $pid
-#     exit 1
-# fi
+if [ $rootServiceName == '"test-with-curl"' ]
+then
+    echo 'Exit status 0: All good.'
+    kill -15 $pid
+    exit 0
+else
+    echo 'Exit status 1: unexpected rootServiceName ' + $rootServiceName
+    kill -15 $pid
+    exit 1
+fi

--- a/.github/workflows/integration.sh
+++ b/.github/workflows/integration.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 pwd
+
+ls -la
 # Launch the app in the background
 ./otel-desktop-viewer &
 

--- a/.github/workflows/integration.sh
+++ b/.github/workflows/integration.sh
@@ -2,7 +2,7 @@
 
 pwd
 # Launch the app in the background
-./../../otel-desktop-viewer &
+./otel-desktop-viewer &
 
 # Save the process ID to kill it later
 pid=$!

--- a/.github/workflows/integration.sh
+++ b/.github/workflows/integration.sh
@@ -6,11 +6,7 @@
 # Save the process ID to kill it later
 pid=$!
 
-pwd
-
-ls -la
-
-# Wait a second for everything to boot up
+# Wait 2 seconds for everything to boot up
 sleep 2
 
 # Send an example trace

--- a/.github/workflows/integration.sh
+++ b/.github/workflows/integration.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Launch the app in the background
+./../../otel-desktop-viewer &
+
+# Save the process ID to kill it later
+pid=$!
+
+# Wait a second for everything to boot up
+sleep 1
+
+# Send an example trace
+curl -is http://localhost:4318/v1/traces -X POST -H "Content-Type: application/json" -d @./span.json
+
+sleep 1
+
+# Check that a trace summary has been created, and the rootServiceName is correct
+response=$(curl 'http://localhost:8000/api/traces' -H "Content-Type: application/json")
+
+rootServiceName=$(jq '.traceSummaries[0].rootServiceName' <<< $response)
+
+if [ $rootServiceName == '"test-with-curl"' ]
+then
+    echo 'Exit status 0: All good.'
+    kill -15 $pid
+    exit 0
+else
+    echo 'Exit status 1: unexpected rootServiceName ' + $rootServiceName
+    kill -15 $pid
+    exit 1
+fi

--- a/.github/workflows/integration.sh
+++ b/.github/workflows/integration.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pwd
 # Launch the app in the background
 ./../../otel-desktop-viewer &
 

--- a/.github/workflows/integration.sh
+++ b/.github/workflows/integration.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-make build-go
 
-ls -la
 # Launch the app in the background
 ./otel-desktop-viewer &
 

--- a/.github/workflows/integration.sh
+++ b/.github/workflows/integration.sh
@@ -6,26 +6,30 @@
 # Save the process ID to kill it later
 pid=$!
 
-# Wait a second for everything to boot up
-sleep 5
+pwd
 
-# Send an example trace
-curl -i http://localhost:4318/v1/traces -X POST -H "Content-Type: application/json" -d @./span.json
+ls -la
 
-sleep 1
+# # Wait a second for everything to boot up
+# sleep 5
 
-# Check that a trace summary has been created, and the rootServiceName is correct
-response=$(curl 'http://localhost:8000/api/traces' -H "Content-Type: application/json")
+# # Send an example trace
+# curl -i http://localhost:4318/v1/traces -X POST -H "Content-Type: application/json" -d @./span.json
 
-rootServiceName=$(jq '.traceSummaries[0].rootServiceName' <<< $response)
+# sleep 1
 
-if [ $rootServiceName == '"test-with-curl"' ]
-then
-    echo 'Exit status 0: All good.'
-    kill -15 $pid
-    exit 0
-else
-    echo 'Exit status 1: unexpected rootServiceName ' + $rootServiceName
-    kill -15 $pid
-    exit 1
-fi
+# # Check that a trace summary has been created, and the rootServiceName is correct
+# response=$(curl 'http://localhost:8000/api/traces' -H "Content-Type: application/json")
+
+# rootServiceName=$(jq '.traceSummaries[0].rootServiceName' <<< $response)
+
+# if [ $rootServiceName == '"test-with-curl"' ]
+# then
+#     echo 'Exit status 0: All good.'
+#     kill -15 $pid
+#     exit 0
+# else
+#     echo 'Exit status 1: unexpected rootServiceName ' + $rootServiceName
+#     kill -15 $pid
+#     exit 1
+# fi

--- a/.github/workflows/integration.sh
+++ b/.github/workflows/integration.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-pwd
+make build-go
 
 ls -la
 # Launch the app in the background

--- a/.github/workflows/integration.sh
+++ b/.github/workflows/integration.sh
@@ -7,10 +7,10 @@
 pid=$!
 
 # Wait a second for everything to boot up
-sleep 1
+sleep 5
 
 # Send an example trace
-curl -is http://localhost:4318/v1/traces -X POST -H "Content-Type: application/json" -d @./span.json
+curl -i http://localhost:4318/v1/traces -X POST -H "Content-Type: application/json" -d @./span.json
 
 sleep 1
 

--- a/.github/workflows/span.json
+++ b/.github/workflows/span.json
@@ -1,0 +1,37 @@
+{
+ "resourceSpans": [
+   {
+     "resource": {
+       "attributes": [
+         {
+           "key": "service.name",
+           "value": {
+             "stringValue": "test-with-curl"
+           }
+         }
+       ]
+     },
+     "scopeSpans": [
+       {
+         "scope": {
+           "name": "manual-test"
+         },
+         "spans": [
+           {
+             "traceId": "71699b6fe85982c7c8995ea3d9c95df2",
+             "spanId": "3c191d03fa8be065",
+             "name": "spanitron",
+             "kind": 2,
+             "droppedAttributesCount": 0,
+             "events": [],
+             "droppedEventsCount": 0,
+             "status": {
+               "code": 1
+             }
+           }
+         ]
+       }
+     ]
+   }
+ ]
+}

--- a/desktop-exporter/server.go
+++ b/desktop-exporter/server.go
@@ -131,12 +131,15 @@ func NewServer(traceStore *TraceStore, endpoint string) *Server {
 }
 
 func (s Server) Start() error {
-	go func() {
-		// Wait a bit for the server to come up to avoid a 404 as a first experience
-		time.Sleep(250 * time.Millisecond)
-		endpoint := s.server.Addr
-		browser.OpenURL("http://" + endpoint + "/")
-	}()
+	_, isCI := os.LookupEnv("CI")
+	if !isCI {
+		go func() {
+			// Wait a bit for the server to come up to avoid a 404 as a first experience
+			time.Sleep(250 * time.Millisecond)
+			endpoint := s.server.Addr
+			browser.OpenURL("http://" + endpoint + "/")
+		}()
+	}
 	return s.server.ListenAndServe()
 }
 


### PR DESCRIPTION
This test runs a bash script that 
- launches the executable in the background 
- sends a minimal test trace using a curl command
- queries the trace store via api call to make sure the trace data was received and processed correctly
- kills the running process and exits with the appropriate exit code

Note: I have added a "CI" environment variable to prevent the browser window from being launched when running in CI. This is set in `go.yaml` under the Integration step.