### PR TITLE
fix: handle BigInt division by zero for zero-duration spans

### DIFF
--- a/desktopexporter/internal/app/components/waterfall-view/header-row.tsx
+++ b/desktopexporter/internal/app/components/waterfall-view/header-row.tsx
@@ -28,7 +28,7 @@ function DurationIndicator(props: DurationIndicatorProps) {
   // Determine the time unit we are working in
   let { traceBounds } = props;
   let duration = traceBounds.endTime.nanoseconds - traceBounds.startTime.nanoseconds;
-  let sectionNs = duration / BigInt(numSections);
+  let sectionNs = duration === BigInt(0) ? BigInt(0) : duration / BigInt(numSections);
   let sectionWidth = availableWidth / numSections;
 
   let durationSections = Array(numSections - 1)

--- a/desktopexporter/internal/app/utils/duration.ts
+++ b/desktopexporter/internal/app/utils/duration.ts
@@ -45,6 +45,9 @@ export function formatDuration(nanoseconds: bigint): string {
 
 export function getOffset(startTime: PreciseTimestamp, endTime: PreciseTimestamp, point: PreciseTimestamp): number {
   let totalNs = endTime.nanoseconds - startTime.nanoseconds;
+  if (totalNs === BigInt(0)) {
+    return 0;
+  }
   let offsetNs = point.nanoseconds - startTime.nanoseconds;
   return Math.floor(Number((offsetNs * BigInt(100)) / totalNs));
 }

--- a/desktopexporter/internal/server/static/main.js
+++ b/desktopexporter/internal/server/static/main.js
@@ -57999,6 +57999,9 @@
   }
   function getOffset2(startTime, endTime, point) {
     let totalNs = endTime.nanoseconds - startTime.nanoseconds;
+    if (totalNs === BigInt(0)) {
+      return 0;
+    }
     let offsetNs = point.nanoseconds - startTime.nanoseconds;
     return Math.floor(Number(offsetNs * BigInt(100) / totalNs));
   }
@@ -59731,7 +59734,7 @@ otel-cli exec --service my-service --name "curl google" curl https://google.com
     }
     let { traceBounds } = props;
     let duration = traceBounds.endTime.nanoseconds - traceBounds.startTime.nanoseconds;
-    let sectionNs = duration / BigInt(numSections);
+    let sectionNs = duration === BigInt(0) ? BigInt(0) : duration / BigInt(numSections);
     let sectionWidth = availableWidth / numSections;
     let durationSections = Array(numSections - 1).fill(null).map((_, i) => {
       let sectionLabel = formatDuration(sectionNs * BigInt(i));


### PR DESCRIPTION
## What
Handle BigInt division by zero errors in the frontend when rendering traces that contain zero-duration spans.

## Why
Fixes #204

Some OpenTelemetry SDKs (e.g., Pydantic Logfire) can emit spans where `startTime` equals `endTime`, resulting in a zero-duration trace. When the frontend attempts to calculate percentage offsets or duration section widths, it performs BigInt division where the divisor (`totalNs` or `duration`) is `0n`, which throws a `BigInt division by zero` error and crashes the page.

## How
Added zero-value guards at the two division sites:

1. **`getOffset()` in `duration.ts`**: Returns `0` immediately when the total duration (`endTime - startTime`) is `0n`, avoiding the division entirely. This is the primary fix — a zero-duration trace has no meaningful offset, so returning 0% is the correct behavior.

2. **`DurationIndicator` in `header-row.tsx`**: Guards the section width calculation (`duration / numSections`) by returning `0n` when duration is zero. While `numSections` is always `>= 1` (so this path wouldn't divide by zero), the guard prevents a nonsensical calculation and keeps the code defensive.

## Testing
- Verified that traces with zero-duration spans no longer crash the frontend
- Existing traces with normal durations continue to render correctly
- The waterfall view gracefully handles the edge case by showing a minimal-width bar at offset 0%