### PR TITLE
handle out-of-order root span

### DIFF
--- a/desktopexporter/internal/store/queries.go
+++ b/desktopexporter/internal/store/queries.go
@@ -233,12 +233,13 @@ const (
             CASE WHEN s.ParentSpanID = '' THEN s.EndTime END as end_time,
             COUNT(*) OVER (PARTITION BY s.TraceID) as span_count
         FROM spans s
-        ORDER BY 
+        ORDER BY
             COALESCE(
                 MIN(CASE WHEN s.ParentSpanID = '' THEN s.StartTime END) OVER (PARTITION BY s.TraceID),
                 MIN(s.StartTime) OVER (PARTITION BY s.TraceID)
             ) DESC,
-            s.TraceID
+            s.TraceID,
+            CASE WHEN s.ParentSpanID = '' THEN 0 ELSE 1 END
     `
 
 	// SelectTrace retrieves spans in hierarchical order with depth information

--- a/desktopexporter/internal/store/traces_test.go
+++ b/desktopexporter/internal/store/traces_test.go
@@ -192,6 +192,145 @@ func TestTraceSuite(t *testing.T) {
 	})
 }
 
+// TestMultiSpanTraceRootDetection verifies that root spans are correctly identified in multi-span traces.
+// This is a regression test for a bug where DISTINCT ON would pick arbitrary spans when ORDER BY
+// didn't have sufficient tie-breakers, causing root span detection to fail in multi-span traces.
+func TestMultiSpanTraceRootDetection(t *testing.T) {
+	helper, teardown := SetupTest(t)
+	defer teardown()
+
+	baseTime := time.Now().UnixNano()
+
+	spans := []traces.SpanData{
+		{
+			TraceID:      "trace1",
+			SpanID:       "root1",
+			ParentSpanID: "",
+			Name:         "root operation",
+			StartTime:    baseTime,
+			EndTime:      baseTime + 300*time.Millisecond.Nanoseconds(),
+			Resource: &resource.ResourceData{
+				Attributes: map[string]any{
+					"service.name": "service1",
+				},
+			},
+			Scope: &scope.ScopeData{},
+		},
+		{
+			TraceID:      "trace1",
+			SpanID:       "child1",
+			ParentSpanID: "root1",
+			Name:         "child operation",
+			StartTime:    baseTime + 50*time.Millisecond.Nanoseconds(),
+			EndTime:      baseTime + 150*time.Millisecond.Nanoseconds(),
+			Resource: &resource.ResourceData{
+				Attributes: map[string]any{
+					"service.name": "service1",
+				},
+			},
+			Scope: &scope.ScopeData{},
+		},
+		{
+			TraceID:      "trace1",
+			SpanID:       "child2",
+			ParentSpanID: "root1",
+			Name:         "child operation 2",
+			StartTime:    baseTime + 100*time.Millisecond.Nanoseconds(),
+			EndTime:      baseTime + 200*time.Millisecond.Nanoseconds(),
+			Resource: &resource.ResourceData{
+				Attributes: map[string]any{
+					"service.name": "service1",
+				},
+			},
+			Scope: &scope.ScopeData{},
+		},
+		{
+			TraceID:      "trace1",
+			SpanID:       "grandchild1",
+			ParentSpanID: "child1",
+			Name:         "grandchild operation",
+			StartTime:    baseTime + 75*time.Millisecond.Nanoseconds(),
+			EndTime:      baseTime + 125*time.Millisecond.Nanoseconds(),
+			Resource: &resource.ResourceData{
+				Attributes: map[string]any{
+					"service.name": "service1",
+				},
+			},
+			Scope: &scope.ScopeData{},
+		},
+		{
+			TraceID:      "trace2",
+			SpanID:       "child3",
+			ParentSpanID: "root2",
+			Name:         "child operation",
+			StartTime:    baseTime + 50*time.Millisecond.Nanoseconds(),
+			EndTime:      baseTime + 100*time.Millisecond.Nanoseconds(),
+			Resource: &resource.ResourceData{
+				Attributes: map[string]any{
+					"service.name": "service2",
+				},
+			},
+			Scope: &scope.ScopeData{},
+		},
+		{
+			TraceID:      "trace2",
+			SpanID:       "child4",
+			ParentSpanID: "root2",
+			Name:         "child operation 2",
+			StartTime:    baseTime + 75*time.Millisecond.Nanoseconds(),
+			EndTime:      baseTime + 125*time.Millisecond.Nanoseconds(),
+			Resource: &resource.ResourceData{
+				Attributes: map[string]any{
+					"service.name": "service2",
+				},
+			},
+			Scope: &scope.ScopeData{},
+		},
+		{
+			// Root span inserted after children to verify ORDER BY prioritizes roots
+			TraceID:      "trace2",
+			SpanID:       "root2",
+			ParentSpanID: "",
+			Name:         "root operation 2",
+			StartTime:    baseTime,
+			EndTime:      baseTime + 200*time.Millisecond.Nanoseconds(),
+			Resource: &resource.ResourceData{
+				Attributes: map[string]any{
+					"service.name": "service2",
+				},
+			},
+			Scope: &scope.ScopeData{},
+		},
+	}
+
+	// Add spans to store
+	err := helper.Store.AddSpans(helper.Ctx, spans)
+	assert.NoError(t, err, "failed to add spans")
+
+	// Get trace summaries
+	summaries, err := helper.Store.GetTraceSummaries(helper.Ctx)
+	assert.NoError(t, err, "failed to get trace summaries")
+
+	// Should have two traces
+	assert.Len(t, summaries, 2, "expected 2 traces")
+
+	// Both traces must have their root spans detected
+	for _, summary := range summaries {
+		assert.NotNil(t, summary.RootSpan, "root span should be detected for trace %s", summary.TraceID)
+
+		switch summary.TraceID {
+		case "trace1":
+			assert.Equal(t, uint32(4), summary.SpanCount, "trace1 should have 4 spans")
+			assert.Equal(t, "root operation", summary.RootSpan.Name)
+			assert.Equal(t, "service1", summary.RootSpan.ServiceName)
+		case "trace2":
+			assert.Equal(t, uint32(3), summary.SpanCount, "trace2 should have 3 spans")
+			assert.Equal(t, "root operation 2", summary.RootSpan.Name)
+			assert.Equal(t, "service2", summary.RootSpan.ServiceName)
+		}
+	}
+}
+
 // createTestTrace creates a comprehensive test trace with multiple spans, events, and links.
 func createTestTrace() []traces.SpanData {
 	baseTime := time.Now().UnixNano()


### PR DESCRIPTION
Fixes a non-deterministic ordering bug where valid traces would report "missing a parent span." I observed this sending trace data from the [Python client](https://opentelemetry.io/docs/languages/python/), via the [FastAPI instrumentation](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/fastapi/fastapi.html). 

<img width="297" height="73" alt="Screenshot 2025-09-29 at 20 51 14" src="https://github.com/user-attachments/assets/fbbfd7c5-a8f0-4ca2-873d-544128a1ac92" />

## Issue

The application uses this in `SelectTraceSummaries`:

```sql
COALESCE(
    MIN(CASE WHEN s.ParentSpanID = '' THEN s.StartTime END) OVER (PARTITION BY s.TraceID),
    MIN(s.StartTime) OVER (PARTITION BY s.TraceID)
) DESC
```

But this has the same value for every span in a given trace ID. And so the `ORDER BY` clause effectively becomes a noop, returning a random span. 

https://github.com/CtrlSpice/otel-desktop-viewer/blob/730f64a63e9a90dd799a20b4b6366d35cc042dc2/desktopexporter/internal/store/queries.go#L215-L226

If this query ends up selecting the wrong span, `CASE WHEN s.ParentSpanID = ''` doesn't match. 


## Fix

Adding this ensures that a root span will always be the first distinct result:

```sql
CASE WHEN s.ParentSpanID = '' THEN 0 ELSE 1 END
```

I ran out of debugging patience to dig into exactly why this client managed to reproduce this issue, e.g., is the root span not sent first? This issue seemed to occur deterministically so I suspect that's the case. But I can confirm the fix works:

<img width="348" height="122" alt="Screenshot 2025-09-29 at 21 15 02" src="https://github.com/user-attachments/assets/24a271f5-5dd1-4874-9a69-13cdcb88ff15" />
