### PR TITLE
Bringing testing back (part 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build-go:
 
 .PHONY: test-go
 test-go:
-	cd desktopcollector; go test ./...
+	cd desktopexporter; go test ./...
 	
 .PHONY: run-go
 run-go:

--- a/desktopexporter/internal/telemetry/sample.go
+++ b/desktopexporter/internal/telemetry/sample.go
@@ -144,7 +144,7 @@ func fillCurrencyLog(log plog.LogRecord) {
 // currencyservice resource data
 func fillCurrencyResource(resource pcommon.Resource) {
 	resource.SetDroppedAttributesCount(0)
-	resource.Attributes().PutStr("service.name", "sample-currencyservice")
+	resource.Attributes().PutStr("service.name", "sample.currencyservice")
 	resource.Attributes().PutStr("telemetry.sdk.language", "cpp")
 	resource.Attributes().PutStr("telemetry.sdk.name", "opentelemetry")
 	resource.Attributes().PutStr("telemetry.sdk.version", "1.5.0")
@@ -177,30 +177,31 @@ func fillFrontEndResource(resource pcommon.Resource) {
 
 // currencyservice scope data
 func fillCurrencyScope(scope pcommon.InstrumentationScope) {
-	scope.SetDroppedAttributesCount(0)
-	scope.SetName("sample-currencyservice")
+	scope.SetDroppedAttributesCount(2)
+	scope.SetName("sample.currencyservice")
 	scope.SetVersion("v1.2.3")
+	scope.Attributes().PutStr("owner.name", "Mila Ardath")
+	scope.Attributes().PutStr("owner.contact", "github.com/CtrlSpice")
 }
 
 // requests scope data
 func fillRequestsScope(scope pcommon.InstrumentationScope) {
-	scope.Attributes().PutStr("pumpkin", "pie")
-	scope.SetDroppedAttributesCount(42)
-	scope.SetName("sample-opentelemetry.instrumentation.requests")
+	scope.SetDroppedAttributesCount(0)
+	scope.SetName("sample.opentelemetry.instrumentation.requests")
 	scope.SetVersion("0.28b1")
 }
 
 // urllib3 scope data
 func fillUrlLib3Scope(scope pcommon.InstrumentationScope) {
 	scope.SetDroppedAttributesCount(0)
-	scope.SetName("sample-opentelemetry.instrumentation.urllib3")
+	scope.SetName("sample.opentelemetry.instrumentation.urllib3")
 	scope.SetVersion("0.28b1")
 }
 
 // http scope data
 func fillHttpScope(scope pcommon.InstrumentationScope) {
 	scope.SetDroppedAttributesCount(0)
-	scope.SetName("sample-@opentelemetry/instrumentation-http")
+	scope.SetName("sample.@opentelemetry/instrumentation-http")
 	scope.SetVersion("0.32.0")
 }
 
@@ -209,7 +210,7 @@ func fillCurrencySpan(span ptrace.Span) {
 	span.SetDroppedAttributesCount(0)
 	span.SetDroppedEventsCount(0)
 	span.SetDroppedLinksCount(0)
-	span.SetName("sample-CurrencyService/Convert")
+	span.SetName("sample.CurrencyService/Convert")
 	span.SetKind(ptrace.SpanKindServer)
 	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Date(2023, 02, 01, 20, 25, 36, 179472007, time.UTC)))
 	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Date(2023, 02, 01, 20, 25, 36, 179498174, time.UTC)))
@@ -224,12 +225,15 @@ func fillCurrencySpan(span ptrace.Span) {
 	conversionRequestEvent := span.Events().AppendEmpty()
 	conversionRequestEvent.SetDroppedAttributesCount(0)
 	conversionRequestEvent.SetTimestamp(pcommon.NewTimestampFromTime(time.Date(2023, 02, 01, 20, 25, 36, 179475132, time.UTC)))
-	conversionRequestEvent.SetName("sample-Processing currency conversion request")
+	conversionRequestEvent.SetName("Processing currency conversion request")
+	conversionRequestEvent.Attributes().PutStr("event.class", "sample")
 
 	conversionSuccessEvent := span.Events().AppendEmpty()
-	conversionSuccessEvent.SetDroppedAttributesCount(0)
+	conversionSuccessEvent.SetDroppedAttributesCount(1)
 	conversionSuccessEvent.SetTimestamp(pcommon.NewTimestampFromTime(time.Date(2023, 02, 01, 20, 25, 36, 179479924, time.UTC)))
-	conversionSuccessEvent.SetName("sample-Conversion successful. Response sent back.")
+	conversionSuccessEvent.SetName("Conversion successful. Response sent back.")
+	conversionSuccessEvent.Attributes().PutStr("event.class", "sample")
+	conversionSuccessEvent.Attributes().PutInt("event.priority", 1)
 }
 
 // HTTP POST span data (client, root)
@@ -237,7 +241,7 @@ func fillHttpPostSpan1(span ptrace.Span) {
 	span.SetDroppedAttributesCount(0)
 	span.SetDroppedEventsCount(0)
 	span.SetDroppedLinksCount(0)
-	span.SetName("sample-HTTP POST")
+	span.SetName("SAMPLE HTTP POST")
 	span.SetKind(ptrace.SpanKindClient)
 	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Date(2023, 02, 02, 18, 17, 54, 803511676, time.UTC)))
 	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Date(2023, 02, 02, 18, 17, 54, 817351051, time.UTC)))
