### PR TITLE
Docs: Issues Templates and Code of Conduct

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,97 @@
+name: Bug Report
+description: For reporting the bug, you see
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Something broke? Tell me about it.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      placeholder: You see what has happened was...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: How do I make it happen again?
+      description: Numbered steps are great. "I clicked something and then it broke everything" is a start too.
+      placeholder: |
+        1. 
+        2. 
+        3. 
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: signal
+    attributes:
+      label: Where did this show up?
+      options:
+        - label: Traces
+        - label: Metrics
+        - label: Logs
+        - label: UI / frontend
+        - label: Not sure / general
+
+  - type: input
+    id: version
+    attributes:
+      label: axolot(e)l version
+      placeholder: e.g. v0.5.0
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: e.g. macOS 15.4, Ubuntu 24.04
+    validations:
+      required: true
+
+  - type: input
+    id: instrumentation
+    attributes:
+      label: How are you sending telemetry?
+      description: Skip if this isn't about incoming data.
+      placeholder: e.g. OTel Go SDK, OpenTelemetry Collector, bargeboard, etc.
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Paste whatever looks useful — terminal output, browser console, app logs. I'll format it.
+      render: shell
+
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else?
+      description: Screenshots, config snippets, related issues.
+
+  - type: textarea
+    id: dad-joke
+    attributes:
+      label: Tell me a dad joke
+      description: Optional at your own risk.
+      placeholder: "Why did the axolotl get into observability? It wanted to keep an eye on things. It has four."
+
+  - type: checkboxes
+    id: coc
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: Feature Request
+description: What's missing? What's awkward?
+title: "[feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: Got an idea? Tell me about it.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do? What's in the way?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: What would make this better for you?
+      description: Rough idea is fine. Even "I'm not sure but this bit feels weird" is helpful.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: signal
+    attributes:
+      label: Where would this live?
+      options:
+        - label: Traces
+        - label: Metrics
+        - label: Logs
+        - label: Cross-signal
+        - label: Not sure / general
+
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else?
+      description: Prior art, related issues, mockups, or context that might help.
+
+  - type: textarea
+    id: dad-joke
+    attributes:
+      label: Tell me a dad joke
+      description: Optional at your own risk.
+      placeholder: "Why did the axolotl get into observability? It wanted to keep an eye on things. It has four."
+
+  - type: checkboxes
+    id: coc
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
+          required: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,79 @@
+# Code of Conduct
+
+Hello there. Thank you for being here.
+
+We want this project to feel as approachable as the app tries to be. If something's wrong, confusing, or uncomfortable, please reach out to us. We will help.
+
+Below is the [Contributor Covenant](https://www.contributor-covenant.org) (v3.0). It outlines what's expected, what's not, and how reports are handled.
+
+---
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Code of Conduct.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+- Respecting the purpose of our community, our activities, and our ways of gathering.
+- Engaging kindly and honestly with others.
+- Respecting different viewpoints and experiences.
+- Taking responsibility for our actions and contributions.
+- Gracefully giving and accepting constructive feedback.
+- Committing to repairing harm when it occurs.
+- Behaving in other ways that promote and sustain the well-being of our community.
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+- **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+- **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+- **Stereotyping or discrimination.** Characterizing anyone's personality or behavior on the basis of immutable identities or traits.
+- **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+- **Violating confidentiality.** Sharing or acting on someone's personal or private information without their permission.
+- **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+- Behaving in other ways that threaten the well-being of our community.
+
+### Other Restrictions
+
+- **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+- **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+- **Promotional materials.** Sharing marketing or other commercial content in a way that is outside the norms of the community.
+- **Irresponsible communication.** Failing to responsibly present content which includes, links to, or describes any other restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a Code of Conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, contact us at [amelia.ardath@gmail.com](mailto:amelia.ardath@gmail.com).
+
+Reports will be reviewed and investigated promptly and fairly, with reporter privacy respected throughout.
+
+## Addressing and Repairing Harm
+
+If an investigation finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+- **Warning** — A private, written warning. Repair may include a private apology, acknowledgement of responsibility, and seeking clarification on expectations.
+- **Temporarily Limited Activities** — A time-limited cooldown period, which may be limited to particular channels or interactions. Repair includes using the cooldown period to reflect on actions and impact.
+- **Temporary Suspension** — Suspension with conditions for return. Repair includes respecting the spirit of the suspension and being thoughtful about reintegration.
+- **Permanent Ban** — Permanent removal from all community spaces, tools, and communication channels. Reserved for patterns of repeated violation that other steps have failed to resolve, or a single violation serious enough that no safe path forward exists.
+
+This enforcement ladder is a guideline. It does not limit our ability to use discretion and judgment in the best interests of the community.
+
+### Zero-Tolerance Policy
+
+The expression, promotion, or defense of fascist, white supremacist, or nazi ideology is grounds for immediate and permanent ban. This is not subject to the graduated enforcement ladder above. There is no warning step.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/). Contributor Covenant is stewarded by the [Organization for Ethical Source](https://ethicalsource.dev) and licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).

--- a/files/bug_report.yml
+++ b/files/bug_report.yml
@@ -1,0 +1,88 @@
+name: Bug Report
+description: Something isn't working as expected.
+title: "[bug] "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to file a bug report! The more detail you provide, the faster we can help.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      placeholder: Describe the bug clearly and concisely.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. 
+        2. 
+        3. 
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: signal
+    attributes:
+      label: Signal type affected
+      options:
+        - label: Traces
+        - label: Metrics
+        - label: Logs
+        - label: UI / frontend
+        - label: Not sure
+
+  - type: input
+    id: version
+    attributes:
+      label: axolot(e)l version
+      placeholder: e.g. v0.5.0
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: e.g. macOS 15.4, Ubuntu 24.04
+    validations:
+      required: true
+
+  - type: input
+    id: instrumentation
+    attributes:
+      label: How are you sending telemetry?
+      placeholder: e.g. OTel Go SDK, OpenTelemetry Collector, bargeboard, etc.
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Copy and paste any relevant logs. This will be automatically formatted into code.
+      render: shell
+
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else?
+      description: Screenshots, config snippets, or anything else that might help.
+
+  - type: checkboxes
+    id: coc
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
+          required: true

--- a/files/feature_request.yml
+++ b/files/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature Request
+description: Suggest an idea or improvement.
+title: "[feature] "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: Got an idea? Tell us about it. A good dad joke at the bottom may bump this up the queue.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do, and what's making it hard right now?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you have in mind
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: signal
+    attributes:
+      label: Signal type (if applicable)
+      options:
+        - label: Traces
+        - label: Metrics
+        - label: Logs
+        - label: Cross-signal
+        - label: Not signal-specific
+
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else?
+      description: Prior art, related issues, mockups, or context that might help.
+
+  - type: textarea
+    id: dad-joke
+    attributes:
+      label: Tell me a dad joke
+      description: Optional, but a genuinely good one may bump this up the queue. A bad one will not be held against you.
+      placeholder: "Why did the axolotl get into observability? It wanted to keep an eye on things. It has four."
+
+  - type: checkboxes
+    id: coc
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
+          required: true


### PR DESCRIPTION
- Add GitHub issue form templates for feature requests and bug reports, with approachable copy, OTel-specific fields (signal type, instrumentation, axolot(e)l version), optional dad joke field, and required Code of Conduct acknowledgment.

- Add `CODE_OF_CONDUCT.md`: a short project intro plus Contributor Covenant v3.0, with conduct reports sent to the maintainer email listed in the Reporting section.

## Test plan

- [ ] I shall poke at it!