### PR TITLE
Sync list scroll with keyboard navigation

### DIFF
--- a/desktopexporter/app/components/sidebar-view/trace-list.tsx
+++ b/desktopexporter/app/components/sidebar-view/trace-list.tsx
@@ -143,8 +143,9 @@ type TraceListProps = {
 };
 
 export function TraceList(props: TraceListProps) {
-  let ref = useRef(null);
-  let size = useSize(ref);
+  let containerRef = useRef(null);
+  let summaryListRef = React.createRef<FixedSizeList>();
+  let size = useSize(containerRef);
 
   let location = useLocation();
   let navigate = useNavigate();
@@ -173,6 +174,8 @@ export function TraceList(props: TraceListProps) {
   useEffect(() => {
     if (arrowLeftPressed || hPressed) {
       selectedIndex = selectedIndex > 0 ? selectedIndex - 1 : 0;
+      summaryListRef.current?.scrollToItem(selectedIndex);
+
       selectedTraceID = traceSummaries[selectedIndex].traceID;
       navigate(`/traces/${selectedTraceID}`);
     }
@@ -184,10 +187,16 @@ export function TraceList(props: TraceListProps) {
         selectedIndex < traceSummaries.length - 1
           ? selectedIndex + 1
           : traceSummaries.length - 1;
+      summaryListRef.current?.scrollToItem(selectedIndex);
+
       selectedTraceID = traceSummaries[selectedIndex].traceID;
       navigate(`/traces/${selectedTraceID}`);
     }
   }, [arrowRightPressed, lPressed]);
+
+  useEffect(() => {
+    summaryListRef.current?.scrollToItem(selectedIndex, "start");
+  }, []);
 
   let itemData = {
     selectedTraceID: selectedTraceID,
@@ -198,7 +207,7 @@ export function TraceList(props: TraceListProps) {
 
   return (
     <Flex
-      ref={ref}
+      ref={containerRef}
       height="100%"
     >
       <FixedSizeList
@@ -207,6 +216,7 @@ export function TraceList(props: TraceListProps) {
         itemCount={props.traceSummaries.length}
         itemSize={itemHeight}
         width="100%"
+        ref={summaryListRef}
       >
         {SidebarRow}
       </FixedSizeList>

--- a/desktopexporter/app/components/waterfall-view/waterfall-view.tsx
+++ b/desktopexporter/app/components/waterfall-view/waterfall-view.tsx
@@ -17,8 +17,9 @@ type WaterfallViewProps = {
 };
 
 export function WaterfallView(props: WaterfallViewProps) {
-  const ref = useRef(null);
-  const size = useSize(ref);
+  let containerRef = useRef(null);
+  let spanListRef = React.createRef<FixedSizeList>();
+  const size = useSize(containerRef);
 
   const waterfallItemHeight = 50;
   const headerRowHeight = 30;
@@ -49,6 +50,7 @@ export function WaterfallView(props: WaterfallViewProps) {
           selectedIndex--;
         } while (orderedSpans[selectedIndex].status === SpanDataStatus.missing);
         setSelectedSpanID(orderedSpans[selectedIndex].metadata.spanID);
+        spanListRef.current?.scrollToItem(selectedIndex);
       }
     }
   }, [arrowUpPressed, kPressed]);
@@ -61,6 +63,7 @@ export function WaterfallView(props: WaterfallViewProps) {
           selectedIndex++;
         } while (orderedSpans[selectedIndex].status === SpanDataStatus.missing);
         setSelectedSpanID(orderedSpans[selectedIndex].metadata.spanID);
+        spanListRef.current?.scrollToItem(selectedIndex);
       }
     }
   }, [arrowDownPressed, jPressed]);
