### PR TITLE
fix desktopexporter dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/CtrlSpice/otel-desktop-viewer
 go 1.19
 
 require (
-	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter v0.0.0-20230515221800-9c594f0581e6
+	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter v0.0.0-20231031015839-a93f76367789
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/collector v0.77.0
 	go.opentelemetry.io/collector/component v0.77.0

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ contrib.go.opencensus.io/exporter/prometheus v0.4.2/go.mod h1:dvEHbiKmgvbr5pjaF9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CtrlSpice/otel-desktop-viewer/desktopexporter v0.0.0-20230515221800-9c594f0581e6 h1:fW5KXgind+QDiUzs0hjCdqimn2rDtovCaozzPXAOGoU=
-github.com/CtrlSpice/otel-desktop-viewer/desktopexporter v0.0.0-20230515221800-9c594f0581e6/go.mod h1:ijxLfFsK8Z1GuhyK/phX4F0A6NfVWiL/tusWwIBA2qg=
+github.com/CtrlSpice/otel-desktop-viewer/desktopexporter v0.0.0-20231031015839-a93f76367789 h1:aCsbN/uAOxN1YLmfpSfFLmjyB7RVWBdLYNPsaKGpeQs=
+github.com/CtrlSpice/otel-desktop-viewer/desktopexporter v0.0.0-20231031015839-a93f76367789/go.mod h1:1VlnkAgYf3QMeQSPZz6cec1caEBov1oJ/CNmgHraUBA=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
This caused a bug because the dependency is no longer replaced with the latest in the repo as of https://github.com/CtrlSpice/otel-desktop-viewer/pull/136