### PR TITLE
Fix ci release step

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,7 +4,10 @@
 
 name: Build and Test
 
-on: push
+on: 
+  push:
+    branches-ignore:
+      - fix-ci-release
 
 jobs:
   build:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,8 +6,6 @@ name: Build and Test
 
 on: 
   push:
-    branches-ignore:
-      - fix-ci-release
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
           # cause cross-compilation issues, especially for CGO-enabled builds.
           args: release --clean --split ${{ github.event_name == 'workflow_dispatch' && '--snapshot' || '' }} --id ${{ matrix.build_id }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           CGO_ENABLED: 1
 
@@ -163,5 +163,5 @@ jobs:
           version: v2.9.0
           args: continue --merge
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - fix-ci-release
   workflow_dispatch:
     inputs:
       test_mode:
@@ -166,7 +168,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: v2.9.0
-          args: continue --merge
+          args: continue --merge ${{ github.ref_name == 'fix-ci-release' && '--snapshot' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,16 +63,12 @@ jobs:
           go-version: '1.24'
 
       # Cache Go dependencies to speed up builds.
-      # - ~/go/pkg/mod: Caches downloaded Go modules
-      # - **/go.sum: Used to determine if dependencies have changed
-      # - key: Unique key based on OS and go.sum hash
-      # - restore-keys: Fallback to most recent cache if no exact match
+      # Note: Only cache directories in 'path', use go.sum files only in 'key' with hashFiles()
       - name: Cache Go dependencies
         uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod
-            **/go.sum
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
@@ -172,8 +168,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: v2.9.0
-          args: continue --merge ${{ github.ref_name == 'fix-ci-release' && '--snapshot' || '' }}
+          args: continue --merge
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,10 @@ jobs:
         with:
           path: |
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('desktopexporter/go.sum', 'desktopcollector/go.sum') }}
+            ~/.cache/go-build
+            /home/runner/go/pkg/mod
+            /home/runner/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,12 @@ jobs:
         with:
           go-version: '1.24'
 
+      - name: Initialize Go workspace
+        run: |
+          go work sync
+          cd desktopcollector && go mod download
+          cd ../desktopexporter && go mod download
+
       # Cache Go dependencies to speed up builds.
       # Note: Only cache directories in 'path', use go.sum files only in 'key' with hashFiles()
       - name: Cache Go dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-    branches:
-      - fix-ci-release
   workflow_dispatch:
     inputs:
       test_mode:
@@ -24,11 +22,6 @@ jobs:
   prepare:
     strategy:
       matrix:
-        # GoReleaser automatically matches builds to runners based on goos/goarch:
-        # macos-latest -> macos (both amd64 and arm64)
-        # ubuntu-latest -> linux_x86_64
-        # ubuntu-24.04-arm -> linux_arm64
-        # windows-latest -> windows_amd64
         include:
           - os: macos-latest
             build_id: macos_amd64
@@ -69,7 +62,7 @@ jobs:
         with:
           path: |
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ hashFiles('desktopexporter/go.sum', 'desktopcollector/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,25 +54,15 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24'
+          cache-dependency-path: |
+            desktopexporter/go.sum
+            desktopcollector/go.sum
 
       - name: Initialize Go workspace
         run: |
           go work sync
           cd desktopcollector && go mod download
           cd ../desktopexporter && go mod download
-
-      # Cache Go dependencies to speed up builds.
-      - name: Cache Go dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-          enableCrossOsArchive: true
-          mode: recursive
 
       - name: Cache build artifacts
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,13 @@ jobs:
         # windows-latest -> windows_amd64
         include:
           - os: macos-latest
-            build_id: macos
+            build_id: macos_amd64
             goos: darwin
-            goarch: [amd64, arm64]
+            goarch: amd64
+          - os: macos-latest
+            build_id: macos_arm64
+            goos: darwin
+            goarch: arm64
           - os: ubuntu-latest
             build_id: linux_x86_64
             goos: linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,18 +62,17 @@ jobs:
           cd ../desktopexporter && go mod download
 
       # Cache Go dependencies to speed up builds.
-      # Note: Only cache directories in 'path', use go.sum files only in 'key' with hashFiles()
       - name: Cache Go dependencies
         uses: actions/cache@v4
         with:
           path: |
-            ~/go/pkg/mod
             ~/.cache/go-build
-            /home/runner/go/pkg/mod
-            /home/runner/.cache/go-build
+            ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+          enableCrossOsArchive: true
+          mode: recursive
 
       - name: Cache build artifacts
         uses: actions/cache@v4

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -81,6 +81,7 @@ builds:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{ .CommitDate }}
 
 archives:
+  # Main archive with all platforms
   - id: otel-desktop-viewer-archive
     ids:
       - macos_amd64
@@ -90,10 +91,9 @@ archives:
       - windows_amd64
     formats: 
       - tar.gz
-      - zip
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ['zip']
     name_template: >-
       {{ .ProjectName }}_
       {{- if eq .Os "darwin" }}MacOS
@@ -111,7 +111,7 @@ archives:
     formats: 
       - tar.gz
     name_template: >-
-      {{ .ProjectName }}_
+      {{ .ProjectName }}_homebrew_
       {{- if eq .Os "darwin" }}MacOS
       {{- else }}{{ title .Os }}{{ end }}_
       {{- if eq .Arch "amd64" }}x86_64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,7 @@ before:
     - cmd: sh -c "cd desktopcollector && go mod tidy && cd ../desktopexporter && go mod tidy"
 
 builds:
-  - id: macos
+  - id: macos_amd64
     main: ./desktopcollector/
     # Using simple binary name as GoReleaser automatically creates unique directories
     # with build ID and target info (e.g. macos_darwin_amd64, macos_darwin_arm64)
@@ -18,7 +18,6 @@ builds:
       - darwin
     goarch:
       - amd64
-      - arm64
     # Sets binary timestamp to commit time for reproducible builds
     mod_timestamp: "{{ .CommitTimestamp }}"
     # Removes file paths from binary for security and portability
@@ -26,6 +25,19 @@ builds:
       - -trimpath
     # -s -w: strips debug info
     # -X: injects version, commit, and date into binary
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{ .CommitDate }}
+
+  - id: macos_arm64
+    main: ./desktopcollector/
+    binary: otel-desktop-viewer
+    goos: 
+      - darwin
+    goarch:
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{ .CommitDate }}
 