@@ -77,7 +80,7 @@ export function WaterfallView(props: WaterfallViewProps) {
   return (
     <Flex
       direction="column"
-      ref={ref}
+      ref={containerRef}
       height="100%"
       onCopy={stripZeroWidthSpacesOnCopyCallback}
     >
@@ -85,14 +88,15 @@ export function WaterfallView(props: WaterfallViewProps) {
         headerRowHeight={headerRowHeight}
         spanNameColumnWidth={spanNameColumnWidth}
         serviceNameColumnWidth={serviceNameColumnWidth}
-        traceDuration={props.traceTimeAttributes.traceDurationNS}
+        traceDuration={traceTimeAttributes.traceDurationNS}
       />
       <FixedSizeList
         className="List"
         height={size ? size.height - headerRowHeight : 0}
         itemData={rowData}
-        itemCount={props.orderedSpans.length}
+        itemCount={orderedSpans.length}
         itemSize={waterfallItemHeight}
+        ref={spanListRef}
         width={"100%"}
       >
         {WaterfallRow}

--- a/desktopexporter/static/main.js
+++ b/desktopexporter/static/main.js
@@ -51203,8 +51203,9 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
     }, "Trace ID: ", /* @__PURE__ */ import_react140.default.createElement("strong", null, traceSummary.traceID)))));
   }
   function TraceList(props) {
-    let ref = (0, import_react140.useRef)(null);
-    let size3 = useSize(ref);
+    let containerRef = (0, import_react140.useRef)(null);
+    let summaryListRef = import_react140.default.createRef();
+    let size3 = useSize(containerRef);
     let location = useLocation();
     let navigate = useNavigate();
     let selectedIndex = 0;
@@ -51226,6 +51227,7 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
     (0, import_react140.useEffect)(() => {
       if (arrowLeftPressed || hPressed) {
         selectedIndex = selectedIndex > 0 ? selectedIndex - 1 : 0;
+        summaryListRef.current?.scrollToItem(selectedIndex);
         selectedTraceID = traceSummaries[selectedIndex].traceID;
         navigate(`/traces/${selectedTraceID}`);
       }
@@ -51233,24 +51235,29 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
     (0, import_react140.useEffect)(() => {
       if (arrowRightPressed || lPressed) {
         selectedIndex = selectedIndex < traceSummaries.length - 1 ? selectedIndex + 1 : traceSummaries.length - 1;
+        summaryListRef.current?.scrollToItem(selectedIndex);
         selectedTraceID = traceSummaries[selectedIndex].traceID;
         navigate(`/traces/${selectedTraceID}`);
       }
     }, [arrowRightPressed, lPressed]);
+    (0, import_react140.useEffect)(() => {
+      summaryListRef.current?.scrollToItem(selectedIndex, "start");
+    }, []);
     let itemData = {
       selectedTraceID,
       traceSummaries
     };
     let itemHeight = sidebarSummaryHeight + dividerHeight;
     return /* @__PURE__ */ import_react140.default.createElement(Flex, {
-      ref,
+      ref: containerRef,
       height: "100%"
     }, /* @__PURE__ */ import_react140.default.createElement(FixedSizeList, {
       height: size3 ? size3.height : 0,
       itemData,
       itemCount: props.traceSummaries.length,
       itemSize: itemHeight,
-      width: "100%"
+      width: "100%",
+      ref: summaryListRef
     }, SidebarRow));
   }
 
@@ -52820,8 +52827,9 @@ otel-cli exec --service my-service --name "curl google" curl https://google.com
 
   // app/components/waterfall-view/waterfall-view.tsx
   function WaterfallView(props) {
-    const ref = (0, import_react173.useRef)(null);
-    const size3 = useSize(ref);
+    let containerRef = (0, import_react173.useRef)(null);
+    let spanListRef = import_react173.default.createRef();
+    const size3 = useSize(containerRef);
     const waterfallItemHeight = 50;
     const headerRowHeight = 30;
     const spanNameColumnWidth = 300;
@@ -52844,6 +52852,7 @@ otel-cli exec --service my-service --name "curl google" curl https://google.com
             selectedIndex--;
           } while (orderedSpans[selectedIndex].status === "missing" /* missing */);
           setSelectedSpanID(orderedSpans[selectedIndex].metadata.spanID);
+          spanListRef.current?.scrollToItem(selectedIndex);
         }
       }
     }, [arrowUpPressed, kPressed]);
@@ -52854,6 +52863,7 @@ otel-cli exec --service my-service --name "curl google" curl https://google.com
             selectedIndex++;
           } while (orderedSpans[selectedIndex].status === "missing" /* missing */);
           setSelectedSpanID(orderedSpans[selectedIndex].metadata.spanID);
+          spanListRef.current?.scrollToItem(selectedIndex);
         }
       }
     }, [arrowDownPressed, jPressed]);
@@ -52867,20 +52877,21 @@ otel-cli exec --service my-service --name "curl google" curl https://google.com
     };
     return /* @__PURE__ */ import_react173.default.createElement(Flex, {
       direction: "column",
-      ref,
+      ref: containerRef,
       height: "100%",
       onCopy: stripZeroWidthSpacesOnCopyCallback
     }, /* @__PURE__ */ import_react173.default.createElement(HeaderRow, {
       headerRowHeight,
       spanNameColumnWidth,
       serviceNameColumnWidth,
-      traceDuration: props.traceTimeAttributes.traceDurationNS
+      traceDuration: traceTimeAttributes.traceDurationNS
     }), /* @__PURE__ */ import_react173.default.createElement(FixedSizeList, {
       className: "List",
       height: size3 ? size3.height - headerRowHeight : 0,
       itemData: rowData,
-      itemCount: props.orderedSpans.length,
+      itemCount: orderedSpans.length,
       itemSize: waterfallItemHeight,
+      ref: spanListRef,
       width: "100%"
     }, WaterfallRow));
   }


### PR DESCRIPTION
Both the list of summaries and the waterfall view now scroll to the correct position when using keyboard navigation:
![KeyboardNavScroll](https://github.com/CtrlSpice/otel-desktop-viewer/assets/56372758/c712be46-9a29-4288-ad7d-9d016b2a490b)


Additionally, the list of summaries will scroll to the selected summary on reload:
![ScrollToItemOnReload](https://github.com/CtrlSpice/otel-desktop-viewer/assets/56372758/3a52418a-d7aa-4b01-9e3b-f7e1de32c0c3)
