### PR TITLE
Make traces deep-linkable via /traces/{id}

### DIFF
--- a/desktopexporter/internal/frontend/src/App.svelte
+++ b/desktopexporter/internal/frontend/src/App.svelte
@@ -23,7 +23,7 @@
   <Route path="/logs">
     <LogsPage />
   </Route>
-  <Route path="/traces">
+  <Route path="/traces/*">
     <TracesPage />
   </Route>
 </main>

--- a/desktopexporter/internal/frontend/src/pages/TracesPage.svelte
+++ b/desktopexporter/internal/frontend/src/pages/TracesPage.svelte
@@ -56,6 +56,7 @@
 
 <script lang="ts">
   import { onMount } from 'svelte'
+  import { router } from 'tinro5'
   import { telemetryAPI } from '@/services/telemetry-service'
   import {
     getTimeContext,
@@ -89,8 +90,19 @@
   let sortColumn = $state<TraceSummarySortColumn>('startTime')
   let sortDirection = $state<TraceSummarySortDirection>('desc')
 
+  // --- deep linking: the selected trace lives in the URL as /traces/{id} ---
+  // Parse the id out of a path; null for the bare /traces list.
+  function traceIdFromPath(p: string): string | null {
+    const m = /^\/traces\/(.+)$/.exec(p)
+    return m ? decodeURIComponent(m[1]) : null
+  }
+
   // --- state: selection + detail ---
-  let selectedTraceId = $state<string | null>(null)
+  // Initialize from the current URL (not null) so a hard-loaded /traces/{id} selects
+  // that trace on mount, before any router subscription fires — and so the reflect
+  // effect below sees state and URL already in agreement (no spurious navigation).
+  let currentPath = $state(location.pathname)
+  let selectedTraceId = $state<string | null>(traceIdFromPath(location.pathname))
   let traceData = $state<TraceData | null>(null)
   let selectedSpanID = $state<string | null>(null)
   let detailLoading = $state(false)
@@ -154,6 +166,28 @@
   })
 
   // --- effects ---
+
+  // URL -> selection. subscribe() fires immediately with the current route and again
+  // on every navigation (nav clicks, browser back/forward), keeping the selection in
+  // sync with the address bar. Returned from onMount so it unsubscribes on unmount.
+  onMount(() =>
+    router.subscribe(route => {
+      currentPath = route.path
+      const id = traceIdFromPath(route.path)
+      if (id !== selectedTraceId) selectedTraceId = id
+    })
+  )
+
+  // selection -> URL. Reflect the current selection into the path so a trace is
+  // shareable and survives a refresh, and so browser back/forward walks the traces
+  // you visited. Guarded on currentPath so this never fights the subscription above
+  // (no feedback loop).
+  $effect(() => {
+    const target = selectedTraceId
+      ? `/traces/${encodeURIComponent(selectedTraceId)}`
+      : '/traces'
+    if (currentPath !== target) router.goto(target)
+  })
 
   let lastValidIndex = $state(0)
 

--- a/desktopexporter/internal/server/server.go
+++ b/desktopexporter/internal/server/server.go
@@ -8,7 +8,9 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store"
 	"github.com/rs/cors"