@@ -254,7 +258,7 @@ func fillHttpPostSpan2(span ptrace.Span) {
 	span.SetDroppedAttributesCount(0)
 	span.SetDroppedEventsCount(0)
 	span.SetDroppedLinksCount(0)
-	span.SetName("sample-HTTP POST")
+	span.SetName("SAMPLE HTTP POST")
 	span.SetKind(ptrace.SpanKindClient)
 	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Date(2023, 02, 02, 18, 17, 54, 804417635, time.UTC)))
 	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Date(2023, 02, 02, 18, 17, 54, 816959885, time.UTC)))
@@ -265,6 +269,12 @@ func fillHttpPostSpan2(span ptrace.Span) {
 	span.Attributes().PutStr("http.method", "POST")
 	span.Attributes().PutInt("http.status_code", 200)
 	span.Attributes().PutStr("http.url", "http://frontend:8080/api/cart")
+
+	link := span.Links().AppendEmpty()
+	link.SetSpanID(encodeSpanID("2c1ae93af4d3f887"))
+	link.SetTraceID(encodeTraceID("7979cec4d1c04222fa9a3c7c97c0a99c"))
+	link.SetDroppedAttributesCount(5)
+	link.Attributes().PutStr("relationship", "in-cart currency conversion")
 }
 
 // HTTP POST span data (server, child)
@@ -272,7 +282,7 @@ func fillHttpPostSpan3(span ptrace.Span) {
 	span.SetDroppedAttributesCount(0)
 	span.SetDroppedEventsCount(0)
 	span.SetDroppedLinksCount(0)
-	span.SetName("sample-HTTP POST")
+	span.SetName("SAMPLE HTTP POST")
 	span.SetKind(ptrace.SpanKindServer)
 	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Date(2023, 02, 02, 18, 17, 54, 805039872, time.UTC)))
 	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Date(2023, 02, 02, 18, 17, 54, 816274688, time.UTC)))

