### PR TITLE
goreleaser: Remove quarantine bit from Homebrew Cask

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -133,5 +133,10 @@ homebrew_casks:
     caveats: |
       To start the viewer, run:
         otel-desktop-viewer
-
-
+    # https://goreleaser.com/customization/homebrew_casks/#signing-and-notarizing
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/otel-desktop-viewer"]
+          end


### PR DESCRIPTION
Unless the binary inside the Homebrew Cask is signed and notarized, macOS will not allow running it.
Right now, running `brew reinstall --cask ctrlspice/otel-desktop-viewer/otel-desktop-viewer`,
then `otel-desktop-viewer` will result in:

<img width="262" height="256" alt="image" src="https://github.com/user-attachments/assets/92f552cb-5ac6-4711-b819-292b9cccadb9" />

The fix for this is to sign the binary, or to drop the quarantine bit from the file with `xattr`.

Ref: https://goreleaser.com/customization/homebrew_casks/#signing-and-notarizing