### PR TITLE
refactor front-end timestamps to use bigint

### DIFF
--- a/desktopexporter/internal/app/components/detail-view/events-panel.tsx
+++ b/desktopexporter/internal/app/components/detail-view/events-panel.tsx
@@ -16,7 +16,7 @@ import { EventData } from "../../types/api-types";
 import { SpanField } from "./span-field";
 import { parseAttributeType } from "../../utils/parse-type";
 import { PreciseTimestamp } from "../../types/precise-timestamp";
-import { getDuration } from "../../utils/duration";
+import { formatDuration } from "../../utils/duration";
 
 type EventItemProps = {
   event: EventData;
@@ -25,7 +25,7 @@ type EventItemProps = {
 
 function EventItem(props: EventItemProps) {
   let { event, spanStartTime } = props;
-  let timeSinceSpanStart = getDuration(spanStartTime, event.timestamp).label;
+  let timeSinceSpanStart = formatDuration(event.timestamp.nanoseconds - spanStartTime.nanoseconds);
 
   let eventAttributes = Object.entries(event.attributes).map(([key, value]) => (
     <li key={key + value?.toString()}>

--- a/desktopexporter/internal/app/components/detail-view/fields-panel.tsx
+++ b/desktopexporter/internal/app/components/detail-view/fields-panel.tsx
@@ -14,7 +14,7 @@ import {
 
 import { SpanData } from "../../types/api-types";
 import { SpanField } from "./span-field";
-import { getDuration } from "../../utils/duration";
+import { formatDuration } from "../../utils/duration";
 import { parseAttributeType } from "../../utils/parse-type";
 
 type FieldsPanelProps = {
@@ -44,7 +44,7 @@ export function FieldsPanel(props: FieldsPanelProps) {
   ) : null;
 
   // Duration: label in appropriate human-readable time unit (s, ms, μs, ns)
-  let duration = getDuration(span.startTime, span.endTime);
+  let durationLabel = formatDuration(span.endTime.nanoseconds - span.startTime.nanoseconds);
 
   // Attributes:
   let spanAttributes = Object.entries(span.attributes).map(([key, value]) => (
@@ -125,7 +125,7 @@ export function FieldsPanel(props: FieldsPanelProps) {
             />
             <SpanField
               fieldName="duration"
-              fieldValue={duration.label}
+              fieldValue={durationLabel}
               fieldType="string"
             />
             <SpanField

--- a/desktopexporter/internal/app/components/sidebar-view/trace-list.tsx
+++ b/desktopexporter/internal/app/components/sidebar-view/trace-list.tsx
@@ -16,8 +16,7 @@ import { useSize } from "@chakra-ui/react-use-size";
 import { TraceSummaryWithUIData } from "../../types/ui-types";
 import { useKeyCombo, useKeyPress } from "../../utils/use-key-press";
 import { KeyboardHelp } from "../modals/keyboard-help";
-import { getDuration } from "../../utils/duration";
-import { traceSummaryFromJSON } from "../../types/api-types";
+import { formatDuration } from "../../utils/duration";
 
 const sidebarSummaryHeight = 120;
 const dividerHeight = 1;
@@ -57,10 +56,7 @@ function SidebarRow({ index, style, data }: SidebarRowProps) {
       .replaceAll("-", "-\u200B")
       .replaceAll(".", ".\u200B");
 
-    let duration = getDuration(
-      traceSummary.root.startTime,
-      traceSummary.root.endTime
-    );
+    let duration = traceSummary.root.endTime.nanoseconds - traceSummary.root.startTime.nanoseconds;
 
     return (
       <div style={style}>
@@ -92,7 +88,7 @@ function SidebarRow({ index, style, data }: SidebarRowProps) {
           </Text>
           <Text fontSize="xs">
             {"Root Duration: "}
-            <strong>{duration.label}</strong>
+            <strong>{formatDuration(duration)}</strong>
           </Text>
           <Text fontSize="xs">
             {"Number of Spans: "}

--- a/desktopexporter/internal/app/components/waterfall-view/duration-bar.tsx
+++ b/desktopexporter/internal/app/components/waterfall-view/duration-bar.tsx
@@ -10,7 +10,7 @@ import {
 } from "@chakra-ui/react";
 import { useSize } from "@chakra-ui/react-use-size";
 
-import { Duration, getDuration, getOffset } from "../../utils/duration";
+import { formatDuration, getOffset } from "../../utils/duration";
 import { EventData, SpanData } from "../../types/api-types";
 import { PreciseTimestamp } from "../../types/precise-timestamp";
 
@@ -25,9 +25,9 @@ function EventDotsList(props: EventDotsListProps) {
 
   let eventDotsList = events.map((eventData) => {
     let eventName = eventData.name;
-    let spanDuration = getDuration(spanStartTime, spanEndTime);
     let eventOffsetPercent = getOffset(
-      spanDuration,
+      spanStartTime,
+      spanEndTime,
       eventData.timestamp
     );
 
@@ -57,7 +57,7 @@ function EventDotsList(props: EventDotsListProps) {
 }
 
 type DurationBarProps = {
-  traceDuration: Duration
+  traceBounds: { startTime: PreciseTimestamp; endTime: PreciseTimestamp };
   spanData: SpanData;
 };
 
@@ -71,9 +71,10 @@ export function DurationBar(props: DurationBarProps) {
   let durationBarColour = useColorModeValue("cyan.800", "cyan.700");
   let labelTextColour = useColorModeValue("blackAlpha.800", "white");
 
+  let { traceBounds } = props;
   let { startTime, endTime } = props.spanData;
-  let barOffsetPercent = getOffset(props.traceDuration, startTime);
-  let barEndPercent = getOffset(props.traceDuration, endTime);
+  let barOffsetPercent = getOffset(traceBounds.startTime, traceBounds.endTime, startTime);
+  let barEndPercent = getOffset(traceBounds.startTime, traceBounds.endTime, endTime);
   let barWidthPercent = barEndPercent - barOffsetPercent;
 
   let labelOffset;
@@ -119,7 +120,7 @@ export function DurationBar(props: DurationBarProps) {
             color={labelTextColour}
             whiteSpace="nowrap"
           >
-            {props.traceDuration.label}
+            {formatDuration(traceBounds.endTime.nanoseconds - traceBounds.startTime.nanoseconds)}
           </Text>
         </Flex>
         <EventDotsList

--- a/desktopexporter/internal/app/components/waterfall-view/waterfall-row.tsx
+++ b/desktopexporter/internal/app/components/waterfall-view/waterfall-row.tsx
@@ -3,12 +3,12 @@ import { Text, Flex, Spacer, useColorModeValue } from "@chakra-ui/react";
 import { WarningTwoIcon } from "@chakra-ui/icons";
 
 import { SpanDataStatus, SpanWithUIData } from "../../types/ui-types";
-import { Duration } from "../../utils/duration";
 import { DurationBar } from "./duration-bar";
+import { PreciseTimestamp } from "../../types/precise-timestamp";
 
 type WaterfallRowData = {
   orderedSpans: SpanWithUIData[];
-  traceDuration: Duration;
+  traceBounds: { startTime: PreciseTimestamp; endTime: PreciseTimestamp };
   spanNameColumnWidth: number;
   serviceNameColumnWidth: number;
   selectedSpanID: string | undefined;
@@ -29,7 +29,7 @@ export function WaterfallRow({ index, style, data }: WaterfallRowProps) {
 
   let {
     orderedSpans,
-    traceDuration,
+    traceBounds,
     spanNameColumnWidth,
     serviceNameColumnWidth,
     selectedSpanID,
@@ -93,7 +93,7 @@ export function WaterfallRow({ index, style, data }: WaterfallRowProps) {
           </Text>
         </Flex>
         <DurationBar
-          traceDuration={traceDuration}
+          traceBounds={traceBounds}
           spanData={spanData}
         />
       </Flex>

--- a/desktopexporter/internal/app/components/waterfall-view/waterfall-view.tsx
+++ b/desktopexporter/internal/app/components/waterfall-view/waterfall-view.tsx
@@ -6,12 +6,12 @@ import { useSize } from "@chakra-ui/react-use-size";
 import { SpanDataStatus, SpanWithUIData } from "../../types/ui-types";
 import { WaterfallRow } from "./waterfall-row";
 import { HeaderRow } from "./header-row";
-import { Duration, getDuration } from "../../utils/duration";
 import { useKeyPress } from "../../utils/use-key-press";
+import { PreciseTimestamp } from "../../types/precise-timestamp";
 
 type WaterfallViewProps = {
   orderedSpans: SpanWithUIData[];
-  traceDuration: Duration;
+  traceBounds: { startTime: PreciseTimestamp; endTime: PreciseTimestamp };
   selectedSpanID: string | undefined;
   setSelectedSpanID: (spanID: string) => void;
 };
@@ -26,7 +26,7 @@ export function WaterfallView(props: WaterfallViewProps) {
   const spanNameColumnWidth = 300;
   const serviceNameColumnWidth = 200;
 
-  let { orderedSpans, traceDuration, selectedSpanID, setSelectedSpanID } =
+  let { orderedSpans, traceBounds, selectedSpanID, setSelectedSpanID } =
     props;
 
   // Set up keyboard navigation
@@ -68,7 +68,7 @@ export function WaterfallView(props: WaterfallViewProps) {
 
   let rowData = {
     orderedSpans,
-    traceDuration,
+    traceBounds,
     spanNameColumnWidth,
     serviceNameColumnWidth,
     selectedSpanID,
@@ -86,7 +86,7 @@ export function WaterfallView(props: WaterfallViewProps) {
         headerRowHeight={headerRowHeight}
         spanNameColumnWidth={spanNameColumnWidth}
         serviceNameColumnWidth={serviceNameColumnWidth}
-        traceDuration={traceDuration}
+        traceBounds={traceBounds}
       />
       <FixedSizeList
         className="List"

--- a/desktopexporter/internal/app/routes/trace-view.tsx
+++ b/desktopexporter/internal/app/routes/trace-view.tsx
@@ -9,7 +9,7 @@ import { Header } from "../components/header-view/header";
 import { DetailView } from "../components/detail-view/detail-view";
 import { WaterfallView } from "../components/waterfall-view/waterfall-view";
 import { arrayToTree, TreeItem, RootTreeItem } from "../utils/array-to-tree";
-import { getTraceDuration } from "../utils/duration";
+import { getTraceBounds } from "../utils/duration";
 
 export async function traceLoader({ params }: any) {
   let response = await fetch(`/api/traces/${params.traceID}`);
@@ -19,7 +19,7 @@ export async function traceLoader({ params }: any) {
 
 export default function TraceView() {
   let traceData = useLoaderData() as TraceData;
-  let traceDuration = getTraceDuration(traceData.spans);
+  let traceBounds = getTraceBounds(traceData.spans);
   let spanTree: RootTreeItem[] = arrayToTree(traceData.spans);
   let orderedSpans = orderSpans(spanTree);
   
@@ -71,7 +71,7 @@ export default function TraceView() {
       >
         <WaterfallView
           orderedSpans={orderedSpans}
-          traceDuration={traceDuration}
+          traceBounds={traceBounds}
           selectedSpanID={selectedSpanID}
           setSelectedSpanID={setSelectedSpanID}
         />
@@ -131,9 +131,9 @@ function orderSpans(spanTree: RootTreeItem[]): SpanWithUIData[] {
             b.status === SpanDataStatus.present
           ) {
             // Sort by start time, with earlier times first (ascending order)
-            if (a.spanData.startTime.isBefore(b.spanData.startTime)) {
+            if (a.spanData.startTime.nanoseconds < b.spanData.startTime.nanoseconds) {
               return -1;
-            } else if (a.spanData.startTime.isAfter(b.spanData.startTime)) {
+            } else if (a.spanData.startTime.nanoseconds > b.spanData.startTime.nanoseconds) {
               return 1;
             }
             return 0;

--- a/desktopexporter/internal/app/types/api-types.ts
+++ b/desktopexporter/internal/app/types/api-types.ts
@@ -128,3 +128,13 @@ export function traceDataFromJSON(json: any): TraceData {
     }))
   };
 }
+
+export function logsFromJSON(json: any): Logs {
+  return {
+    logs: json.logs.map((log: any) => ({
+      ...log,
+      timestamp: PreciseTimestamp.fromJSON(log.timestamp),
+      observedTimestamp: PreciseTimestamp.fromJSON(log.observedTimestamp)
+    }))
+  };
+}

--- a/desktopexporter/internal/app/types/precise-timestamp.ts
+++ b/desktopexporter/internal/app/types/precise-timestamp.ts
@@ -1,40 +1,28 @@
 export class PreciseTimestamp {
-  constructor(
-    public milliseconds: number,
-    public nanoseconds: number
-  ) {}
-
-  static fromJSON(json: any): PreciseTimestamp {
-    if (json instanceof PreciseTimestamp) {
-      return json;
-    }
-    return new PreciseTimestamp(json.milliseconds, json.nanoseconds);
+  constructor(nanoseconds: bigint) {
+    this.nanoseconds = nanoseconds;
   }
 
-  isBefore(other: PreciseTimestamp): boolean {
-    return this.milliseconds < other.milliseconds || 
-           (this.milliseconds === other.milliseconds && this.nanoseconds < other.nanoseconds);
-  }
+  nanoseconds: bigint;
 
-  isAfter(other: PreciseTimestamp): boolean {
-    return this.milliseconds > other.milliseconds || 
-           (this.milliseconds === other.milliseconds && this.nanoseconds > other.nanoseconds);
-  }
-
-  isEqual(other: PreciseTimestamp): boolean {
-    return this.milliseconds === other.milliseconds && this.nanoseconds === other.nanoseconds;
+  static fromJSON(json: { milliseconds: number; nanoseconds: number }): PreciseTimestamp {
+    return new PreciseTimestamp(
+      BigInt(json.milliseconds) * BigInt(1_000_000) + BigInt(json.nanoseconds)
+    );
   }
 
   toString(): string {
-    const date = new Date(this.milliseconds);
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
-    const day = String(date.getUTCDate()).padStart(2, '0');
-    const hours = String(date.getUTCHours()).padStart(2, '0');
-    const minutes = String(date.getUTCMinutes()).padStart(2, '0');
-    const seconds = String(date.getUTCSeconds()).padStart(2, '0');
-    const ms = String(date.getUTCMilliseconds()).padStart(3, '0');
-    const ns = this.nanoseconds.toString().padStart(9, '0');
+    let totalMs = this.nanoseconds / BigInt(1_000_000);
+    let remainderNs = this.nanoseconds % BigInt(1_000_000);
+    let date = new Date(Number(totalMs));
+    let year = date.getUTCFullYear();
+    let month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    let day = String(date.getUTCDate()).padStart(2, '0');
+    let hours = String(date.getUTCHours()).padStart(2, '0');
+    let minutes = String(date.getUTCMinutes()).padStart(2, '0');
+    let seconds = String(date.getUTCSeconds()).padStart(2, '0');
+    let ms = String(date.getUTCMilliseconds()).padStart(3, '0');
+    let ns = remainderNs.toString().padStart(9, '0');
     return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}.${ms}${ns} +0000 UTC`;
   }
-} 
+}

--- a/desktopexporter/internal/app/utils/array-to-tree.ts
+++ b/desktopexporter/internal/app/utils/array-to-tree.ts
@@ -85,9 +85,9 @@ export function arrayToTree(spans: SpanData[]): RootTreeItem[] {
       let earliestStartTimeA = getEarliestStartTime(lookup[a].children);
       let earliestStartTimeB = getEarliestStartTime(lookup[b].children);
       
-      if (earliestStartTimeA.isBefore(earliestStartTimeB)) {
+      if (earliestStartTimeA.nanoseconds < earliestStartTimeB.nanoseconds) {
         return -1;
-      } else if (earliestStartTimeA.isAfter(earliestStartTimeB)) {
+      } else if (earliestStartTimeA.nanoseconds > earliestStartTimeB.nanoseconds) {
         return 1;
       }
       return 0;
@@ -113,7 +113,7 @@ function getEarliestStartTime(children: TreeItem[]): PreciseTimestamp {
   let earliestStart = children[0].spanData.startTime;
   for (let i = 1; i < children.length; i++) {
     let currentStart = children[i].spanData.startTime;
-    if (currentStart.isBefore(earliestStart)) {
+    if (currentStart.nanoseconds < earliestStart.nanoseconds) {
       earliestStart = currentStart;
     }
   }

--- a/desktopexporter/internal/app/utils/duration.ts
+++ b/desktopexporter/internal/app/utils/duration.ts
@@ -1,106 +1,52 @@
 import { SpanData } from "../types/api-types";
 import { PreciseTimestamp } from "../types/precise-timestamp";
 
-export type Duration = {
-  startTime: PreciseTimestamp
-  endTime: PreciseTimestamp
-  milliseconds: number
-  nanoseconds: number
-  label: string
-};
-
-export function getTraceDuration(spans: SpanData[]): Duration {
+export function getTraceBounds(spans: SpanData[]): { startTime: PreciseTimestamp; endTime: PreciseTimestamp } {
   if (!spans.length) {
-    return {
-      startTime: new PreciseTimestamp(0, 0),
-      endTime: new PreciseTimestamp(0, 0),
-      milliseconds: 0,
-      nanoseconds: 0,
-      label: ""
-    };
+    return { startTime: new PreciseTimestamp(BigInt(0)), endTime: new PreciseTimestamp(BigInt(0)) };
   }
 
-  let earliestStartTime = spans[0].startTime;
-  let latestEndTime = spans[0].endTime;
+  let earliestStart = spans[0].startTime.nanoseconds;
+  let latestEnd = spans[0].endTime.nanoseconds;
 
   spans.forEach((span) => {
-    let spanStart = span.startTime;
-    if (spanStart.isBefore(earliestStartTime)) {
-      earliestStartTime = spanStart;
+    let spanStart = span.startTime.nanoseconds;
+    if (spanStart < earliestStart) {
+      earliestStart = spanStart;
     }
 
-    let spanEnd = span.endTime;
-    if (spanEnd.isAfter(latestEndTime)) {
-      latestEndTime = spanEnd;
+    let spanEnd = span.endTime.nanoseconds;
+    if (spanEnd > latestEnd) {
+      latestEnd = spanEnd;
     }
   });
 
-  return getDuration(earliestStartTime, latestEndTime);
+  return { startTime: new PreciseTimestamp(earliestStart), endTime: new PreciseTimestamp(latestEnd) };
 }
 
-export function getDuration(startTime: PreciseTimestamp, endTime: PreciseTimestamp): Duration {
-  if (startTime === null || endTime === null) {
-    return {
-      startTime: startTime,
-      endTime: endTime,
-      milliseconds: 0,
-      nanoseconds: 0,
-      label: ""
-    };
-  }
-
-  // Calculate duration in milliseconds and nanoseconds separately
-  let msDiff = endTime.milliseconds - startTime.milliseconds;
-  let nsDiff = endTime.nanoseconds - startTime.nanoseconds;
-
-  // If nanoseconds went negative, borrow from milliseconds
-  let finalMs = msDiff;
-  let finalNs = nsDiff;
-  if (nsDiff < 0) {
-    finalMs -= 1;
-    finalNs += 1e6; // Add 1ms worth of nanoseconds
-  }
-
-  // Format label based on total duration
-  let label = "";
-  if (finalMs >= 1000) {
+export function formatDuration(nanoseconds: bigint): string {
+  if (nanoseconds >= BigInt(1_000_000_000)) {
     // Convert to seconds
-    let seconds = finalMs / 1000;
-    label = `${seconds.toFixed(3)} s`
-  } else if (finalMs >= 1) {
-    // Show milliseconds with nanosecond precision
-    label = `${finalMs}.${finalNs.toString().padStart(6, '0')} ms`
-  } else if (finalNs >= 1000) {
+    let seconds = Number(nanoseconds) / 1_000_000_000;
+    return `${seconds.toFixed(3)} s`;
+  } else if (nanoseconds >= BigInt(1_000_000)) {
+    // Show milliseconds
+    let ms = Number(nanoseconds) / 1_000_000;
+    return `${ms.toFixed(3)} ms`;
+  } else if (nanoseconds >= BigInt(1000)) {
     // Show microseconds
-    label = `${(finalNs / 1000).toFixed(3)} μs`
+    let μs = Number(nanoseconds) / 1000;
+    return `${μs.toFixed(3)} μs`;
   } else {
     // Show nanoseconds
-    label = `${finalNs} ns`
+    return `${Number(nanoseconds)} ns`;
   }
-
-  return {
-    startTime: startTime,
-    endTime: endTime,
-    milliseconds: finalMs,
-    nanoseconds: finalNs,
-    label: label
-  };
 }
 
-export function getOffset(duration: Duration, point: PreciseTimestamp): number {
-  // Try nanosecond precision first
-  let totalNs = duration.milliseconds * 1e6 + duration.nanoseconds;
-  let offsetNs = (point.milliseconds - duration.startTime.milliseconds) * 1e6 + 
-                 (point.nanoseconds - duration.startTime.nanoseconds);
-
-  if (totalNs <= Number.MAX_SAFE_INTEGER && offsetNs <= Number.MAX_SAFE_INTEGER) {
-    // Use nanosecond precision
-    return Math.floor((offsetNs / totalNs) * 100);
-  } else {
-    // Fall back to millisecond precision
-    return Math.floor(((point.milliseconds - duration.startTime.milliseconds) / 
-                      (duration.endTime.milliseconds - duration.startTime.milliseconds)) * 100);
-  }
+export function getOffset(startTime: PreciseTimestamp, endTime: PreciseTimestamp, point: PreciseTimestamp): number {
+  let totalNs = endTime.nanoseconds - startTime.nanoseconds;
+  let offsetNs = point.nanoseconds - startTime.nanoseconds;
+  return Math.floor(Number((offsetNs * BigInt(100)) / totalNs));
 }
 
 


### PR DESCRIPTION
- Simplified the time calculations on the front end my unmarshalling the PreciseTimestamp objects I use to convey ns-accurate timestamps over JSON to bigint. 
- Purged some repetitive code
- I didn't do the whole "rounding to nice readable values" thing for the trace duration bar. I'll leave that to the next iteration of the front end.

![Gemini_Generated_Image_or7ii4or7ii4or7i (1)](https://github.com/user-attachments/assets/ffe2dc49-69c6-40d3-9ca4-4cd9bafc890b)
