### PR TITLE
fix: support IPv6 addresses and wildcard hosts in --host flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"log"
+	"net"
 	"strconv"
 	"time"
 
@@ -63,11 +64,16 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 		Use:     set.BuildInfo.Command,
 		Version: set.BuildInfo.Version,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Format the host for use in endpoint addresses.
+			// IPv6 addresses must be wrapped in brackets for net.JoinHostPort
+			// and YAML values containing special characters need quoting.
+			endpoint := formatEndpoint(hostFlag)
+
 			set.ConfigProviderSettings.ResolverSettings.URIs = []string{
 				`yaml:receivers::otlp::protocols::http::cors::allowed_origins: [https://*,http://*]`,
-				`yaml:receivers::otlp::protocols::http::endpoint: ` + hostFlag + `:` + strconv.Itoa(httpPortFlag),
-				`yaml:receivers::otlp::protocols::grpc::endpoint: ` + hostFlag + `:` + strconv.Itoa(grpcPortFlag),
-				`yaml:exporters::desktop::endpoint: ` + hostFlag + `:` + strconv.Itoa(browserPortFlag),
+				`yaml:receivers::otlp::protocols::http::endpoint: "` + endpoint(httpPortFlag) + `"`,
+				`yaml:receivers::otlp::protocols::grpc::endpoint: "` + endpoint(grpcPortFlag) + `"`,
+				`yaml:exporters::desktop::endpoint: "` + endpoint(browserPortFlag) + `"`,
 				`yaml:exporters::desktop::db: ` + dbFlag,
 				`yaml:service::pipelines::traces::receivers: [otlp]`,
 				`yaml:service::pipelines::traces::exporters: [desktop]`,
@@ -82,7 +88,8 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 				go func() {
 					// Wait a bit for the server to come up to avoid a 404 as a first experience
 					time.Sleep(300 * time.Millisecond)
-					browser.OpenURL("http://" + hostFlag + `:` + strconv.Itoa(browserPortFlag) + "/")
+					browserHost := browserHostFor(hostFlag)
+					browser.OpenURL("http://" + browserHost + ":" + strconv.Itoa(browserPortFlag) + "/")
 				}()
 			}
 
@@ -98,8 +105,27 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 	rootCmd.Flags().IntVar(&grpcPortFlag, "grpc", 4317, "The port number on which we listen for OTLP grpc payloads")
 	rootCmd.Flags().BoolVar(&openBrowserFlag, "open-browser", true, "Open the browser automatically on launch")
 	rootCmd.Flags().IntVar(&browserPortFlag, "browser-port", 8000, "The port number where we expose our data")
-	rootCmd.Flags().StringVar(&hostFlag, "host", "localhost", "The host where we expose our all endpoints (OTLP receivers and browser)")
+	rootCmd.Flags().StringVar(&hostFlag, "host", "localhost", "The host where we expose our all endpoints (OTLP receivers and browser). Use '::' or '0.0.0.0' to listen on all interfaces.")
 	rootCmd.Flags().StringVar(&dbFlag, "db", "", "The path of your database file. Omitting this flag opens DuckDB in in-memory mode, with no data persisted to disk.")
 
 	return rootCmd
+}
+
+// formatEndpoint returns a function that produces a properly formatted
+// host:port string for the given host. IPv6 addresses are wrapped in
+// brackets so that net.Dial / net.Listen can parse them correctly.
+func formatEndpoint(host string) func(port int) string {
+	return func(port int) string {
+		return net.JoinHostPort(host, strconv.Itoa(port))
+	}
+}
+
+// browserHostFor returns the host string to use when opening the browser.
+// Wildcard addresses (0.0.0.0, ::) are replaced with localhost because
+// browsers cannot connect to wildcard addresses directly.
+func browserHostFor(host string) string {
+	if host == "0.0.0.0" || host == "::" || host == "[::]" {
+		return "localhost"
+	}
+	return host
 }


### PR DESCRIPTION
## What
Support IPv6 addresses and wildcard bind addresses in the `--host` CLI flag.

## Why
Fixes #144

The `--host` flag fails with IPv6 addresses and has a poor UX with wildcard addresses:

1. **`--host '::''`** → `too many colons in address` because the raw `::` is concatenated with the port (`:::4318`), which Go's `net.Listen` cannot parse. IPv6 addresses require bracket notation (`[::]:4318`).

2. **`--host '[::]'`** → YAML parsing error because `[` and `]` are interpreted as YAML array syntax in the inline config URIs.

3. **`--host '0.0.0.0'`** → The browser opens `http://0.0.0.0:8000` which doesn't resolve in most browsers. It should open `http://localhost:8000` instead.

## How

1. **`net.JoinHostPort`**: Replaced manual `host + ":" + port` string concatenation with Go's `net.JoinHostPort()`, which automatically wraps IPv6 addresses in brackets (`[::]:4318`).

2. **YAML quoting**: Wrapped endpoint values in double quotes in the YAML config URIs to prevent brackets and colons from being misinterpreted as YAML syntax.

3. **Browser URL normalization**: Added `browserHostFor()` helper that maps wildcard addresses (`0.0.0.0`, `::`, `[::]`) to `localhost` when constructing the browser URL.

## Usage
```bash
# Listen on all interfaces (IPv4 + IPv6)
otel-desktop-viewer --host ::

# Listen on all IPv4 interfaces
otel-desktop-viewer --host 0.0.0.0

# Default behavior unchanged
otel-desktop-viewer --host localhost
```