### PR TITLE
Fix drawer empty state bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .cursor/
 .claude/
+.clinerules/
 otel-desktop-viewer
 desktopexporter/internal/frontend-legacy/
 .vscode/

--- a/desktopexporter/internal/frontend/src/components/shared/Drawer/SignalListDrawer.svelte
+++ b/desktopexporter/internal/frontend/src/components/shared/Drawer/SignalListDrawer.svelte
@@ -50,8 +50,13 @@
     refreshPulse?: boolean
     /** Plain text for DaisyUI tooltip + screen reader when new data is pending */
     refreshAsideTip?: string
-    /** When true, an empty list does not force-collapse the drawer (initial fetch). */
+    /** When true, an empty list shows a loading gap instead of the empty state (initial fetch). */
     loading?: boolean
+    /** Page has no list at all (Home): force-collapse into a thin nav rail
+     * and disable the expand toggle. Zero *results* on a list page should
+     * NOT set this — the drawer stays open with an empty state so the
+     * search and time filters remain reachable. */
+    railOnly?: boolean
     drawerChromeToolbar?: Snippet
     drawerSearch?: Snippet
     footer?: Snippet
@@ -71,6 +76,7 @@
     refreshPulse = false,
     refreshAsideTip = '',
     loading = false,
+    railOnly = false,
     drawerChromeToolbar,
     drawerSearch,
     footer,
@@ -106,14 +112,15 @@
     })
   })
 
