### PR TITLE
feat: add CLI flags to override OTLP HTTP receiver URL paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func runInteractive(params otelcol.CollectorSettings) error {
 func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 	var httpPortFlag, grpcPortFlag, browserPortFlag int
 	var hostFlag, dbFlag string
+	var tracesURLPathFlag, metricsURLPathFlag, logsURLPathFlag string
 	var openBrowserFlag bool
 
 	rootCmd := &cobra.Command{
@@ -66,6 +67,9 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 			set.ConfigProviderSettings.ResolverSettings.URIs = []string{
 				`yaml:receivers::otlp::protocols::http::cors::allowed_origins: [https://*,http://*]`,
 				`yaml:receivers::otlp::protocols::http::endpoint: ` + hostFlag + `:` + strconv.Itoa(httpPortFlag),
+				`yaml:receivers::otlp::protocols::http::traces_url_path: ` + tracesURLPathFlag,
+				`yaml:receivers::otlp::protocols::http::metrics_url_path: ` + metricsURLPathFlag,
+				`yaml:receivers::otlp::protocols::http::logs_url_path: ` + logsURLPathFlag,
 				`yaml:receivers::otlp::protocols::grpc::endpoint: ` + hostFlag + `:` + strconv.Itoa(grpcPortFlag),
 				`yaml:exporters::desktop::endpoint: ` + hostFlag + `:` + strconv.Itoa(browserPortFlag),
 				`yaml:exporters::desktop::db: ` + dbFlag,
@@ -100,6 +104,9 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 	rootCmd.Flags().IntVar(&browserPortFlag, "browser-port", 8000, "The port number where we expose our data")
 	rootCmd.Flags().StringVar(&hostFlag, "host", "localhost", "The host where we expose our all endpoints (OTLP receivers and browser)")
 	rootCmd.Flags().StringVar(&dbFlag, "db", "", "The path of your database file. Omitting this flag opens DuckDB in in-memory mode, with no data persisted to disk.")
+	rootCmd.Flags().StringVar(&tracesURLPathFlag, "traces-url-path", "/v1/traces", "The URL path on which the OTLP HTTP receiver listens for trace payloads")
+	rootCmd.Flags().StringVar(&metricsURLPathFlag, "metrics-url-path", "/v1/metrics", "The URL path on which the OTLP HTTP receiver listens for metric payloads")
+	rootCmd.Flags().StringVar(&logsURLPathFlag, "logs-url-path", "/v1/logs", "The URL path on which the OTLP HTTP receiver listens for log payloads")
 
 	return rootCmd
 }


### PR DESCRIPTION
## What
Add three new CLI flags to allow overriding the URL paths used by the OTLP HTTP receiver.

## Why
Closes #170

Some applications use the OTel SDK's `WithURLPath()` client option to send telemetry to non-standard paths instead of the defaults (`/v1/traces`, `/v1/metrics`, `/v1/logs`). Currently there is no way to configure the receiver to listen on those custom paths.

## How
Added three new CLI flags that map directly to the `otlpreceiver`'s HTTP config:

| Flag | Default | Maps to |
|------|---------|---------|
| `--traces-url-path` | `/v1/traces` | `receivers.otlp.protocols.http.traces_url_path` |
| `--metrics-url-path` | `/v1/metrics` | `receivers.otlp.protocols.http.metrics_url_path` |
| `--logs-url-path` | `/v1/logs` | `receivers.otlp.protocols.http.logs_url_path` |

The defaults match the OTel spec, so existing behavior is unchanged.

## Usage
```bash
# Use custom URL paths
otel-desktop-viewer --traces-url-path /custom/traces --metrics-url-path /custom/metrics

# Default behavior unchanged
otel-desktop-viewer
```

## Notes
- Only the HTTP receiver paths are configurable; gRPC uses service reflection and doesn't have URL paths.
- The `otlpreceiver` internally validates and sanitizes the paths (ensures leading `/`, etc.).