### PR TITLE
Fix bug that prevents the use of default browser keyboard shortcuts

### DIFF
--- a/desktopexporter/app/utils/use-key-press.ts
+++ b/desktopexporter/app/utils/use-key-press.ts
@@ -44,7 +44,6 @@ export const useKeyCombo = (
   let [comboPressed, setComboPressed] = useState(false);
   useEffect(() => {
     const downHandler = (event: KeyboardEvent) => {
-      event.preventDefault();
       let modifiersPressed: boolean = modifierKeys
         .map((modKey) => {
           switch (modKey) {
@@ -65,6 +64,7 @@ export const useKeyCombo = (
         });
 
       if (modifiersPressed && targetKeys.includes(event.key)) {
+        event.preventDefault();
         setComboPressed(true);
       }
     };

--- a/desktopexporter/static/main.js
+++ b/desktopexporter/static/main.js
@@ -54769,7 +54769,6 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
     let [comboPressed, setComboPressed] = (0, import_react152.useState)(false);
     (0, import_react152.useEffect)(() => {
       const downHandler = (event) => {
-        event.preventDefault();
         let modifiersPressed = modifierKeys.map((modKey) => {
           switch (modKey) {
             case "Alt":
@@ -54787,6 +54786,7 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_liter
           return accumulator && currentValue;
         });
         if (modifiersPressed && targetKeys.includes(event.key)) {
+          event.preventDefault();
           setComboPressed(true);
         }
       };


### PR DESCRIPTION
All fixed! Closes #122 
![AllowDefaultKeyboardShortcuts](https://github.com/CtrlSpice/otel-desktop-viewer/assets/56372758/6e054767-e081-4fba-93e2-9758c7349e34)