@@ -47,20 +49,16 @@ func (s *Server) Start() error {
 func (s *Server) initHandler() error {
 	mux := http.NewServeMux()
 
-	// Handle specific routes first (checked before catch-all)
-	mux.HandleFunc("GET /traces/{id}", s.indexHandler)
 	mux.HandleFunc("POST /rpc", s.rpcHandler)
 
-	// Then handle static files (catches everything else)
-	if s.staticDir != "" {
-		mux.Handle("/", http.FileServer(http.Dir(s.staticDir)))
-	} else {
-		staticContent, err := fs.Sub(assets, "static")
-		if err != nil {
-			return err
-		}
-		mux.Handle("/", http.FileServerFS(staticContent))
+	// Single-page app: serve a static asset when one exists at the request path,
+	// otherwise fall back to index.html so client-side routes (/traces,
+	// /traces/{id}, /metrics, /logs) resolve on hard load, refresh, and shared links.
+	fsys, err := s.staticFS()
+	if err != nil {
+		return err
 	}
+	mux.Handle("/", spaHandler(fsys))
 
 	// CORS for the Vite frontend
 	c := cors.New(cors.Options{
@@ -72,20 +70,41 @@ func (s *Server) initHandler() error {
 	return nil
 }
 
-// indexHandler serves the frontend application.
-// Uses STATIC_ASSETS_DIR for development, embedded assets for production.
-func (s *Server) indexHandler(writer http.ResponseWriter, request *http.Request) {
+// staticFS returns the filesystem holding the built frontend: the on-disk
+// STATIC_ASSETS_DIR in development, or the embedded assets in production.
+func (s *Server) staticFS() (fs.FS, error) {
 	if s.staticDir != "" {
-		http.ServeFile(writer, request, s.staticDir+"/index.html")
-	} else {
-		bytes, err := assets.ReadFile("static/index.html")
+		return os.DirFS(s.staticDir), nil
+	}
+	return fs.Sub(assets, "static")
+}
+
+// spaHandler serves the single-page app. A GET/HEAD for an existing file is served
+// as-is; any other GET/HEAD path falls back to index.html so the client router owns
+// the route (e.g. a deep-linked /traces/{id} or a refreshed /metrics). Non-GET
+// requests fall through to the file server.
+func spaHandler(fsys fs.FS) http.Handler {
+	fileServer := http.FileServerFS(fsys)
+	serveIndex := func(writer http.ResponseWriter) {
+		bytes, err := fs.ReadFile(fsys, "index.html")
 		if err != nil {
-			log.Printf("Error reading static assets: %v", err)
+			log.Printf("Error reading index.html: %v", err)
 			http.Error(writer, "Failed to load page", http.StatusInternalServerError)
 			return
 		}
+		writer.Header().Set("Content-Type", "text/html; charset=utf-8")
 		writer.Write(bytes)
 	}
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method == http.MethodGet || request.Method == http.MethodHead {
+			name := strings.TrimPrefix(path.Clean(request.URL.Path), "/")
+			if info, err := fs.Stat(fsys, name); name == "" || err != nil || info.IsDir() {
+				serveIndex(writer)
+				return
+			}
+		}
+		fileServer.ServeHTTP(writer, request)
+	})
 }
 
 func (s *Server) rpcHandler(writer http.ResponseWriter, request *http.Request) {

--- a/desktopexporter/internal/server/server_test.go
+++ b/desktopexporter/internal/server/server_test.go
@@ -42,6 +42,27 @@ func TestIndexHandler(t *testing.T) {
 	assert.Contains(t, res.Header.Get("Content-Type"), "text/html")
 }
 
+// Client-side routes have no matching file on disk; the server must fall back to
+// index.html so a hard load, refresh, or shared deep link boots the SPA (which then
+// owns the route). Without this, a refreshed /traces or a shared /traces/{id} 404s.
+func TestSPAFallback(t *testing.T) {
+	testServer, teardown := setupServer(t)
+	defer teardown()
+
+	for _, path := range []string{"/traces", "/traces/abc123def456", "/metrics", "/logs"} {
+		res, err := http.Get(testServer.URL + path)
+		require.NoErrorf(t, err, "GET %s", path)
+		body, err := io.ReadAll(res.Body)
+		res.Body.Close()
+		require.NoErrorf(t, err, "read body for %s", path)
+
+		assert.Equalf(t, http.StatusOK, res.StatusCode, "GET %s status", path)
+		assert.Containsf(t, res.Header.Get("Content-Type"), "text/html", "GET %s content-type", path)
+		assert.Containsf(t, strings.ToLower(string(body)), "<!doctype html",
+			"GET %s should serve index.html", path)
+	}
+}
+
 func TestRPCHandlerInvalidJSON(t *testing.T) {
 	testServer, teardown := setupServer(t)
 	defer teardown()


### PR DESCRIPTION
Currently, you cannot deep-link a trace. The selected trace lives in component state (`selectedTraceId` in `TracesPage.svelte`), not the URL.

- You can't share or bookmark a trace, and a refresh drops the selection.
- `/traces/{id}` is handled by the Go server and renders blank.
- a fresh page load of `/traces`, `/metrics`, or `/logs` 404s, since the server only serves the SPA for `/` and `/traces/{id}`.

Modify the server to serve index.html for deep links and let the Svelte router render the appropriate page.