### PR TITLE
Allow running in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
-FROM golang:1.24
+FROM golang:1.24 AS golang
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update
 
 RUN go install github.com/CtrlSpice/otel-desktop-viewer@latest
 
+FROM ubuntu:24.04
+
+COPY --from=golang /go/bin/otel-desktop-viewer /root/otel-desktop-viewer
+
 EXPOSE 8000
 EXPOSE 4317
 EXPOSE 4318
 
-CMD [ "otel-desktop-viewer", "--host", "0.0.0.0", "--grpc", "4317", "--http", "4318",  "--browser", "8000" ]
+CMD [ "/root/otel-desktop-viewer", "--host", "0.0.0.0", "--grpc", "4317", "--http", "4318",  "--browser", "8000" ]
 # docker --debug build --tag davetron5000/otel-desktop-viewer:go-1.24 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.24
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get -y update
+
+RUN go install github.com/CtrlSpice/otel-desktop-viewer@latest
+
+EXPOSE 8000
+EXPOSE 4317
+EXPOSE 4318
+
+CMD [ "otel-desktop-viewer", "--host", "0.0.0.0", "--grpc", "4317", "--http", "4318",  "--browser", "8000" ]
+# docker --debug build --tag davetron5000/otel-desktop-viewer:go-1.24 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,3 @@ EXPOSE 4317
 EXPOSE 4318
 
 CMD [ "/root/otel-desktop-viewer", "--host", "0.0.0.0", "--grpc", "4317", "--http", "4318",  "--browser", "8000" ]
-# docker --debug build --tag davetron5000/otel-desktop-viewer:go-1.24 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM golang:1.24 AS golang
-
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get -y update
+FROM golang:1.24-alpine AS golang
 
 RUN go install github.com/CtrlSpice/otel-desktop-viewer@latest
 
-FROM ubuntu:24.04
+FROM alpine:3
 
 COPY --from=golang /go/bin/otel-desktop-viewer /root/otel-desktop-viewer
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,60 @@ Running the CLI will open a browser tab to `localhost:8000` to load the UI,
 and spin up a server listening on `localhost:4318` for OTLP http payloads and
 `localhost:4317` for OTLP grpc payloads.
 
+#### via Docker
+
+The included `Dockerfile` will build a relatively slim image you can use to run otel-desktop-viewer without
+using Homebrew or setting up Go.
+
+To build the image
+
+* [Install Docker](https://docs.docker.com/get-started/)
+  - For Windows or Mac, you likely want Docker Desktop
+  - For Linux, Docker Engine is fine, but do read the [post-install instructions](https://docs.docker.com/engine/install/linux-postinstall/) so that you can run Docker as your user
+* Build the image. You'll need a tag so you can reference it.
+
+  ```
+  > docker build --tag otel-desktop-viewer:alpine-3
+  ```
+
+To use the image, you have a few options:
+
+* **Run it so apps on your computer can access it**:
+
+  ```
+  docker run -p 8000:8000 -p 4317:4317 -p 4318:4318 davetron5000/otel-desktop-viewer:alpine-3
+  ```
+
+  The `-p` arguments map otel-desktop-viewers ports to the same ports on localhost.  When you do this, you would
+  access the web UI via `localhost:8000` and use `localhost:4318` or `localhost:4319` to export to.
+* **Run it in docker compose as part of a devcontainer-based environment**. Here, the app you are working on
+that is sending telemetry is running as a Docker container.  You can use Docker compose to allow that app to
+export to your otel-desktop-viewer, but still access its web UI on your computer. A very simplified
+`docker-compose.yml`:
+
+  ```yaml
+  services:
+    app:
+      image: your-apps-image-tag
+      # probably more config based on the app
+    otel-desktop-viewer:
+      image: otel-desktop-viewer:alpine-3 # or whatever you used for docker build
+      ports:
+        - "8000:8000"
+  ```
+
+  With this setup:
+  - `localhost:8000` is the web UI
+  - `otel-desktop-viewer:4318` and `otel-desktop-viewer:4319` are where your app should export to. The hostname
+  is based on the key in the docker compose YAML file.
+  - Your computer cannot access ports 4318 or 4319 (but, it shouldn't need to)
+
+To update your local copy when this repo changes:
+
+* Update from GitHub
+* Rebuild the image based on instructions above. It will overwrite the previous image
+* Stop and restart all containers using the image
+
 ## Command Line Options
 ```bash
 Flags:


### PR DESCRIPTION
I run my dev environment using Docker, and don't want to/can't easily install stuff on my computer with Homebrew.

The `Dockerfile` in this PR worked for me, but I want to contribute whatever makes sense to this project if others want to do the same.

I'm not sure the best way, but I can think of a few scenarios:

1. **Publish a Docker image others can use.** This would require a `Dockerfile` similar to what is in this PR as well as necessary
   scripts and credentials to build and push the image.  It would also require this repo's owners to maintain that image.
2. **Just provide instructions.** This would involve adding something to the `README` I guess?

I'm happy to do more work along either option, so if one is prefered over the other, I will have more questions on how to properly
proceed.
