### PR TITLE
Enable trace summaries to auto-update

### DIFF
--- a/desktopexporter/app/components/sidebar-view/sidebar.tsx
+++ b/desktopexporter/app/components/sidebar-view/sidebar.tsx
@@ -12,11 +12,12 @@ type SidebarProps = {
   isFullWidth: boolean;
   toggleSidebarWidth: () => void;
   traceSummaries: TraceSummaryWithUIData[];
+  numNewTraces: number;
 };
 
 export function Sidebar(props: SidebarProps) {
   let sidebarColour = useColorModeValue("gray.50", "gray.700");
-  let { isFullWidth, toggleSidebarWidth, traceSummaries } = props;
+  let { isFullWidth, toggleSidebarWidth, traceSummaries, numNewTraces } = props;
   let isFullWidthDisabled = traceSummaries.length === 0;
 
   if (isFullWidth) {
@@ -32,7 +33,7 @@ export function Sidebar(props: SidebarProps) {
           isFullWidth={isFullWidth}
           toggleSidebarWidth={toggleSidebarWidth}
           isFullWidthDisabled={false}
-          numNewTraces={0}
+          numNewTraces={numNewTraces}
         />
         <TraceList traceSummaries={traceSummaries} />
       </Flex>

--- a/desktopexporter/app/routes/main-view.tsx
+++ b/desktopexporter/app/routes/main-view.tsx
@@ -80,7 +80,6 @@ function updateSidebarData(
   sidebarData: SidebarData,
   traceSummaries: TraceSummary[],
 ): SidebarData {
-  
   let mergedData: SidebarData = {
     numNewTraces: 0,
     summaries: [...sidebarData.summaries],
@@ -108,8 +107,8 @@ function updateSidebarData(
   }
 
   // Check for deleted/expired traces
-  for (let i = 0; i < mergedData.summaries.length; i++) {
-    let traceID = mergedData.summaries[i].traceID;
+  for (let [i, summary] of mergedData.summaries.entries()) {
+    let traceID = summary.traceID;
     let counterpartIndex = traceSummaries.findIndex(
       (s) => s.traceID === traceID,
     );

--- a/desktopexporter/app/routes/main-view.tsx
+++ b/desktopexporter/app/routes/main-view.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Outlet } from "react-router-dom";
 import { Flex, useBoolean } from "@chakra-ui/react";
 import { useLoaderData } from "react-router-dom";
@@ -6,7 +6,7 @@ import { useLoaderData } from "react-router-dom";
 import { Sidebar } from "../components/sidebar-view/sidebar";
 import { EmptyStateView } from "../components/empty-state-view/empty-state-view";
 import { TraceSummaries, TraceSummary } from "../types/api-types";
-import { TraceSummaryWithUIData } from "../types/ui-types";
+import { SidebarData, TraceSummaryWithUIData } from "../types/ui-types";
 import { getDurationNs, getDurationString } from "../utils/duration";
 
 export async function mainLoader() {
@@ -19,6 +19,28 @@ export default function MainView() {
   let { traceSummaries } = useLoaderData() as TraceSummaries;
   let [isFullWidth, setFullWidth] = useBoolean(traceSummaries.length > 0);
 
+  // initialize the sidebar summaries at mount time
+  let [sidebarData, setSidebarData] = useState(initSidebarData(traceSummaries));
+
+  // check every second to see if we have new data
+  // and upsate sidebar summaries accordingly
+  useEffect(() => {
+    async function checkForNewData() {
+      let response = await fetch("/api/traces");
+      if (response.ok) {
+        let { traceSummaries } = (await response.json()) as TraceSummaries;
+        let newSidebarData = {
+          ...updateSidebarData(sidebarData, traceSummaries),
+        };
+        setSidebarData(newSidebarData);
+      }
+    }
+
+    let interval = setInterval(checkForNewData, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
   // Handle empty state
   if (!traceSummaries.length) {
     return (
@@ -27,50 +49,100 @@ export default function MainView() {
           isFullWidth={isFullWidth}
           toggleSidebarWidth={setFullWidth.toggle}
           traceSummaries={[]}
+          numNewTraces={0}
         />
         <EmptyStateView />
       </Flex>
     );
   }
 
-  let sidebarSummaries: TraceSummaryWithUIData[] =
-    getTraceSummariesWithUIData(traceSummaries);
   return (
     <Flex height="100vh">
       <Sidebar
         isFullWidth={isFullWidth}
         toggleSidebarWidth={setFullWidth.toggle}
-        traceSummaries={sidebarSummaries}
+        traceSummaries={sidebarData.summaries}
+        numNewTraces={sidebarData.numNewTraces}
       />
       <Outlet />
     </Flex>
   );
 }
 
-function getTraceSummariesWithUIData(
-  traceSummaries: TraceSummary[],
-): TraceSummaryWithUIData[] {
-  return traceSummaries.map((traceSummary) => {
-    if (traceSummary.hasRootSpan) {
-      let duration = getDurationNs(
-        traceSummary.rootStartTime,
-        traceSummary.rootEndTime,
-      );
+function initSidebarData(traceSummaries: TraceSummary[]): SidebarData {
+  return {
+    summaries: traceSummaries.map((traceSummary) =>
+      generateTraceSummaryWithUIData(traceSummary),
+    ),
+    numNewTraces: 0,
+  };
+}
 
-      let durationString = getDurationString(duration);
-      return {
-        hasRootSpan: true,
-        rootServiceName: traceSummary.rootServiceName,
-        rootName: traceSummary.rootName,
-        rootDurationString: durationString,
-        spanCount: traceSummary.spanCount,
-        traceID: traceSummary.traceID,
-      };
+function updateSidebarData(
+  sidebarData: SidebarData,
+  traceSummaries: TraceSummary[],
+): SidebarData {
+  sidebarData.numNewTraces = 0;
+
+  // Check for new and stale traces
+  for (let i = 0; i < traceSummaries.length; i++) {
+    let traceID = traceSummaries[i].traceID;
+    let sidebarSummaryIndex = sidebarData.summaries.findIndex(
+      (s) => s.traceID === traceID,
+    );
+
+    if (sidebarSummaryIndex === -1) {
+      // If the traceID of the new summary has no match in the sidebar
+      // increment the number of new traces.
+      sidebarData.numNewTraces++;
+    } else if (
+      traceSummaries[i].spanCount >
+      sidebarData.summaries[sidebarSummaryIndex].spanCount
+    ) {
+      // If the number of spans in an existing trace is greater than what's displayed in the sidebar
+      // generate a whole new summary with ui data
+      sidebarData.summaries[sidebarSummaryIndex] =
+        generateTraceSummaryWithUIData(traceSummaries[i]);
     }
+  }
+
+  // Check for deleted/expired traces
+  for (let i = 0; i < sidebarData.summaries.length; i++) {
+    let traceID = sidebarData.summaries[i].traceID;
+    let counterpartIndex = traceSummaries.findIndex(
+      (s) => s.traceID === traceID,
+    );
+    if (counterpartIndex === -1) {
+      // If a summary present in the sidebar is not present in the list of incoming traces
+      // it is expired and must be removed
+      sidebarData.summaries.splice(i, 1);
+    }
+  }
+  return sidebarData;
+}
+
+function generateTraceSummaryWithUIData(
+  traceSummary: TraceSummary,
+): TraceSummaryWithUIData {
+  if (traceSummary.hasRootSpan) {
+    let duration = getDurationNs(
+      traceSummary.rootStartTime,
+      traceSummary.rootEndTime,
+    );
+
+    let durationString = getDurationString(duration);
     return {
-      hasRootSpan: false,
+      hasRootSpan: true,
+      rootServiceName: traceSummary.rootServiceName,
+      rootName: traceSummary.rootName,
+      rootDurationString: durationString,
       spanCount: traceSummary.spanCount,
       traceID: traceSummary.traceID,
     };
-  });
+  }
+  return {
+    hasRootSpan: false,
+    spanCount: traceSummary.spanCount,
+    traceID: traceSummary.traceID,
+  };
 }

--- a/desktopexporter/app/types/ui-types.ts
+++ b/desktopexporter/app/types/ui-types.ts
@@ -35,3 +35,8 @@ export type TraceSummaryWithUIData =
       spanCount: number;
       traceID: string;
     };
+
+    export type SidebarData = {
+      numNewTraces: number;
+      summaries: TraceSummaryWithUIData[];
+    };

--- a/desktopexporter/static/main.js
+++ b/desktopexporter/static/main.js
@@ -1001,7 +1001,7 @@
             }
             return dispatcher.useContext(Context);
           }
-          function useState20(initialState2) {
+          function useState21(initialState2) {
             var dispatcher = resolveDispatcher();
             return dispatcher.useState(initialState2);
           }
@@ -1013,7 +1013,7 @@
             var dispatcher = resolveDispatcher();
             return dispatcher.useRef(initialValue);
           }
-          function useEffect35(create, deps) {
+          function useEffect36(create, deps) {
             var dispatcher = resolveDispatcher();
             return dispatcher.useEffect(create, deps);
           }
@@ -1793,7 +1793,7 @@
           exports.useContext = useContext16;
           exports.useDebugValue = useDebugValue2;
           exports.useDeferredValue = useDeferredValue;
-          exports.useEffect = useEffect35;
+          exports.useEffect = useEffect36;
           exports.useId = useId8;
           exports.useImperativeHandle = useImperativeHandle;
           exports.useInsertionEffect = useInsertionEffect2;
@@ -1801,7 +1801,7 @@
           exports.useMemo = useMemo19;
           exports.useReducer = useReducer;
           exports.useRef = useRef28;
-          exports.useState = useState20;
+          exports.useState = useState21;
           exports.useSyncExternalStore = useSyncExternalStore3;
           exports.useTransition = useTransition;
           exports.version = ReactVersion;
@@ -51762,7 +51762,7 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
   var sidebarCollapsedWidth = 70;
   function Sidebar(props) {
     let sidebarColour = useColorModeValue("gray.50", "gray.700");
-    let { isFullWidth, toggleSidebarWidth, traceSummaries } = props;
+    let { isFullWidth, toggleSidebarWidth, traceSummaries, numNewTraces } = props;
     let isFullWidthDisabled = traceSummaries.length === 0;
     if (isFullWidth) {
       return /* @__PURE__ */ import_react144.default.createElement(Flex, {
@@ -51775,7 +51775,7 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
         isFullWidth,
         toggleSidebarWidth,
         isFullWidthDisabled: false,
-        numNewTraces: 0
+        numNewTraces
       }), /* @__PURE__ */ import_react144.default.createElement(TraceList, {
         traceSummaries
       }));
@@ -52025,47 +52025,93 @@ otel-cli exec --service my-service --name "curl google" curl https://google.com
   function MainView() {
     let { traceSummaries } = useLoaderData();
     let [isFullWidth, setFullWidth] = useBoolean(traceSummaries.length > 0);
+    let [sidebarData, setSidebarData] = (0, import_react148.useState)(initSidebarData(traceSummaries));
+    (0, import_react148.useEffect)(() => {
+      async function checkForNewData() {
+        let response = await fetch("/api/traces");
+        if (response.ok) {
+          let { traceSummaries: traceSummaries2 } = await response.json();
+          let newSidebarData = {
+            ...updateSidebarData(sidebarData, traceSummaries2)
+          };
+          setSidebarData(newSidebarData);
+        }
+      }
+      let interval = setInterval(checkForNewData, 1e3);
+      return () => clearInterval(interval);
+    }, []);
     if (!traceSummaries.length) {
       return /* @__PURE__ */ import_react148.default.createElement(Flex, {
         height: "100vh"
       }, /* @__PURE__ */ import_react148.default.createElement(Sidebar, {
         isFullWidth,
         toggleSidebarWidth: setFullWidth.toggle,
-        traceSummaries: []
+        traceSummaries: [],
+        numNewTraces: 0
       }), /* @__PURE__ */ import_react148.default.createElement(EmptyStateView, null));
     }
-    let sidebarSummaries = getTraceSummariesWithUIData(traceSummaries);
     return /* @__PURE__ */ import_react148.default.createElement(Flex, {
       height: "100vh"
     }, /* @__PURE__ */ import_react148.default.createElement(Sidebar, {
       isFullWidth,
       toggleSidebarWidth: setFullWidth.toggle,
-      traceSummaries: sidebarSummaries
+      traceSummaries: sidebarData.summaries,
+      numNewTraces: sidebarData.numNewTraces
     }), /* @__PURE__ */ import_react148.default.createElement(Outlet, null));
   }
-  function getTraceSummariesWithUIData(traceSummaries) {
-    return traceSummaries.map((traceSummary) => {
-      if (traceSummary.hasRootSpan) {
-        let duration = getDurationNs(
-          traceSummary.rootStartTime,
-          traceSummary.rootEndTime
-        );
-        let durationString = getDurationString(duration);
-        return {
-          hasRootSpan: true,
-          rootServiceName: traceSummary.rootServiceName,
-          rootName: traceSummary.rootName,
-          rootDurationString: durationString,
-          spanCount: traceSummary.spanCount,
-          traceID: traceSummary.traceID
-        };
+  function initSidebarData(traceSummaries) {
+    return {
+      summaries: traceSummaries.map(
+        (traceSummary) => generateTraceSummaryWithUIData(traceSummary)
+      ),
+      numNewTraces: 0
+    };
+  }
+  function updateSidebarData(sidebarData, traceSummaries) {
+    sidebarData.numNewTraces = 0;
+    for (let i = 0; i < traceSummaries.length; i++) {
+      let traceID = traceSummaries[i].traceID;
+      let sidebarSummaryIndex = sidebarData.summaries.findIndex(
+        (s) => s.traceID === traceID
+      );
+      if (sidebarSummaryIndex === -1) {
+        sidebarData.numNewTraces++;
+      } else if (traceSummaries[i].spanCount > sidebarData.summaries[sidebarSummaryIndex].spanCount) {
+        sidebarData.summaries[sidebarSummaryIndex] = generateTraceSummaryWithUIData(traceSummaries[i]);
       }
+    }
+    for (let i = 0; i < sidebarData.summaries.length; i++) {
+      let traceID = sidebarData.summaries[i].traceID;
+      let counterpartIndex = traceSummaries.findIndex(
+        (s) => s.traceID === traceID
+      );
+      if (counterpartIndex === -1) {
+        sidebarData.summaries.splice(i, 1);
+      }
+    }
+    return sidebarData;
+  }
+  function generateTraceSummaryWithUIData(traceSummary) {
+    if (traceSummary.hasRootSpan) {
+      let duration = getDurationNs(
+        traceSummary.rootStartTime,
+        traceSummary.rootEndTime
+      );
+      let durationString = getDurationString(duration);
       return {
-        hasRootSpan: false,
+        hasRootSpan: true,
+        rootServiceName: traceSummary.rootServiceName,
+        rootName: traceSummary.rootName,
+        rootDurationString: durationString,
         spanCount: traceSummary.spanCount,
         traceID: traceSummary.traceID
       };
-    });
+    }
+    return {
+      hasRootSpan: false,
+      spanCount: traceSummary.spanCount,
+      traceID: traceSummary.traceID
+    };
   }
 
   // app/routes/trace-view.tsx

--- a/desktopexporter/static/main.js
+++ b/desktopexporter/static/main.js
@@ -52081,8 +52081,8 @@ otel-cli exec --service my-service --name "curl google" curl https://google.com
         mergedData.summaries[sidebarSummaryIndex] = generateTraceSummaryWithUIData(summary);
       }
     }
-    for (let i = 0; i < mergedData.summaries.length; i++) {
-      let traceID = mergedData.summaries[i].traceID;
+    for (let [i, summary] of mergedData.summaries.entries()) {
+      let traceID = summary.traceID;
       let counterpartIndex = traceSummaries.findIndex(
         (s) => s.traceID === traceID
       );


### PR DESCRIPTION
![UpdateTraceSummaries](https://user-images.githubusercontent.com/56372758/235533621-d857306c-c125-4d36-9eea-1ae7c8d02b6c.gif)

- The trace summaries in the sidebar now auto-update as new spans become available for that trace. A trace that was marked incomplete will automatically update after its root span becomes available to fill in the missing information.
- A counter now tracks new traces that are available to view, with an option to refresh to see them. 