### PR TITLE
DEV and CI Environment Variable Cleanup (Part Deux: the Great Deflagging)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,7 @@
 otel-desktop-viewer
 desktopexporter/internal/app/node_modules
 .vscode/
-duck.*
+*.db
+*.wal
 help
-# dist/
-# distribution/linux/*
-# distribution/darwin/*
 go.work*

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ test-go:
 run-go:
 	SERVE_FROM_FS=true cd desktopcollector; go run ./...
 
+.PHONY: run-db-go
+run-db-go:
+	SERVE_FROM_FS=true cd desktopcollector; go run ./... --db ../duck.db
+
 .PHONY: build-js
 build-js:
 	cd desktopexporter/internal/app; npx esbuild --bundle main.tsx main.css --outdir=../server/static

--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,15 @@ build-go:
 
 .PHONY: test-go
 test-go:
-	cd desktopexporter; go test ./...
+	cd desktopexporter; DEV=false go test ./...
 	
 .PHONY: run-go
 run-go:
-	cd desktopcollector; go run ./... --dev
+	cd desktopcollector; DEV=true STATIC_DIR="/desktopexporter/internal/server/static/" go run ./...
 
 .PHONY: run-db-go
 run-db-go:
-	cd desktopcollector; go run ./... --dev --db ../duck.db
+	cd desktopcollector; DEV=true STATIC_DIR="/desktopexporter/internal/server/static/" go run ./... --db ../duck.db
 
 .PHONY: build-js
 build-js:

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ test-go:
 	
 .PHONY: run-go
 run-go:
-	SERVE_FROM_FS=true cd desktopcollector; go run ./...
+	cd desktopcollector; go run ./... --dev
 
 .PHONY: run-db-go
 run-db-go:
-	SERVE_FROM_FS=true cd desktopcollector; go run ./... --db ../duck.db
+	cd desktopcollector; go run ./... --dev --db ../duck.db
 
 .PHONY: build-js
 build-js:

