### PR TITLE
Implement keyboard shortcuts and combos

### DIFF
--- a/desktopexporter/app/components/sidebar-view/sidebar-header.tsx
+++ b/desktopexporter/app/components/sidebar-view/sidebar-header.tsx
@@ -16,15 +16,7 @@ import {
   useColorMode,
   useColorModeValue,
 } from "@chakra-ui/react";
-
-async function clearTraceData() {
-  let response = await fetch("/api/clearData");
-  if (!response.ok) {
-    throw new Error("HTTP status " + response.status);
-  } else {
-    window.location.replace("/");
-  }
-}
+import { clearTraceData } from "./trace-list";
 
 type SidebarHeaderProps = {
   isFullWidth: boolean;

--- a/desktopexporter/app/components/sidebar-view/trace-list.tsx
+++ b/desktopexporter/app/components/sidebar-view/trace-list.tsx
@@ -165,6 +165,11 @@ export function TraceList(props: TraceListProps) {
     window.location.href = `/traces/${selectedTraceID}`;
   }
 
+  // Scroll to the currently selected trace summary on load
+  useEffect(() => {
+    summaryListRef.current?.scrollToItem(selectedIndex, "start");
+  }, []);
+
   // Set up keyboard navigation
   let prevTraceKeyPressed = useKeyPress(["ArrowLeft", "h"]);
   let nextTraceKeyPressed = useKeyPress(["ArrowRight", "l"]);
@@ -172,6 +177,7 @@ export function TraceList(props: TraceListProps) {
   let navHelpComboPressed = useKeyCombo(["Shift"], ["?"]);
   let clearTracesComboPressed = useKeyCombo(["Control"], ["l"]);
 
+  // Navigate to previous trace
   useEffect(() => {
     if (prevTraceKeyPressed) {
       selectedIndex = selectedIndex > 0 ? selectedIndex - 1 : 0;
@@ -182,6 +188,7 @@ export function TraceList(props: TraceListProps) {
     }
   }, [prevTraceKeyPressed]);
 
+  // Navigate to next trace
   useEffect(() => {
     if (nextTraceKeyPressed) {
       selectedIndex =
@@ -195,27 +202,26 @@ export function TraceList(props: TraceListProps) {
     }
   }, [nextTraceKeyPressed]);
 
+  // Reload current window
   useEffect(() => {
     if (reloadKeyPressed) {
       window.location.reload();
     }
   }, [reloadKeyPressed]);
 
+  // Show the keyboard navigation help modal
   useEffect(() => {
     if (navHelpComboPressed) {
       //TODO: Pop up a helpful modal that tells you all about the keyboard shortcuts
     }
   }, [navHelpComboPressed]);
 
+  // Clear current traces
   useEffect(() => {
     if (clearTracesComboPressed) {
       clearTraceData();
     }
   }, [clearTracesComboPressed]);
-
-  useEffect(() => {
-    summaryListRef.current?.scrollToItem(selectedIndex, "start");
-  }, []);
 
   let itemData = {
     selectedTraceID: selectedTraceID,

--- a/desktopexporter/app/components/sidebar-view/trace-list.tsx
+++ b/desktopexporter/app/components/sidebar-view/trace-list.tsx
@@ -204,7 +204,6 @@ export function TraceList(props: TraceListProps) {
   useEffect(() => {
     if (navHelpComboPressed) {
       //TODO: Pop up a helpful modal that tells you all about the keyboard shortcuts
-      console.log("I'M HELPING!");
     }
   }, [navHelpComboPressed]);
 

--- a/desktopexporter/app/components/sidebar-view/trace-list.tsx
+++ b/desktopexporter/app/components/sidebar-view/trace-list.tsx
@@ -12,7 +12,7 @@ import {
 import { useSize } from "@chakra-ui/react-use-size";
 
 import { TraceSummaryWithUIData } from "../../types/ui-types";
-import { useKeyPress } from "../../utils/use-key-press";
+import { useKeyCombo, useKeyPress } from "../../utils/use-key-press";
 
 const sidebarSummaryHeight = 120;
 const dividerHeight = 1;
@@ -168,6 +168,9 @@ export function TraceList(props: TraceListProps) {
   // Set up keyboard navigation
   let prevTraceKeyPressed = useKeyPress(["ArrowLeft", "h"]);
   let nextTraceKeyPressed = useKeyPress(["ArrowRight", "l"]);
+  let reloadKeyPressed = useKeyPress(["r"]);
+  let navHelpComboPressed = useKeyCombo(["Shift"], ["?"]);
+  let clearTracesComboPressed = useKeyCombo(["Control"], ["l"]);
 
   useEffect(() => {
     if (prevTraceKeyPressed) {
@@ -191,6 +194,25 @@ export function TraceList(props: TraceListProps) {
       navigate(`/traces/${selectedTraceID}`);
     }
   }, [nextTraceKeyPressed]);
+
+  useEffect(() => {
+    if (reloadKeyPressed) {
+      window.location.reload();
+    }
+  }, [reloadKeyPressed]);
+
+  useEffect(() => {
+    if (navHelpComboPressed) {
+      //TODO: Pop up a helpful modal that tells you all about the keyboard shortcuts
+      console.log("I'M HELPING!");
+    }
+  }, [navHelpComboPressed]);
+
+  useEffect(() => {
+    if (clearTracesComboPressed) {
+      clearTraceData();
+    }
+  }, [clearTracesComboPressed]);
 
   useEffect(() => {
     summaryListRef.current?.scrollToItem(selectedIndex, "start");
@@ -220,4 +242,13 @@ export function TraceList(props: TraceListProps) {
       </FixedSizeList>
     </Flex>
   );
+}
+
+export async function clearTraceData() {
+  let response = await fetch("/api/clearData");
+  if (!response.ok) {
+    throw new Error("HTTP status " + response.status);
+  } else {
+    window.location.replace("/");
+  }
 }

--- a/desktopexporter/app/components/waterfall-view/waterfall-view.tsx
+++ b/desktopexporter/app/components/waterfall-view/waterfall-view.tsx
@@ -67,12 +67,12 @@ export function WaterfallView(props: WaterfallViewProps) {
   }, [nextSpanKeyPressed]);
 
   let rowData = {
-    orderedSpans: orderedSpans,
-    traceTimeAttributes: traceTimeAttributes,
-    spanNameColumnWidth: spanNameColumnWidth,
-    serviceNameColumnWidth: serviceNameColumnWidth,
-    selectedSpanID: selectedSpanID,
-    setSelectedSpanID: setSelectedSpanID,
+    orderedSpans,
+    traceTimeAttributes,
+    spanNameColumnWidth,
+    serviceNameColumnWidth,
+    selectedSpanID,
+    setSelectedSpanID,
   };
 
   return (

--- a/desktopexporter/app/types/ui-types.ts
+++ b/desktopexporter/app/types/ui-types.ts
@@ -40,3 +40,5 @@ export type TraceSummaryWithUIData =
       numNewTraces: number;
       summaries: TraceSummaryWithUIData[];
     };
+
+    export type ModifierKey = "Alt" | "Control" | "Meta" | "Shift";

--- a/desktopexporter/app/utils/use-key-press.ts
+++ b/desktopexporter/app/utils/use-key-press.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { ModifierKey } from "../types/ui-types";
 
 export const useKeyPress = (targetKeys: string[]) => {
   let [keyPressed, setKeyPressed] = useState(false);
@@ -36,7 +37,10 @@ export const useKeyPress = (targetKeys: string[]) => {
   return keyPressed;
 };
 
-export const useKeyCombo = (modifierKeys: string[], targetKeys: string[]) => {
+export const useKeyCombo = (
+  modifierKeys: ModifierKey[],
+  targetKeys: string[],
+) => {
   let [comboPressed, setComboPressed] = useState(false);
   useEffect(() => {
     const downHandler = (event: KeyboardEvent) => {
@@ -67,7 +71,7 @@ export const useKeyCombo = (modifierKeys: string[], targetKeys: string[]) => {
 
     const upHandler = (event: KeyboardEvent) => {
       if (
-        modifierKeys.includes(event.key) ||
+        modifierKeys.map((modKey) => modKey.toString()).includes(event.key) ||
         targetKeys.includes(event.key.toLowerCase())
       ) {
         setComboPressed(false);

--- a/desktopexporter/app/utils/use-key-press.ts
+++ b/desktopexporter/app/utils/use-key-press.ts
@@ -1,11 +1,13 @@
 import { useState, useEffect } from "react";
 
 export const useKeyPress = (targetKeys: string[]) => {
-  const [keyPressed, setKeyPressed] = useState(false);
-
+  let [keyPressed, setKeyPressed] = useState(false);
   useEffect(
     () => {
       const downHandler = (event: KeyboardEvent) => {
+        if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+          return;
+        }
         event.preventDefault();
         if (targetKeys.includes(event.key)) {
           setKeyPressed(true);
@@ -32,4 +34,55 @@ export const useKeyPress = (targetKeys: string[]) => {
     [targetKeys, setKeyPressed],
   );
   return keyPressed;
+};
+
+export const useKeyCombo = (modifierKeys: string[], targetKeys: string[]) => {
+  let [comboPressed, setComboPressed] = useState(false);
+  useEffect(() => {
+    const downHandler = (event: KeyboardEvent) => {
+      event.preventDefault();
+      let modifiersPressed: boolean = modifierKeys
+        .map((modKey) => {
+          switch (modKey) {
+            case "Alt":
+              return event.altKey;
+            case "Control":
+              return event.ctrlKey;
+            case "Meta":
+              return event.metaKey;
+            case "Shift":
+              return event.shiftKey;
+            default:
+              return false;
+          }
+        })
+        .reduce((accumulator, currentValue) => {
+          return accumulator && currentValue;
+        });
+
+      if (modifiersPressed && targetKeys.includes(event.key)) {
+        setComboPressed(true);
+      }
+    };
+
+    const upHandler = (event: KeyboardEvent) => {
+      if (
+        modifierKeys.includes(event.key) ||
+        targetKeys.includes(event.key.toLowerCase())
+      ) {
+        setComboPressed(false);
+      }
+    };
+
+    // attach the listeners to the window.
+    window.addEventListener("keydown", downHandler);
+    window.addEventListener("keyup", upHandler);
+
+    // remove the listeners when the component is unmounted.
+    return () => {
+      window.removeEventListener("keydown", downHandler);
+      window.removeEventListener("keyup", upHandler);
+    };
+  }, [modifierKeys, targetKeys, setComboPressed]);
+  return comboPressed;
 };

--- a/desktopexporter/static/main.js
+++ b/desktopexporter/static/main.js
@@ -51290,7 +51290,6 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
     }, [reloadKeyPressed]);
     (0, import_react140.useEffect)(() => {
       if (navHelpComboPressed) {
-        console.log("I'M HELPING!");
       }
     }, [navHelpComboPressed]);
     (0, import_react140.useEffect)(() => {

--- a/desktopexporter/static/main.js
+++ b/desktopexporter/static/main.js
@@ -51262,6 +51262,9 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
       selectedTraceID = traceSummaries[selectedIndex].traceID;
       window.location.href = `/traces/${selectedTraceID}`;
     }
+    (0, import_react140.useEffect)(() => {
+      summaryListRef.current?.scrollToItem(selectedIndex, "start");
+    }, []);
     let prevTraceKeyPressed = useKeyPress(["ArrowLeft", "h"]);
     let nextTraceKeyPressed = useKeyPress(["ArrowRight", "l"]);
     let reloadKeyPressed = useKeyPress(["r"]);
@@ -51297,9 +51300,6 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
         clearTraceData();
       }
     }, [clearTracesComboPressed]);
-    (0, import_react140.useEffect)(() => {
-      summaryListRef.current?.scrollToItem(selectedIndex, "start");
-    }, []);
     let itemData = {
       selectedTraceID,
       traceSummaries

--- a/desktopexporter/static/main.js
+++ b/desktopexporter/static/main.js
@@ -51111,10 +51111,13 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
   // app/utils/use-key-press.ts
   var import_react139 = __toESM(require_react());
   var useKeyPress = (targetKeys) => {
-    const [keyPressed, setKeyPressed] = (0, import_react139.useState)(false);
+    let [keyPressed, setKeyPressed] = (0, import_react139.useState)(false);
     (0, import_react139.useEffect)(
       () => {
         const downHandler = (event) => {
+          if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+            return;
+          }
           event.preventDefault();
           if (targetKeys.includes(event.key)) {
             setKeyPressed(true);
@@ -51135,6 +51138,45 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
       [targetKeys, setKeyPressed]
     );
     return keyPressed;
+  };
+  var useKeyCombo = (modifierKeys, targetKeys) => {
+    let [comboPressed, setComboPressed] = (0, import_react139.useState)(false);
+    (0, import_react139.useEffect)(() => {
+      const downHandler = (event) => {
+        event.preventDefault();
+        let modifiersPressed = modifierKeys.map((modKey) => {
+          switch (modKey) {
+            case "Alt":
+              return event.altKey;
+            case "Control":
+              return event.ctrlKey;
+            case "Meta":
+              return event.metaKey;
+            case "Shift":
+              return event.shiftKey;
+            default:
+              return false;
+          }
+        }).reduce((accumulator, currentValue) => {
+          return accumulator && currentValue;
+        });
+        if (modifiersPressed && targetKeys.includes(event.key)) {
+          setComboPressed(true);
+        }
+      };
+      const upHandler = (event) => {
+        if (modifierKeys.includes(event.key) || targetKeys.includes(event.key.toLowerCase())) {
+          setComboPressed(false);
+        }
+      };
+      window.addEventListener("keydown", downHandler);
+      window.addEventListener("keyup", upHandler);
+      return () => {
+        window.removeEventListener("keydown", downHandler);
+        window.removeEventListener("keyup", upHandler);
+      };
+    }, [modifierKeys, targetKeys, setComboPressed]);
+    return comboPressed;
   };
 
   // app/components/sidebar-view/trace-list.tsx
@@ -51222,6 +51264,9 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
     }
     let prevTraceKeyPressed = useKeyPress(["ArrowLeft", "h"]);
     let nextTraceKeyPressed = useKeyPress(["ArrowRight", "l"]);
+    let reloadKeyPressed = useKeyPress(["r"]);
+    let navHelpComboPressed = useKeyCombo(["Shift"], ["?"]);
+    let clearTracesComboPressed = useKeyCombo(["Control"], ["l"]);
     (0, import_react140.useEffect)(() => {
       if (prevTraceKeyPressed) {
         selectedIndex = selectedIndex > 0 ? selectedIndex - 1 : 0;
@@ -51238,6 +51283,21 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
         navigate(`/traces/${selectedTraceID}`);
       }
     }, [nextTraceKeyPressed]);
+    (0, import_react140.useEffect)(() => {
+      if (reloadKeyPressed) {
+        window.location.reload();
+      }
+    }, [reloadKeyPressed]);
+    (0, import_react140.useEffect)(() => {
+      if (navHelpComboPressed) {
+        console.log("I'M HELPING!");
+      }
+    }, [navHelpComboPressed]);
+    (0, import_react140.useEffect)(() => {
+      if (clearTracesComboPressed) {
+        clearTraceData();
+      }
+    }, [clearTracesComboPressed]);
     (0, import_react140.useEffect)(() => {
       summaryListRef.current?.scrollToItem(selectedIndex, "start");
     }, []);
@@ -51257,6 +51317,14 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
       width: "100%",
       ref: summaryListRef
     }, SidebarRow));
+  }
+  async function clearTraceData() {
+    let response = await fetch("/api/clearData");
+    if (!response.ok) {
+      throw new Error("HTTP status " + response.status);
+    } else {
+      window.location.replace("/");
+    }
   }
 
   // app/components/sidebar-view/sidebar-header.tsx
@@ -51720,14 +51788,6 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
   });
 
   // app/components/sidebar-view/sidebar-header.tsx
-  async function clearTraceData() {
-    let response = await fetch("/api/clearData");
-    if (!response.ok) {
-      throw new Error("HTTP status " + response.status);
-    } else {
-      window.location.replace("/");
-    }
-  }
   function SidebarHeader(props) {
     let { toggleColorMode } = useColorMode();
     let colourModeIcon = useColorModeValue(/* @__PURE__ */ import_react143.default.createElement(MoonIcon, null), /* @__PURE__ */ import_react143.default.createElement(SunIcon, null));

--- a/desktopexporter/static/main.js
+++ b/desktopexporter/static/main.js
@@ -51165,7 +51165,7 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
         }
       };
       const upHandler = (event) => {
-        if (modifierKeys.includes(event.key) || targetKeys.includes(event.key.toLowerCase())) {
+        if (modifierKeys.map((modKey) => modKey.toString()).includes(event.key) || targetKeys.includes(event.key.toLowerCase())) {
           setComboPressed(false);
         }
       };


### PR DESCRIPTION
This PR introduces a new custom hook called `useKeyCombo` to complement `useKeyPress` that will allow us to quickly create new keyboard shortcuts as the application grows.

It also defines the following shortcuts: 
-`r` to reload the page
-`Ctrl` + `l` to clear all traces
- `?` to show a modal with keyboard shortcuts and navigation tips (this will be implemented in the next PR)

Sorry, no video this time because it doesn't add much. 😄 