### PR TITLE
Add --metrics-port flag for internal Prometheus self-telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Flags:
       --grpc int           OTLP gRPC listen port (default 4317)
       --host string        Host for OTLP receivers and the web UI (default localhost)
       --http int           OTLP HTTP listen port (default 4318)
+      --metrics-port int   Port for the collector's internal Prometheus self-telemetry (default 8888)
       --open-browser       Open the browser on launch (default true)
   -h, --help               help for otel-desktop-viewer
   -v, --version            version for otel-desktop-viewer

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func runInteractive(params otelcol.CollectorSettings) error {
 }
 
 func newCommand(set otelcol.CollectorSettings) *cobra.Command {
-	var httpPortFlag, grpcPortFlag, browserPortFlag int
+	var httpPortFlag, grpcPortFlag, browserPortFlag, metricsPortFlag int
 	var hostFlag, dbFlag string
 	var openBrowserFlag bool
 
@@ -98,6 +98,12 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 				`yaml:service::pipelines::metrics::exporters: [desktop]`,
 				`yaml:service::pipelines::logs::receivers: [otlp]`,
 				`yaml:service::pipelines::logs::exporters: [desktop]`,
+				// Expose the collector's own Prometheus self-telemetry on a configurable
+				// port instead of the hardcoded default (:8888), which is a common port
+				// to already have in use. Setting the reader explicitly overrides the
+				// collector default.
+				`yaml:service::telemetry::metrics::readers: [{pull: {exporter: {prometheus: {host: "` +
+					hostFlag + `", port: ` + strconv.Itoa(metricsPortFlag) + `}}}}]`,
 			}
 			set.ConfigProviderSettings.ResolverSettings.DefaultScheme = "env"
 
@@ -122,6 +128,7 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 	rootCmd.Flags().IntVar(&grpcPortFlag, "grpc", 4317, "The port number on which we listen for OTLP grpc payloads")
 	rootCmd.Flags().BoolVar(&openBrowserFlag, "open-browser", true, "Open the browser automatically on launch")
 	rootCmd.Flags().IntVar(&browserPortFlag, "browser-port", 8000, "The port number where we expose our data")
+	rootCmd.Flags().IntVar(&metricsPortFlag, "metrics-port", 8888, "The port number for the collector's internal Prometheus self-telemetry metrics")
 	rootCmd.Flags().StringVar(&hostFlag, "host", "localhost", "The host where we expose our all endpoints (OTLP receivers and browser). Use '::' or '0.0.0.0' to listen on all interfaces.")
 	rootCmd.Flags().StringVar(&dbFlag, "db", "", "The path of your database file. Omitting this flag opens DuckDB in in-memory mode, with no data persisted to disk.")
 


### PR DESCRIPTION
## Problem

The collector's internal self-telemetry Prometheus endpoint is hardcoded to `:8888`, so `otel-desktop-viewer` fails to start when something already holds that port:

```
Error: failed to create SDK: binding address localhost:8888 for Prometheus exporter: listen tcp 127.0.0.1:8888: bind: address already in use
```

`:8888` is a commonly-occupied port (Jupyter, other collectors, SSH tunnels). The OTLP/UI ports are all configurable via flags, but this one isn't — and `config.go` actively reserves `8888`, so there's no escape hatch. On a machine that already has `:8888` bound, the viewer simply won't launch.

## Change

Add a `--metrics-port` flag (default `8888`, so existing behavior is unchanged) that sets the `service::telemetry::metrics` Prometheus reader explicitly, letting users relocate it:

```bash
otel-desktop-viewer --metrics-port 18888
```

It's a one-line config URI wired to a new flag, matching the existing `--http`/`--grpc`/`--browser-port` pattern, plus a README line.

## Verification

Built from source (Go 1.26, collector v0.126.0) and, with `:8888` already occupied:

- default (no flag) → still errors with the bind message above (unchanged behavior)
- `--metrics-port 18888` → starts cleanly; UI serves on `:8000`, and the internal metrics are served on `:18888` (`GET /metrics` → 200)

Happy to adjust the flag name/semantics (e.g. a `--disable-internal-metrics` variant instead) if you'd prefer.