### PR TITLE
README: fix Cask instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Also, it has a dark mode.
 
 #### via Homebrew Cask
 ```bash
-brew install --cask ctrlspice/tap/otel-desktop-viewer
+brew install --cask ctrlspice/otel-desktop-viewer/otel-desktop-viewer
 ```
 
 #### via `go install`


### PR DESCRIPTION
Looks like the Homebrew Tap ctrlspice/homebrew-otel-desktop-viewer, so the install command should be:

```
brew install --cask ctrlspice/otel-desktop-viewer/otel-desktop-viewer
```