--- a/desktopcollector/main.go
+++ b/desktopcollector/main.go
@@ -54,7 +54,6 @@ func runInteractive(params otelcol.CollectorSettings) error {
 func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 	var httpPortFlag, grpcPortFlag, browserPortFlag int
 	var hostFlag, dbFlag string
-	var devFlag bool
 
 	rootCmd := &cobra.Command{
 		Use:          set.BuildInfo.Command,
@@ -67,7 +66,6 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 				`yaml:exporters::desktop:`,
 				`yaml:exporters::desktop::endpoint: ` + hostFlag + `:` + strconv.Itoa(browserPortFlag),
 				`yaml:exporters::desktop::db: ` + dbFlag,
-				`yaml:exporters::desktop::dev: ` + strconv.FormatBool(devFlag),
 				`yaml:service::pipelines::traces::receivers: [otlp]`,
 				`yaml:service::pipelines::traces::exporters: [desktop]`,
 				`yaml:service::pipelines::metrics::receivers: [otlp]`,
@@ -89,7 +87,6 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 	rootCmd.Flags().IntVar(&browserPortFlag, "browser", 8000, "The port number where we expose our data")
 	rootCmd.Flags().StringVar(&hostFlag, "host", "localhost", "The host where we expose our endpoints (OTLP receivers and browser)")
 	rootCmd.Flags().StringVar(&dbFlag, "db", "", "The path of our database file. Omitting this flag opens DuckDB in in-memory mode, with no data persisted to disk.")
-	rootCmd.Flags().BoolVar(&devFlag, "dev", false, "Avoids recompiling the back-end during front-end development by serving the latter from the filesystem instead of embeddeding it")
 	return rootCmd
 }
 

--- a/desktopcollector/main.go
+++ b/desktopcollector/main.go
@@ -54,6 +54,7 @@ func runInteractive(params otelcol.CollectorSettings) error {
 func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 	var httpPortFlag, grpcPortFlag, browserPortFlag int
 	var hostFlag, dbFlag string
+	var devFlag bool
 
 	rootCmd := &cobra.Command{
 		Use:          set.BuildInfo.Command,
@@ -66,6 +67,7 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 				`yaml:exporters::desktop:`,
 				`yaml:exporters::desktop::endpoint: ` + hostFlag + `:` + strconv.Itoa(browserPortFlag),
 				`yaml:exporters::desktop::db: ` + dbFlag,
+				`yaml:exporters::desktop::dev: ` + strconv.FormatBool(devFlag),
 				`yaml:service::pipelines::traces::receivers: [otlp]`,
 				`yaml:service::pipelines::traces::exporters: [desktop]`,
 				`yaml:service::pipelines::metrics::receivers: [otlp]`,
@@ -85,8 +87,9 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 	rootCmd.Flags().IntVar(&httpPortFlag, "http", 4318, "The port number on which we listen for OTLP http payloads")
 	rootCmd.Flags().IntVar(&grpcPortFlag, "grpc", 4317, "The port number on which we listen for OTLP grpc payloads")
 	rootCmd.Flags().IntVar(&browserPortFlag, "browser", 8000, "The port number where we expose our data")
-	rootCmd.Flags().StringVar(&hostFlag, "host", "localhost", "The host where we expose our all endpoints (OTLP receivers and browser)")
-	rootCmd.Flags().StringVar(&dbFlag, "db", "", "The path of your database file. Omitting this flag opens DuckDB in in-memory mode, with no data persisted to disk.")
+	rootCmd.Flags().StringVar(&hostFlag, "host", "localhost", "The host where we expose our endpoints (OTLP receivers and browser)")
+	rootCmd.Flags().StringVar(&dbFlag, "db", "", "The path of our database file. Omitting this flag opens DuckDB in in-memory mode, with no data persisted to disk.")
+	rootCmd.Flags().BoolVar(&devFlag, "dev", false, "Avoids recompiling the back-end during front-end development by serving the latter from the filesystem instead of embeddeding it")
 	return rootCmd
 }
 

--- a/desktopcollector/main.go
+++ b/desktopcollector/main.go
@@ -53,7 +53,7 @@ func runInteractive(params otelcol.CollectorSettings) error {
 
 func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 	var httpPortFlag, grpcPortFlag, browserPortFlag int
-	var hostFlag string
+	var hostFlag, dbFlag string
 
 	rootCmd := &cobra.Command{
 		Use:          set.BuildInfo.Command,
@@ -65,6 +65,7 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 				`yaml:receivers::otlp::protocols::grpc::endpoint: ` + hostFlag + `:` + strconv.Itoa(grpcPortFlag),
 				`yaml:exporters::desktop:`,
 				`yaml:exporters::desktop::endpoint: ` + hostFlag + `:` + strconv.Itoa(browserPortFlag),
+				`yaml:exporters::desktop::db: ` + dbFlag,
 				`yaml:service::pipelines::traces::receivers: [otlp]`,
 				`yaml:service::pipelines::traces::exporters: [desktop]`,
 				`yaml:service::pipelines::metrics::receivers: [otlp]`,
@@ -85,6 +86,7 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 	rootCmd.Flags().IntVar(&grpcPortFlag, "grpc", 4317, "The port number on which we listen for OTLP grpc payloads")
 	rootCmd.Flags().IntVar(&browserPortFlag, "browser", 8000, "The port number where we expose our data")
 	rootCmd.Flags().StringVar(&hostFlag, "host", "localhost", "The host where we expose our all endpoints (OTLP receivers and browser)")
+	rootCmd.Flags().StringVar(&dbFlag, "db", "", "The path of your database file. Omitting this flag opens DuckDB in in-memory mode, with no data persisted to disk.")
 	return rootCmd
 }
 

--- a/desktopexporter/config.go
+++ b/desktopexporter/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	// DbPath defines the path of your database file. Setting an enpty string opens DuckDB in in-memory mode
 	DbPath string `mapstructure:"db"`
 
-	// IsDev launches the app in dev mode, which Avoids recompiling the back-end during
+	// IsDev launches the app in dev mode, which avoids recompiling the back-end during
 	// front-end development by serving the latter from the filesystem instead of embeddeding it.
 	IsDev bool `mapstructure:"dev"`
 }

--- a/desktopexporter/config.go
+++ b/desktopexporter/config.go
@@ -9,8 +9,12 @@ type Config struct {
 	// Endpoint defines the host and port where we serve our frontend app
 	Endpoint string `mapstructure:"endpoint"`
 
-	// Endpoint defines the path of your database file. Setting an enpty string opens DuckDB in in-memory mode
+	// DbPath defines the path of your database file. Setting an enpty string opens DuckDB in in-memory mode
 	DbPath string `mapstructure:"db"`
+
+	// IsDev launches the app in dev mode, which Avoids recompiling the back-end during
+	// front-end development by serving the latter from the filesystem instead of embeddeding it.
+	IsDev bool `mapstructure:"dev"`
 }
 
 // Validate checks if the exporter configuration is valid

--- a/desktopexporter/config.go
+++ b/desktopexporter/config.go
@@ -11,10 +11,6 @@ type Config struct {
 
 	// DbPath defines the path of your database file. Setting an enpty string opens DuckDB in in-memory mode
 	DbPath string `mapstructure:"db"`
-
-	// IsDev launches the app in dev mode, which avoids recompiling the back-end during
-	// front-end development by serving the latter from the filesystem instead of embeddeding it.
-	IsDev bool `mapstructure:"dev"`
 }
 
 // Validate checks if the exporter configuration is valid

--- a/desktopexporter/config.go
+++ b/desktopexporter/config.go
@@ -8,6 +8,9 @@ import (
 type Config struct {
 	// Endpoint defines the host and port where we serve our frontend app
 	Endpoint string `mapstructure:"endpoint"`
+
+	// Endpoint defines the path of your database file. Setting an enpty string opens DuckDB in in-memory mode
+	DbPath string `mapstructure:"db"`
 }
 
 // Validate checks if the exporter configuration is valid

--- a/desktopexporter/exporter.go
+++ b/desktopexporter/exporter.go
@@ -20,7 +20,7 @@ type desktopExporter struct {
 }
 
 func newDesktopExporter(cfg *Config) *desktopExporter {
-	server := server.NewServer(cfg.Endpoint, cfg.DbPath)
+	server := server.NewServer(cfg.Endpoint, cfg.DbPath, cfg.IsDev)
 	return &desktopExporter{
 		server: server,
 	}

--- a/desktopexporter/exporter.go
+++ b/desktopexporter/exporter.go
@@ -15,14 +15,21 @@ import (
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/telemetry"
 )
 
+type EnvConfig struct {
+	IsDev     bool
+	IsCI      bool
+	StaticDir string
+}
+
 type desktopExporter struct {
 	server *server.Server
 }
 
 func newDesktopExporter(cfg *Config) *desktopExporter {
-	server := server.NewServer(cfg.Endpoint, cfg.DbPath, cfg.IsDev)
+	s := server.NewServer(cfg.Endpoint, cfg.DbPath)
+
 	return &desktopExporter{
-		server: server,
+		server: s,
 	}
 }
 
@@ -54,7 +61,7 @@ func (exporter *desktopExporter) Start(ctx context.Context, host component.Host)
 		err := exporter.server.Start()
 
 		if errors.Is(err, http.ErrServerClosed) {
-			fmt.Printf("server closed\n")
+			fmt.Println("server closed")
 		} else if err != nil {
 			fmt.Printf("error listening for server: %s\n", err)
 		}

--- a/desktopexporter/exporter.go
+++ b/desktopexporter/exporter.go
@@ -20,7 +20,7 @@ type desktopExporter struct {
 }
 
 func newDesktopExporter(cfg *Config) *desktopExporter {
-	server := server.NewServer(cfg.Endpoint)
+	server := server.NewServer(cfg.Endpoint, cfg.DbPath)
 	return &desktopExporter{
 		server: server,
 	}

--- a/desktopexporter/internal/server/server.go
+++ b/desktopexporter/internal/server/server.go
@@ -25,12 +25,12 @@ type Server struct {
 	Store  *store.Store
 }
 
-func NewServer(endpoint string) *Server {
+func NewServer(endpoint string, dbPath string) *Server {
 	s := Server{
 		server: http.Server{
 			Addr: endpoint,
 		},
-		Store: store.NewStore(context.Background()),
+		Store: store.NewStore(context.Background(), dbPath),
 	}
 
 	serveFromFS, err := strconv.ParseBool(os.Getenv("SERVE_FROM_FS"))

--- a/desktopexporter/internal/server/server_test.go
+++ b/desktopexporter/internal/server/server_test.go
@@ -16,7 +16,9 @@ import (
 )
 
 func setupEmpty() (*httptest.Server, func()) {
-	server := NewServer("localhost:8000", "", false)
+	GetEnvConfig()
+	server := NewServer("localhost:8000", "")
+
 	testServer := httptest.NewServer(server.Handler())
 
 	return testServer, func() {
@@ -26,7 +28,8 @@ func setupEmpty() (*httptest.Server, func()) {
 }
 
 func setupWithTrace(t *testing.T) (*httptest.Server, func(*testing.T)) {
-	server := NewServer("localhost:8000", "", false)
+	server := NewServer("localhost:8000", "")
+
 	testSpanData := telemetry.SpanData{
 		TraceID:      "1234567890",
 		TraceState:   "",

--- a/desktopexporter/internal/server/server_test.go
+++ b/desktopexporter/internal/server/server_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 func setupEmpty() (*httptest.Server, func()) {
-	server := NewServer("localhost:8000", "")
-	testServer := httptest.NewServer(server.Handler(false))
+	server := NewServer("localhost:8000", "", false)
+	testServer := httptest.NewServer(server.Handler())
 
 	return testServer, func() {
 		testServer.Close()
@@ -26,7 +26,7 @@ func setupEmpty() (*httptest.Server, func()) {
 }
 
 func setupWithTrace(t *testing.T) (*httptest.Server, func(*testing.T)) {
-	server := NewServer("localhost:8000", "")
+	server := NewServer("localhost:8000", "", false)
 	testSpanData := telemetry.SpanData{
 		TraceID:      "1234567890",
 		TraceState:   "",
@@ -56,7 +56,7 @@ func setupWithTrace(t *testing.T) (*httptest.Server, func(*testing.T)) {
 	err := server.Store.AddSpans(context.Background(), []telemetry.SpanData{testSpanData})
 	assert.Nilf(t, err, "could not create  test span: %v", err)
 
-	testServer := httptest.NewServer(server.Handler(false))
+	testServer := httptest.NewServer(server.Handler())
 
 	return testServer, func(t *testing.T) {
 		testServer.Close()

--- a/desktopexporter/internal/server/server_test.go
+++ b/desktopexporter/internal/server/server_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func setupEmpty() (*httptest.Server, func()) {
-	server := NewServer("localhost:8000")
+	server := NewServer("localhost:8000", "")
 	testServer := httptest.NewServer(server.Handler(false))
 
 	return testServer, func() {
@@ -26,7 +26,7 @@ func setupEmpty() (*httptest.Server, func()) {
 }
 
 func setupWithTrace(t *testing.T) (*httptest.Server, func(*testing.T)) {
-	server := NewServer("localhost:8000")
+	server := NewServer("localhost:8000", "")
 	testSpanData := telemetry.SpanData{
 		TraceID:      "1234567890",
 		TraceState:   "",
@@ -63,6 +63,7 @@ func setupWithTrace(t *testing.T) (*httptest.Server, func(*testing.T)) {
 		server.Store.Close()
 	}
 }
+
 func TestTracesHandler(t *testing.T) {
 	t.Run("Traces Handler (Empty)", func(t *testing.T) {
 		testServer, teardown := setupEmpty()

--- a/desktopexporter/internal/store/store.go
+++ b/desktopexporter/internal/store/store.go
@@ -21,8 +21,9 @@ type Store struct {
 	conn driver.Conn
 }
 
-func NewStore(ctx context.Context) *Store {
-	connector, err := duckdb.NewConnector("", nil)
+func NewStore(ctx context.Context, dbPath string) *Store {
+	connector, err := duckdb.NewConnector(dbPath, nil)
+
 	if err != nil {
 		log.Fatalf("could not initialize new connector: %s", err.Error())
 	}

--- a/desktopexporter/internal/store/store_test.go
+++ b/desktopexporter/internal/store/store_test.go
@@ -1,0 +1,49 @@
+package store
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/telemetry"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPersistence(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(ctx, "./quack.db")
+
+	// Check that db file is created properly
+	_, err := os.Stat("./quack.db")
+	assert.NoErrorf(t, err, "database file does not exist: %v", err)
+
+	// Add sample spans to the store
+	err = store.AddSpans(ctx, telemetry.NewSampleTelemetry().Spans)
+	assert.NoErrorf(t, err, "could not add spans to the database: %v", err)
+
+	// Get trace summaries and check length
+	summaries, err := store.GetTraceSummaries(ctx)
+	if assert.NoErrorf(t, err, "could not get trace summaries: %v", err) {
+		assert.Len(t, *summaries, 2)
+	}
+
+	// Close store
+	err = store.Close()
+	assert.NoErrorf(t, err, "could not close database: %v", err)
+
+	// Reopen store from the database file
+	store = NewStore(ctx, "./quack.db")
+
+	// Get a trace by ID and check ID of root span
+	trace, err := store.GetTrace(ctx, "42957c7c2fca940a0d32a0cdd38c06a4")
+	if assert.NoErrorf(t, err, "could not get trace: %v", err) {
+		assert.Equal(t, "37fd1349bf83d330", trace.Spans[0].SpanID)
+	}
+
+	// Clean up
+	err = store.Close()
+	assert.NoErrorf(t, err, "could not close database: %v", err)
+
+	err = os.Remove("./quack.db")
+	assert.NoError(t, err, "could not remove database file: %v", err)
+}


### PR DESCRIPTION
- Setting the `DEV` environment variable to `true` launches the app in dev mode, which avoids recompiling the back-end during front-end development by serving the latter from the filesystem instead of embedded assets. This replaces `SERVE_FROM_FS`, in case I want to cram in more useful dev things. 
-Setting the `CI` environment variable to true starts the back-end without launching the browser, which is useful for running tests in CI.
- These variables are checked when we are starting the `desktopexporter` and passed to the server via the `EnvConfig` struct.
- Server tests and makefile have been updated to reflect the new flow


![Illustration of a non-binary individual with short brown hair and glasses. They are asleep at their home office desk. A laptop is open next to them. Next to the laptop, a capybara is also asleep, curled up comfortably on the desk.](https://github.com/user-attachments/assets/0f934446-19f8-4f3e-8bd2-353ae3d2a9c7)