--- a/desktopexporter/internal/telemetry/telemetry_test/spans_test.go
+++ b/desktopexporter/internal/telemetry/telemetry_test/spans_test.go
@@ -1,0 +1,168 @@
+package telemetry_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/telemetry"
+	"github.com/stretchr/testify/assert"
+)
+
+// Validate resource data
+type attributeTest struct {
+	key           string
+	expectedValue any
+}
+
+var resourceAttributes = []attributeTest{
+	{"service.name", "sample.currencyservice"},
+	{"telemetry.sdk.language", "cpp"},
+	{"telemetry.sdk.name", "opentelemetry"},
+	{"telemetry.sdk.version", "1.5.0"},
+}
+
+var scopeAttributes = []attributeTest{
+	{"owner.name", "Mila Ardath"},
+	{"owner.contact", "github.com/CtrlSpice"},
+}
+
+var eventAttributes = []attributeTest{
+	{"event.class", "sample"},
+	{"event.priority", int64(1)},
+}
+
+var spanAttributes = []attributeTest{
+	{"http.flavor", "1.1"},
+	{"http.host", "frontend:8080"},
+	{"http.method", "POST"},
+	{"http.request_length", int64(102)},
+	{"http.status_code", int64(200)},
+	{"http.status_text", "Ok"},
+	{"http.target", "/api/cart"},
+	{"http.url", "http://frontend:8080/api/cart"},
+	{"http.user_agent", "python-requests/2.27.1"},
+	{"net.host.ip", "::ffff:172.24.0.22"},
+	{"net.host.name", "frontend"},
+	{"net.host.port", int64(8080)},
+	{"net.peer.ip", "::ffff:172.24.0.23"},
+	{"net.peer.port", int64(46054)},
+	{"net.transport", "ip_tcp"},
+}
+
+var spans []telemetry.SpanData
+
+func init() {
+	spans = telemetry.NewSampleTelemetry().Spans
+}
+
+func TestExtractSpans(t *testing.T) {
+	// Validate number of spans extraced from the sample telemetry
+	assert.Len(t, spans, 4)
+}
+
+func TestSpanResource(t *testing.T) {
+	resource := spans[0].Resource
+
+	// Dropped resource attribute count
+	assert.Equal(t, uint32(0), resource.DroppedAttributesCount)
+
+	// Resource attributes
+	for _, attr := range resourceAttributes {
+		assert.Equal(t, attr.expectedValue, resource.Attributes[attr.key])
+	}
+}
+
+func TestSpanScope(t *testing.T) {
+	scope := spans[0].Scope
+
+	// Scope name
+	assert.Equal(t, "sample.currencyservice", scope.Name)
+
+	// Scope version
+	assert.Equal(t, "v1.2.3", scope.Version)
+
+	// Dropped scope attributes count
+	assert.Equal(t, uint32(2), scope.DroppedAttributesCount)
+
+	// Scope attributes
+	assert.Equal(t, uint32(2), scope.DroppedAttributesCount)
+	for _, attr := range scopeAttributes {
+		assert.Equal(t, attr.expectedValue, scope.Attributes[attr.key])
+	}
+}
+
+func TestSpanEvents(t *testing.T) {
+	event := spans[0].Events[1]
+
+	// Event name
+	assert.Equal(t, "Conversion successful. Response sent back.", event.Name)
+
+	// Event timestamp
+	assert.Equal(t, time.Date(2023, 02, 01, 20, 25, 36, 179479924, time.UTC), event.Timestamp)
+
+	// Dropped event attributes count
+	assert.Equal(t, uint32(1), event.DroppedAttributesCount)
+
+	// Event attributes
+	for _, attr := range eventAttributes {
+		assert.Equal(t, attr.expectedValue, event.Attributes[attr.key])
+	}
+}
+
+func TestSpanLinks(t *testing.T) {
+	link := spans[2].Links[0]
+
+	// Link span ID
+	assert.Equal(t, "2c1ae93af4d3f887", link.SpanID)
+
+	// Link trace ID
+	assert.Equal(t, "7979cec4d1c04222fa9a3c7c97c0a99c", link.TraceID)
+
+	// Dropped link attributes count
+	assert.Equal(t, uint32(5), link.DroppedAttributesCount)
+
+	// Link attributes
+	assert.Equal(t, "in-cart currency conversion", link.Attributes["relationship"])
+}
+
+func TestSpan(t *testing.T) {
+	span := spans[3]
+
+	// Dropped attributes count
+	assert.Equal(t, uint32(0), span.DroppedAttributesCount)
+
+	// Dropped events count
+	assert.Equal(t, uint32(0), span.DroppedEventsCount)
+
+	// Dropped links count
+	assert.Equal(t, uint32(0), span.DroppedLinksCount)
+
+	// Span name
+	assert.Equal(t, "SAMPLE HTTP POST", span.Name)
+
+	// Span kind
+	assert.Equal(t, "Server", span.Kind)
+
+	// Start time
+	assert.Equal(t, time.Date(2023, 02, 02, 18, 17, 54, 805039872, time.UTC), span.StartTime)
+
+	// End time
+	assert.Equal(t, time.Date(2023, 02, 02, 18, 17, 54, 816274688, time.UTC), span.EndTime)
+
+	// Span kind
+	assert.Equal(t, "Unset", span.StatusCode)
+
+	// Span ID
+	assert.Equal(t, "355dc9bea1ec64d8", span.SpanID)
+
+	// Parent span ID
+	assert.Equal(t, "a24ac1588d52a6fc", span.ParentSpanID)
+
+	// Trace ID
+	assert.Equal(t, "42957c7c2fca940a0d32a0cdd38c06a4", span.TraceID)
+
+	// Span attributes
+	for _, attr := range spanAttributes {
+		assert.Equal(t, attr.expectedValue, span.Attributes[attr.key])
+	}
+}


### PR DESCRIPTION
This test checks that we correctly convert otlp traces to the structs we use internally and send to the front end. It uses the telemetry data generated by `telemetry.sample.go` as test data. 

TODO: I have not included logs and metrics data in testing yet, as their definitions aren't complete. I'll update this test when I work on their respective definitions.

Note: I don't feel like logging into the capybara generating machine, so have here's our queen Moo Deng
![moo](https://github.com/user-attachments/assets/d720b43e-30de-4b1e-9200-c2262c95dba2)
