### PR TITLE
Fix: serve front end from filesystem during development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ test-go:
 	
 .PHONY: run-go
 run-go:
-	cd desktopcollector; SERVE_FROM_FS=true STATIC_DIR=$(abspath ./desktopexporter/internal/server/static/) go run ./...
+	cd desktopcollector; STATIC_ASSETS_DIR=$(abspath ./desktopexporter/internal/server/static/) go run ./...
 
 .PHONY: run-db-go
 run-db-go:
-	cd desktopcollector; SERVE_FROM_FS=true STATIC_DIR=$(abspath ./desktopexporter/internal/server/static/) go run ./... --db ../duck.db
+	cd desktopcollector; STATIC_ASSETS_DIR=$(abspath ./desktopexporter/internal/server/static/) go run ./... --db ../duck.db
 
 .PHONY: build-js
 build-js:

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ test-go:
 	
 .PHONY: run-go
 run-go:
-	SERVE_FROM_FS=true cd desktopcollector; go run ./...
+	cd desktopcollector; SERVE_FROM_FS=true STATIC_DIR=$(abspath ./desktopexporter/internal/server/static/) go run ./...
 
 .PHONY: run-db-go
 run-db-go:
-	SERVE_FROM_FS=true cd desktopcollector; go run ./... --db ../duck.db
+	cd desktopcollector; SERVE_FROM_FS=true STATIC_DIR=$(abspath ./desktopexporter/internal/server/static/) go run ./... --db ../duck.db
 
 .PHONY: build-js
 build-js:

--- a/desktopcollector/main.go
+++ b/desktopcollector/main.go
@@ -93,7 +93,7 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 	if openBrowserFlag {
 		go func() {
 			// Wait a bit for the server to come up to avoid a 404 as a first experience
-			time.Sleep(250 * time.Millisecond)
+			time.Sleep(300 * time.Millisecond)
 			browser.OpenURL("http://" + hostFlag + `:` + strconv.Itoa(browserPortFlag) + "/")
 		}()
 	}

--- a/desktopexporter/go.mod
+++ b/desktopexporter/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	go.opentelemetry.io/collector v0.107.0 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.13.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.107.0 // indirect

--- a/desktopexporter/go.sum
+++ b/desktopexporter/go.sum
@@ -63,8 +63,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
-github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
-github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.19.1 h1:wZWJDwK+NameRJuPGDhlnFgx8e8HN3XHQeLaYJFJBOE=
@@ -160,7 +158,6 @@ golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
 golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/desktopexporter/internal/server/server_test.go
+++ b/desktopexporter/internal/server/server_test.go
@@ -17,7 +17,7 @@ import (
 
 func setupEmpty() (*httptest.Server, func()) {
 	server := NewServer("localhost:8000", "")
-	testServer := httptest.NewServer(server.Handler(false))
+	testServer := httptest.NewServer(server.Handler())
 
 	return testServer, func() {
 		testServer.Close()
@@ -56,7 +56,7 @@ func setupWithTrace(t *testing.T) (*httptest.Server, func(*testing.T)) {
 	err := server.Store.AddSpans(context.Background(), []telemetry.SpanData{testSpanData})
 	assert.Nilf(t, err, "could not create  test span: %v", err)
 
-	testServer := httptest.NewServer(server.Handler(false))
+	testServer := httptest.NewServer(server.Handler())
 
 	return testServer, func(t *testing.T) {
 		testServer.Close()


### PR DESCRIPTION
- `SERVE_FROM_FS` and `STATIC_DIR` get passed in as envars, for real this time
- The server environment `env` is read when we instantiate the server
- `Server.Handler` and `Server.IndexHandler` now use the server environment instead of reading envars or getting the data as an argument. I find it cleaner this way but I'm not overly attached to it.
- I added some time to the browser opening delay, and fixed the bug I introduced in the last PR. 