-  // Force-collapse only when the list is empty after load — not while the
-  // initial fetch is in flight (otherwise every signal navigation briefly
-  // collapses then re-opens). Toggle stays disabled when truly empty.
-  let isEmpty = $derived(items.length === 0 && !loading)
-  let effectivelyOpen = $derived(isEmpty ? false : drawerOpen)
+  // Only rail-only pages (Home) force-collapse. A list page with zero
+  // results keeps the drawer open and shows an empty state instead —
+  // otherwise the search bar and time filter needed to broaden the query
+  // are unreachable from the collapsed rail.
+  let effectivelyOpen = $derived(railOnly ? false : drawerOpen)
+  let showEmptyState = $derived(items.length === 0 && !loading)
 
   function handleToggleChange(e: Event) {
-    if (isEmpty) return
+    if (railOnly) return
     skipWidthTransition = false
     drawerOpen = (e.currentTarget as HTMLInputElement).checked
     syncDrawerOpenPreference(drawerOpen)
@@ -192,7 +199,7 @@
     type="checkbox"
     class="drawer-toggle signal-drawer-toggle"
     checked={effectivelyOpen}
-    disabled={isEmpty}
+    disabled={railOnly}
     onchange={handleToggleChange}
   />
 
@@ -208,7 +215,7 @@
       {#if !effectivelyOpen}
         <div class="signal-drawer__collapsed-rail">
           <div class="signal-drawer__collapsed-group">
-          {#if isEmpty}
+          {#if railOnly}
             <span
               class="drawer-header-btn drawer-header-btn--inactive tooltip tooltip-right"
               data-tip="Send data to populate this drawer"
@@ -393,19 +400,28 @@
         class="signal-drawer__body"
         bind:this={drawerBodyEl}
       >
-        <VirtualList
-          bind:this={vlistRef}
-          {items}
-          defaultEstimatedItemHeight={72}
-          bufferSize={10}
-          containerClass="signal-drawer__vlist"
-          viewportClass="signal-drawer__vlist-viewport"
-          itemsClass="signal-drawer__vlist-items"
-        >
-          {#snippet renderItem(item)}
-            {@render itemSnippet(item, selectedId === itemKey(item))}
-          {/snippet}
-        </VirtualList>
+        {#if showEmptyState}
+          <div class="signal-drawer__empty" role="status">
+            <p class="signal-drawer__empty-title">No {label.toLowerCase()} found</p>
+            <p class="signal-drawer__empty-hint">
+              Try widening the time range or clearing the search.
+            </p>
+          </div>
+        {:else}
+          <VirtualList
+            bind:this={vlistRef}
+            {items}
+            defaultEstimatedItemHeight={72}
+            bufferSize={10}
+            containerClass="signal-drawer__vlist"
+            viewportClass="signal-drawer__vlist-viewport"
+            itemsClass="signal-drawer__vlist-items"
+          >
+            {#snippet renderItem(item)}
+              {@render itemSnippet(item, selectedId === itemKey(item))}
+            {/snippet}
+          </VirtualList>
+        {/if}
       </div>
       {/if}
 
@@ -551,6 +567,19 @@
   /* ── Body (list) ── */
   .signal-drawer__body {
     @apply flex-1 min-h-0 overflow-hidden;
+  }
+
+  /* ── Empty state (zero results with filters still reachable above) ── */
+  .signal-drawer__empty {
+    @apply flex h-full flex-col items-center justify-center gap-1 px-6 text-center;
+  }
+
+  .signal-drawer__empty-title {
+    @apply text-sm font-medium text-base-content/70;
+  }
+
+  .signal-drawer__empty-hint {
+    @apply text-xs text-base-content/50;
   }
 
   .signal-drawer__body :global(.signal-drawer__vlist) {

--- a/desktopexporter/internal/frontend/src/components/shared/PageLayout.svelte
+++ b/desktopexporter/internal/frontend/src/components/shared/PageLayout.svelte
@@ -4,9 +4,10 @@
    *
    * Owns:
    *   1. The SignalListDrawer (the left rail with nav/theme + optional
-   *      item list/search/footer). Always rendered. When `items` is
-   *      empty (e.g. on Home) the drawer force-collapses and acts as
-   *      a thin nav rail.
+   *      item list/search/footer). Always rendered. `railOnly` pages
+   *      (Home) force-collapse it into a thin nav rail; list pages with
+   *      zero results keep it open and show an empty state so search and
+   *      time filters stay reachable.
    *   2. The content area: a `main` snippet (required) with an
    *      optional `detail` snippet that, when present, splits the
    *      content area into a horizontally resizable main+detail pair
@@ -23,9 +24,12 @@
 
   type Props<T> = {
     // ── Drawer (forwarded to SignalListDrawer) ─────────────────────
-    /** Items rendered in the drawer list. Pass `[]` for pages with
-     * no list (Home) -- the drawer will force-collapse. */
+    /** Items rendered in the drawer list. Pass `[]` together with
+     * `railOnly` for pages with no list (Home). On list pages an
+     * empty array renders the drawer's empty state instead. */
     items: T[]
+    /** Force-collapse the drawer into a thin nav rail (Home). */
+    railOnly?: boolean
     selectedId: string | null
     drawerId: string
     /** Tooltip label on the collapsed open-drawer button. */
@@ -75,6 +79,7 @@
 
   let {
     items,
+    railOnly,
     selectedId,
     drawerId,
     drawerLabel,
@@ -100,7 +105,7 @@
     resizableStorageKey,
   }: Props<any> = $props()
 
-  // No-op snippet for SignalListDrawer when items is empty -- the
+  // No-op snippet for railOnly pages (Home) that render no list -- the
   // drawer's effectivelyOpen=false guarantees this never renders,
   // but the prop is required so we satisfy the type.
   const noopItem: Snippet<[item: any, selected: boolean]> = $derived(
@@ -113,6 +118,7 @@
 <div class="page-layout">
   <SignalListDrawer
     {items}
+    {railOnly}
     {selectedId}
     {drawerId}
     label={drawerLabel}

--- a/desktopexporter/internal/frontend/src/pages/HomePage.svelte
+++ b/desktopexporter/internal/frontend/src/pages/HomePage.svelte
@@ -86,6 +86,7 @@ $ export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"`,
 <div class="home-page">
   <PageLayout
     items={[]}
+    railOnly
     selectedId={null}
     drawerId="signal-drawer"
     drawerLabel="Home"


### PR DESCRIPTION
- Bug (derogatory): tried to be clever and force the drawer closed when there were no traces/metrics/logs to list so when a search or time filter returned zero results, the drawer happily force-collapsed into the nav rail  and got stuck (with the search bar inside the drawer) so you were locked out of the very controls you'd need to un-filter. Only escape was navigating to a different signal.  🤦<Yay!
- Fix: Empty result lists now keep the drawer open and show an empty state message instead of collapsing, so search and time filters stay reachable
- Added an optional `railOnly` prop to `SignalListDrawer / PageLayout` for pages that genuinely want a collapsed nav rail (currently just Home), separating "this page has no list" from "this list happens to be empty."
- Also sneaks in a one-line .gitignore addition for .clinerules/