@@ -70,6 +82,12 @@ builds:
 
 archives:
   - id: otel-desktop-viewer-archive
+    builds:
+      - macos_amd64
+      - macos_arm64
+      - linux_x86_64
+      - linux_arm64
+      - windows_amd64
     formats: 
       - tar.gz
       - zip
@@ -102,6 +120,8 @@ release:
 
 brews:
   - name: otel-desktop-viewer
+    ids:
+      - otel-desktop-viewer-archive
     # GitHub repository where the formula will be published
     repository:
       owner: CtrlSpice

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -116,7 +116,8 @@ release:
   name_template: "v{{ .Version }}"
   footer: >-
     ---
-    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).
+    Released by [GoReleaser](https://github.com/goreleaser/goreleas
+    er).
 
 brews:
   - name: otel-desktop-viewer

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -82,7 +82,7 @@ builds:
 
 archives:
   - id: otel-desktop-viewer-archive
-    builds:
+    ids:
       - macos_amd64
       - macos_arm64
       - linux_x86_64
@@ -91,10 +91,9 @@ archives:
     formats: 
       - tar.gz
       - zip
-    # Use zip for Windows, tar.gz for others
     format_overrides:
       - goos: windows
-        formats: [zip]
+        format: zip
     name_template: >-
       {{ .ProjectName }}_
       {{- if eq .Os "darwin" }}MacOS

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -100,6 +100,22 @@ archives:
       {{- else }}{{ title .Os }}{{ end }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else }}{{ .Arch }}{{ end }}
+  
+  # Separate archive for Homebrew (macOS and Linux)
+  - id: homebrew-archive
+    ids:
+      - macos_amd64
+      - macos_arm64
+      - linux_x86_64
+      - linux_arm64
+    formats: 
+      - tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- if eq .Os "darwin" }}MacOS
+      {{- else }}{{ title .Os }}{{ end }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
 
 checksum:
   name_template: "checksums.txt"
@@ -121,7 +137,7 @@ release:
 brews:
   - name: otel-desktop-viewer
     ids:
-      - otel-desktop-viewer-archive
+      - homebrew-archive
     # GitHub repository where the formula will be published
     repository:
       owner: CtrlSpice

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ validate-typescript:
 
 .PHONY: release-dry-run
 release-dry-run:
-	gh workflow run "Release" --ref put-back-go-releaser -f test_mode=true
+	gh workflow run "Release" --ref $$(git branch --show-current) -f test_mode=true
 
 .PHONY: kill-port
 kill-port:


### PR DESCRIPTION
- Fixed the archive issue that was causing brew grief by using build ids and a separate archive for homebrew
- Fixed my token woes with a personal access token
- Fixed the go dependency caching warning by adding `cache-dependency-path` to `setup-go` instead of having a separate github action
- If I didn't mess this up in some new and exciting way, it fixes #173 🤪