### PR TITLE
Fix desktop endpoint set by browser flag

### DIFF
--- a/desktopcollector/main.go
+++ b/desktopcollector/main.go
@@ -64,6 +64,7 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 				`yaml:receivers::otlp::protocols::http::endpoint: ` + hostFlag + `:` + strconv.Itoa(httpPortFlag),
 				`yaml:receivers::otlp::protocols::grpc::endpoint: ` + hostFlag + `:` + strconv.Itoa(grpcPortFlag),
 				`yaml:exporters::desktop:`,
+				`yaml:exporters::desktop::endpoint: ` + hostFlag + `:` + strconv.Itoa(browserPortFlag),
 				`yaml:service::pipelines::traces::receivers: [otlp]`,
 				`yaml:service::pipelines::traces::exporters: [desktop]`,
 				`yaml:service::pipelines::metrics::receivers: [otlp]`,
@@ -86,3 +87,4 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 	rootCmd.Flags().StringVar(&hostFlag, "host", "localhost", "The host where we expose our all endpoints (OTLP receivers and browser)")
 	return rootCmd
 }
+


### PR DESCRIPTION
This pull request fixes an issue where the desktop endpoint was not correctly set by the browser flag. By passing --browser <port> to the configuration, the application now listens on the specified request port, ensuring proper handling of desktop requests.

Close #154