### PR TITLE
Add keyboard navigation to spans in waterfall view

### DIFF
--- a/desktopexporter/app/components/waterfall-view/waterfall-view.tsx
+++ b/desktopexporter/app/components/waterfall-view/waterfall-view.tsx
@@ -1,12 +1,13 @@
-import React, { useRef, ClipboardEvent } from "react";
+import React, { useRef, ClipboardEvent, useEffect } from "react";
 import { FixedSizeList } from "react-window";
 import { Flex } from "@chakra-ui/react";
 import { useSize } from "@chakra-ui/react-use-size";
 
-import { SpanWithUIData } from "../../types/ui-types";
+import { SpanDataStatus, SpanWithUIData } from "../../types/ui-types";
 import { WaterfallRow } from "./waterfall-row";
 import { HeaderRow } from "./header-row";
 import { TraceTiming } from "../../utils/duration";
+import { useKeyPress } from "../../utils/use-key-press";
 
 type WaterfallViewProps = {
   orderedSpans: SpanWithUIData[];
@@ -24,13 +25,53 @@ export function WaterfallView(props: WaterfallViewProps) {
   const spanNameColumnWidth = 300;
   const serviceNameColumnWidth = 200;
 
+  let { orderedSpans, traceTimeAttributes, selectedSpanID, setSelectedSpanID } =
+    props;
+
+  // Set up keyboard navigation
+  let arrowUpPressed = useKeyPress("ArrowUp");
+  let arrowDownPressed = useKeyPress("ArrowDown");
+  let kPressed = useKeyPress("k");
+  let jPressed = useKeyPress("j");
+
+  let selectedIndex = orderedSpans.findIndex(
+    (span) => span.metadata.spanID === selectedSpanID,
+  );
+  let firstSelectableIndex = orderedSpans.findIndex(
+    (span) => span.status === SpanDataStatus.present,
+  );
+
+  useEffect(() => {
+    if (arrowUpPressed || kPressed) {
+      // Move up while skipping the missing spans in incomplete traces
+      if (selectedIndex > firstSelectableIndex) {
+        do {
+          selectedIndex--;
+        } while (orderedSpans[selectedIndex].status === SpanDataStatus.missing);
+        setSelectedSpanID(orderedSpans[selectedIndex].metadata.spanID);
+      }
+    }
+  }, [arrowUpPressed, kPressed]);
+
+  useEffect(() => {
+    if (arrowDownPressed || jPressed) {
+      // Move down while skipping the missing spans in incomplete traces
+      if (selectedIndex < orderedSpans.length - 1) {
+        do {
+          selectedIndex++;
+        } while (orderedSpans[selectedIndex].status === SpanDataStatus.missing);
+        setSelectedSpanID(orderedSpans[selectedIndex].metadata.spanID);
+      }
+    }
+  }, [arrowDownPressed, jPressed]);
+
   let rowData = {
-    orderedSpans: props.orderedSpans,
-    traceTimeAttributes: props.traceTimeAttributes,
+    orderedSpans: orderedSpans,
+    traceTimeAttributes: traceTimeAttributes,
     spanNameColumnWidth: spanNameColumnWidth,
     serviceNameColumnWidth: serviceNameColumnWidth,
-    selectedSpanID: props.selectedSpanID,
-    setSelectedSpanID: props.setSelectedSpanID,
+    selectedSpanID: selectedSpanID,
+    setSelectedSpanID: setSelectedSpanID,
   };
 
   return (
@@ -71,4 +112,3 @@ function stripZeroWidthSpacesOnCopyCallback(
   e.clipboardData?.setData("text/plain", text);
   e.preventDefault();
 }
-

--- a/desktopexporter/app/routes/trace-view.tsx
+++ b/desktopexporter/app/routes/trace-view.tsx
@@ -26,13 +26,13 @@ export default function TraceView() {
   let [selectedSpanID, setSelectedSpanID] = React.useState<string>(() => {
     if (
       !orderedSpans.length ||
-      (!(orderedSpans[0].status === SpanDataStatus.present) &&
+      (orderedSpans[0].status === SpanDataStatus.missing &&
         orderedSpans.length < 2)
     ) {
-      return "";
+      throw new Error("Number of spans cannot be zero");
     }
 
-    if (!(orderedSpans[0].status === SpanDataStatus.present)) {
+    if (orderedSpans[0].status === SpanDataStatus.missing) {
       return orderedSpans[1].metadata.spanID;
     }
 

--- a/desktopexporter/app/utils/use-key-press.ts
+++ b/desktopexporter/app/utils/use-key-press.ts
@@ -6,6 +6,7 @@ export const useKeyPress = (targetKey: string) => {
   useEffect(
     () => {
       const downHandler = (event: KeyboardEvent) => {
+        event.preventDefault();
         if (event.key === targetKey) {
           setKeyPressed(true);
         }

--- a/desktopexporter/static/main.js
+++ b/desktopexporter/static/main.js
@@ -1013,7 +1013,7 @@
             var dispatcher = resolveDispatcher();
             return dispatcher.useRef(initialValue);
           }
-          function useEffect38(create, deps) {
+          function useEffect39(create, deps) {
             var dispatcher = resolveDispatcher();
             return dispatcher.useEffect(create, deps);
           }
@@ -1793,7 +1793,7 @@
           exports.useContext = useContext16;
           exports.useDebugValue = useDebugValue2;
           exports.useDeferredValue = useDeferredValue;
-          exports.useEffect = useEffect38;
+          exports.useEffect = useEffect39;
           exports.useId = useId8;
           exports.useImperativeHandle = useImperativeHandle;
           exports.useInsertionEffect = useInsertionEffect2;
@@ -51115,6 +51115,7 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
     (0, import_react139.useEffect)(
       () => {
         const downHandler = (event) => {
+          event.preventDefault();
           if (event.key === targetKey) {
             setKeyPressed(true);
           }
@@ -52825,13 +52826,44 @@ otel-cli exec --service my-service --name "curl google" curl https://google.com
     const headerRowHeight = 30;
     const spanNameColumnWidth = 300;
     const serviceNameColumnWidth = 200;
+    let { orderedSpans, traceTimeAttributes, selectedSpanID, setSelectedSpanID } = props;
+    let arrowUpPressed = useKeyPress("ArrowUp");
+    let arrowDownPressed = useKeyPress("ArrowDown");
+    let kPressed = useKeyPress("k");
+    let jPressed = useKeyPress("j");
+    let selectedIndex = orderedSpans.findIndex(
+      (span) => span.metadata.spanID === selectedSpanID
+    );
+    let firstSelectableIndex = orderedSpans.findIndex(
+      (span) => span.status === "present" /* present */
+    );
+    (0, import_react173.useEffect)(() => {
+      if (arrowUpPressed || kPressed) {
+        if (selectedIndex > firstSelectableIndex) {
+          do {
+            selectedIndex--;
+          } while (orderedSpans[selectedIndex].status === "missing" /* missing */);
+          setSelectedSpanID(orderedSpans[selectedIndex].metadata.spanID);
+        }
+      }
+    }, [arrowUpPressed, kPressed]);
+    (0, import_react173.useEffect)(() => {
+      if (arrowDownPressed || jPressed) {
+        if (selectedIndex < orderedSpans.length - 1) {
+          do {
+            selectedIndex++;
+          } while (orderedSpans[selectedIndex].status === "missing" /* missing */);
+          setSelectedSpanID(orderedSpans[selectedIndex].metadata.spanID);
+        }
+      }
+    }, [arrowDownPressed, jPressed]);
     let rowData = {
-      orderedSpans: props.orderedSpans,
-      traceTimeAttributes: props.traceTimeAttributes,
+      orderedSpans,
+      traceTimeAttributes,
       spanNameColumnWidth,
       serviceNameColumnWidth,
-      selectedSpanID: props.selectedSpanID,
-      setSelectedSpanID: props.setSelectedSpanID
+      selectedSpanID,
+      setSelectedSpanID
     };
     return /* @__PURE__ */ import_react173.default.createElement(Flex, {
       direction: "column",
@@ -52936,10 +52968,10 @@ otel-cli exec --service my-service --name "curl google" curl https://google.com
     let spanTree = arrayToTree(traceData.spans);
     let orderedSpans = orderSpans(spanTree);
     let [selectedSpanID, setSelectedSpanID] = import_react175.default.useState(() => {
-      if (!orderedSpans.length || !(orderedSpans[0].status === "present" /* present */) && orderedSpans.length < 2) {
-        return "";
+      if (!orderedSpans.length || orderedSpans[0].status === "missing" /* missing */ && orderedSpans.length < 2) {
+        throw new Error("Number of spans cannot be zero");
       }
-      if (!(orderedSpans[0].status === "present" /* present */)) {
+      if (orderedSpans[0].status === "missing" /* missing */) {
         return orderedSpans[1].metadata.spanID;
       }
       return orderedSpans[0].metadata.spanID;


### PR DESCRIPTION
The spans in the waterfall view can now be traversed using the up and down arrows as well as the j and k vim equivalents.
Placeholders for missing spans are automatically skipped. The span's data is automatically displayed in the detail view.

Note: I disabled the default behaviour of the keys because arrow presses scrolled through whatever list you happen to have left your cursor in. Right now, it won't scroll as you move up and down the list. I will sync it up with `react-window`'s scroll  to item in the next PR, but wanted to get this logic out of the way first.

Look at it go!
![KeyboardNavSpans](https://user-images.githubusercontent.com/56372758/236705277-82b757fc-0ff1-4215-8157-9c6c3bbad19d.gif)
