### PR TITLE
add support for metrics and logs

### DIFF
--- a/desktopexporter/desktop_exporter.go
+++ b/desktopexporter/desktop_exporter.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
@@ -17,6 +19,22 @@ const (
 type desktopExporter struct {
 	traceStore *TraceStore
 	server     *Server
+}
+
+func (exporter *desktopExporter) pushMetrics(ctx context.Context, metrics pmetric.Metrics) error {
+	md := extractMetrics(metrics)
+	for _, metric := range md {
+		exporter.traceStore.AddMetric(ctx, metric)
+	}
+	return nil
+}
+
+func (exporter *desktopExporter) pushLogs(ctx context.Context, logs plog.Logs) error {
+	ld := extractLogs(logs)
+	for _, logData := range ld {
+		exporter.traceStore.AddLog(ctx, logData)
+	}
+	return nil
 }
 
 func (exporter *desktopExporter) pushTraces(ctx context.Context, traces ptrace.Traces) error {
@@ -39,7 +57,6 @@ func newDesktopExporter(cfg *Config) *desktopExporter {
 func (exporter *desktopExporter) Start(ctx context.Context, host component.Host) error {
 	go func() {
 		err := exporter.server.Start()
-		defer exporter.server.Close()
 
 		if errors.Is(err, http.ErrServerClosed) {
 			fmt.Printf("server closed\n")
@@ -49,4 +66,8 @@ func (exporter *desktopExporter) Start(ctx context.Context, host component.Host)
 
 	}()
 	return nil
+}
+
+func (exporter *desktopExporter) Shutdown(ctx context.Context) error {
+	return exporter.server.Close()
 }

--- a/desktopexporter/factory.go
+++ b/desktopexporter/factory.go
@@ -7,6 +7,8 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/sharedcomponent"
 )
 
 const (
@@ -19,11 +21,63 @@ func NewFactory() exporter.Factory {
 		typeStr,
 		createDefaultConfig,
 		exporter.WithTraces(createTracesExporter, stability),
+		exporter.WithMetrics(createMetricsExporter, stability),
+		exporter.WithLogs(createLogsExporter, stability),
 	)
 }
 
 func createDefaultConfig() component.Config {
 	return &Config{}
+}
+
+func createMetricsExporter(ctx context.Context, set exporter.CreateSettings, config component.Config) (exporter.Metrics, error) {
+	cfg := config.(*Config)
+	err := cfg.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	e, err := exporters.GetOrAdd(cfg, func() (*desktopExporter, error) {
+		return newDesktopExporter(cfg), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return exporterhelper.NewMetricsExporter(ctx, set, cfg,
+		e.Unwrap().pushMetrics,
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		// Disable Timeout/RetryOnFailure and SendingQueue
+		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
+		exporterhelper.WithRetry(exporterhelper.RetrySettings{Enabled: false}),
+		exporterhelper.WithQueue(exporterhelper.QueueSettings{Enabled: false}),
+		exporterhelper.WithStart(e.Start),
+	)
+}
+
+func createLogsExporter(ctx context.Context, set exporter.CreateSettings, config component.Config) (exporter.Logs, error) {
+	cfg := config.(*Config)
+	err := cfg.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	e, err := exporters.GetOrAdd(cfg, func() (*desktopExporter, error) {
+		return newDesktopExporter(cfg), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return exporterhelper.NewLogsExporter(ctx, set, cfg,
+		e.Unwrap().pushLogs,
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		// Disable Timeout/RetryOnFailure and SendingQueue
+		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
+		exporterhelper.WithRetry(exporterhelper.RetrySettings{Enabled: false}),
+		exporterhelper.WithQueue(exporterhelper.QueueSettings{Enabled: false}),
+		exporterhelper.WithStart(e.Start),
+	)
 }
 
 func createTracesExporter(ctx context.Context, set exporter.CreateSettings, config component.Config) (exporter.Traces, error) {
@@ -33,14 +87,28 @@ func createTracesExporter(ctx context.Context, set exporter.CreateSettings, conf
 		return nil, err
 	}
 
-	desktopExporter := newDesktopExporter(cfg)
+	e, err := exporters.GetOrAdd(cfg, func() (*desktopExporter, error) {
+		return newDesktopExporter(cfg), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	return exporterhelper.NewTracesExporter(ctx, set, cfg,
-		desktopExporter.pushTraces,
+		e.Unwrap().pushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		// Disable Timeout/RetryOnFailure and SendingQueue
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
 		exporterhelper.WithRetry(exporterhelper.RetrySettings{Enabled: false}),
 		exporterhelper.WithQueue(exporterhelper.QueueSettings{Enabled: false}),
-		exporterhelper.WithStart(desktopExporter.Start),
+		exporterhelper.WithStart(e.Start),
 	)
 }
+
+// This is the map of already created desktop exporters for particular configurations.
+// We maintain this map because the Factory is asked trace, logs, and metric exporters separately
+// when it gets CreateTracesExporter() and CreateMetricsExporter() but they must not
+// create separate objects, they must use one desktopExporter object per configuration.
+// When the exporter is shutdown it should be removed from this map so the same configuration
+// can be recreated successfully.
+var exporters = sharedcomponent.NewSharedComponents[*Config, *desktopExporter]()

--- a/desktopexporter/go.mod
+++ b/desktopexporter/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/component v0.76.0
 	go.opentelemetry.io/collector/consumer v0.76.0
 	go.opentelemetry.io/collector/exporter v0.76.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc10
+	go.opentelemetry.io/collector/pdata v1.0.0-rc9
 )
 
 require (
@@ -19,6 +19,7 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/knadh/koanf v1.5.0 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
@@ -42,5 +43,6 @@ require (
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
 	google.golang.org/grpc v1.54.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/desktopexporter/go.sum
+++ b/desktopexporter/go.sum
@@ -165,11 +165,11 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -246,6 +246,7 @@ github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJf
 github.com/prometheus/statsd_exporter v0.22.7 h1:7Pji/i2GuhK6Lu7DHrtTkFmNBCudCPT1pX2CziuyQR0=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
+github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
@@ -289,8 +290,7 @@ go.opentelemetry.io/collector/exporter v0.76.0 h1:pnwtyZJiiRZUwalOUhs9DsK89xmxjG
 go.opentelemetry.io/collector/exporter v0.76.0/go.mod h1:havOURkBY5lB/iLQTUVizR8sH/Mqbpy3I9UvRi2Ir0Y=
 go.opentelemetry.io/collector/featuregate v0.76.0 h1:J3wZ6ZhSj2v/q4kYlqT2+aI8IauHidc2MK/clZS42kk=
 go.opentelemetry.io/collector/featuregate v0.76.0/go.mod h1:S3iqaiAYSyfNlvs9ZCj1YfWKN3YclNB/fi+Gi+hP2BI=
-go.opentelemetry.io/collector/pdata v1.0.0-rc10 h1:NyTNauLWmrXPu1lg7ocqBSp5haFSTtiWGtMVFvL4GBk=
-go.opentelemetry.io/collector/pdata v1.0.0-rc10/go.mod h1:ZPMyfub988wSQPGGoibk8shkDyGrCC7VDRjCBxwplho=
+go.opentelemetry.io/collector/pdata v1.0.0-rc9 h1:K1GND9w4hOMVE4lLpGt+0KvjIBcbsR54ZsijEyUQFFI=
 go.opentelemetry.io/collector/receiver v0.76.0 h1:uInnyJAgtrUjNcvVhNfH0HuWKLut2xwP7crVTjk6ll4=
 go.opentelemetry.io/collector/receiver v0.76.0/go.mod h1:apV0aHa6xz0aFjUQ5NbrBhUHvJ8P4IwnjiBBeRmIEyA=
 go.opentelemetry.io/otel v1.14.0 h1:/79Huy8wbf5DnIPhemGB+zEPVwnN6fuQybr/SRXa6hM=
@@ -453,8 +453,8 @@ google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/desktopexporter/internal/sharedcomponent/sharedcomponent.go
+++ b/desktopexporter/internal/sharedcomponent/sharedcomponent.go
@@ -1,0 +1,91 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sharedcomponent exposes util functionality for receivers and exporters
+// that need to share state between different signal types instances such as net.Listener or os.File.
+package sharedcomponent // import "go.opentelemetry.io/collector/internal/sharedcomponent"
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+// SharedComponents a map that keeps reference of all created instances for a given configuration,
+// and ensures that the shared state is started and stopped only once.
+type SharedComponents[K comparable, V component.Component] struct {
+	comps map[K]*SharedComponent[V]
+}
+
+// NewSharedComponents returns a new empty SharedComponents.
+func NewSharedComponents[K comparable, V component.Component]() *SharedComponents[K, V] {
+	return &SharedComponents[K, V]{
+		comps: make(map[K]*SharedComponent[V]),
+	}
+}
+
+// GetOrAdd returns the already created instance if exists, otherwise creates a new instance
+// and adds it to the map of references.
+func (scs *SharedComponents[K, V]) GetOrAdd(key K, create func() (V, error)) (*SharedComponent[V], error) {
+	if c, ok := scs.comps[key]; ok {
+		return c, nil
+	}
+	comp, err := create()
+	if err != nil {
+		return nil, err
+	}
+	newComp := &SharedComponent[V]{
+		component: comp,
+		removeFunc: func() {
+			delete(scs.comps, key)
+		},
+	}
+	scs.comps[key] = newComp
+	return newComp, nil
+}
+
+// SharedComponent ensures that the wrapped component is started and stopped only once.
+// When stopped it is removed from the SharedComponents map.
+type SharedComponent[V component.Component] struct {
+	component V
+
+	startOnce  sync.Once
+	stopOnce   sync.Once
+	removeFunc func()
+}
+
+// Unwrap returns the original component.
+func (r *SharedComponent[V]) Unwrap() V {
+	return r.component
+}
+
+// Start implements component.Component.
+func (r *SharedComponent[V]) Start(ctx context.Context, host component.Host) error {
+	var err error
+	r.startOnce.Do(func() {
+		err = r.component.Start(ctx, host)
+	})
+	return err
+}
+
+// Shutdown implements component.Component.
+func (r *SharedComponent[V]) Shutdown(ctx context.Context) error {
+	var err error
+	r.stopOnce.Do(func() {
+		err = r.component.Shutdown(ctx)
+		r.removeFunc()
+	})
+	return err
+}

--- a/desktopexporter/otlp_payload_processor_test.go
+++ b/desktopexporter/otlp_payload_processor_test.go
@@ -15,7 +15,21 @@ const (
 	resourceCount = 2
 	scopeCount    = 3
 	spanCount     = 4
+	metricCount   = 5
+	logCount      = 6
 )
+
+func TestExtractLogs(t *testing.T) {
+	logs := testdata.GenerateLogs(resourceCount, scopeCount, logCount)
+	ld := extractLogs(logs)
+	assert.Len(t, ld, logs.LogRecordCount())
+}
+
+func TestExtractMetrics(t *testing.T) {
+	metrics := testdata.GenerateMetrics(resourceCount, scopeCount, metricCount)
+	md := extractMetrics(metrics)
+	assert.Len(t, md, metrics.MetricCount())
+}
 
 func TestExtractSpans(t *testing.T) {
 	traces := testdata.GenerateOTLPPayload(resourceCount, scopeCount, spanCount)

--- a/desktopexporter/testdata/trace.go
+++ b/desktopexporter/testdata/trace.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
@@ -12,6 +14,54 @@ var (
 	spanEventTimestamp = pcommon.NewTimestampFromTime(time.Date(2020, 10, 21, 7, 10, 2, 150, time.UTC))
 	spanEndTimestamp   = pcommon.NewTimestampFromTime(time.Date(2020, 10, 21, 7, 10, 2, 300, time.UTC))
 )
+
+func GenerateMetrics(resourceCount, scopeCount, spanCount int) pmetric.Metrics {
+	metrics := pmetric.NewMetrics()
+	metrics.ResourceMetrics().EnsureCapacity(resourceCount)
+	for resourceIndex := 0; resourceIndex < resourceCount; resourceIndex++ {
+		resourceMetric := metrics.ResourceMetrics().AppendEmpty()
+		fillResource(resourceMetric.Resource(), resourceIndex)
+
+		// Create and populate instrumentation scope data
+		resourceMetric.ScopeMetrics().EnsureCapacity(scopeCount)
+		for scopeIndex := 0; scopeIndex < scopeCount; scopeIndex++ {
+			sm := resourceMetric.ScopeMetrics().AppendEmpty()
+			fillScope(sm.Scope(), scopeIndex)
+
+			//Create and populate spans
+			sm.Metrics().EnsureCapacity(spanCount)
+			for idx := 0; idx < spanCount; idx++ {
+				m := sm.Metrics().AppendEmpty()
+				fillMetric(m, idx)
+			}
+		}
+	}
+	return metrics
+}
+
+func GenerateLogs(resourceCount, scopeCount, logCount int) plog.Logs {
+	logs := plog.NewLogs()
+	logs.ResourceLogs().EnsureCapacity(resourceCount)
+	for resourceIndex := 0; resourceIndex < resourceCount; resourceIndex++ {
+		resourceLog := logs.ResourceLogs().AppendEmpty()
+		fillResource(resourceLog.Resource(), resourceIndex)
+
+		// Create and populate instrumentation scope data
+		resourceLog.ScopeLogs().EnsureCapacity(scopeCount)
+		for scopeIndex := 0; scopeIndex < scopeCount; scopeIndex++ {
+			sl := resourceLog.ScopeLogs().AppendEmpty()
+			fillScope(sl.Scope(), scopeIndex)
+
+			//Create and populate spans
+			sl.LogRecords().EnsureCapacity(logCount)
+			for idx := 0; idx < logCount; idx++ {
+				l := sl.LogRecords().AppendEmpty()
+				fillLog(l, idx)
+			}
+		}
+	}
+	return logs
+}
 
 func GenerateOTLPPayload(resourceCount, scopeCount, spanCount int) ptrace.Traces {
 	traceData := ptrace.NewTraces()
@@ -81,4 +131,16 @@ func fillSpan(span ptrace.Span, spanIndex int) {
 	status := span.Status()
 	status.SetCode(ptrace.StatusCodeOk)
 	status.SetMessage("status ok")
+}
+
+func fillMetric(metric pmetric.Metric, index int) {
+	metric.SetName("metric")
+	// TODO: fill in all the details
+	sum := metric.SetEmptySum()
+	sum.SetIsMonotonic(true)
+}
+
+func fillLog(log plog.LogRecord, index int) {
+	log.Body().SetStr("log body")
+	// TODO: fill in all the details
 }

--- a/desktopexporter/trace_store.go
+++ b/desktopexporter/trace_store.go
@@ -23,6 +23,18 @@ func NewTraceStore(maxQueueSize int) *TraceStore {
 	}
 }
 
+func (store *TraceStore) AddMetric(_ context.Context, md MetricData) {
+	store.mut.Lock()
+	defer store.mut.Unlock()
+	// TODO: enqueue metric
+}
+
+func (store *TraceStore) AddLog(_ context.Context, ld LogData) {
+	store.mut.Lock()
+	defer store.mut.Unlock()
+	// TODO: enqueue log
+}
+
 func (store *TraceStore) Add(_ context.Context, spanData SpanData) {
 	store.mut.Lock()
 	defer store.mut.Unlock()
@@ -33,7 +45,7 @@ func (store *TraceStore) Add(_ context.Context, spanData SpanData) {
 	if !traceExists {
 		traceData = TraceData{
 			TraceID: spanData.TraceID,
-			Spans: []SpanData{},
+			Spans:   []SpanData{},
 		}
 	}
 	traceData.Spans = append(traceData.Spans, spanData)
@@ -71,7 +83,7 @@ func (store *TraceStore) GetRecentTraces(traceCount int) []TraceData {
 	return recentTraces
 }
 
-func (store *TraceStore) ClearTraces(){
+func (store *TraceStore) ClearTraces() {
 	store.mut.Lock()
 	defer store.mut.Unlock()
 

--- a/desktopexporter/types.go
+++ b/desktopexporter/types.go
@@ -45,6 +45,18 @@ type ScopeData struct {
 	DroppedAttributesCount uint32                 `json:"droppedAttributesCount"`
 }
 
+type LogData struct {
+	Body     string        `json:"body"`
+	Resource *ResourceData `json:"resource"`
+	Scope    *ScopeData    `json:"scope"`
+}
+
+type MetricData struct {
+	Name     string        `json:"name"`
+	Resource *ResourceData `json:"resource"`
+	Scope    *ScopeData    `json:"scope"`
+}
+
 type SpanData struct {
 	TraceID      string `json:"traceID"`
 	TraceState   string `json:"traceState"`

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -11,3 +11,9 @@ service:
     traces:
       receivers: [otlp]
       exporters: [desktop]
+    metrics:
+      receivers: [otlp]
+      exporters: [desktop]
+    logs:
+      receivers: [otlp]
+      exporters: [desktop]

--- a/main.go
+++ b/main.go
@@ -58,11 +58,18 @@ exporters:
 service:
   pipelines:
     traces:
-      receivers:
-        - otlp
+      receivers: [otlp]
       processors: []
-      exporters:
-        - desktop`
+      exporters: [desktop]
+    metrics:
+      receivers: [otlp]
+      processors: []
+      exporters: [desktop]
+    logs:
+      receivers: [otlp]
+      processors: []
+      exporters: [desktop]
+`
 
 			factories, err := components()
 			if err != nil {


### PR DESCRIPTION
This change adds support for metrics & logs to the exporter code. The commits are as follows:

1. add methods to the factory to make the component available for metrics/logs pipelines
2. add extract methods for logs/metrics

There's still many details to fill in, but I wanted to get the pieces in place to fill in the details later, without too big of a PR.