### PR TITLE
set rpc request body limit

### DIFF
--- a/desktopexporter/internal/server/server.go
+++ b/desktopexporter/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"embed"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -17,6 +18,12 @@ import (
 
 //go:embed static
 var assets embed.FS
+
+// maxRPCRequestBodyBytes caps how much of an /rpc request body we will read.
+// JSON-RPC requests in this app are small (a method name and a few params), so
+// 1 MB is generous headroom while preventing a buggy or malicious client from
+// exhausting memory with an unbounded body.
+const maxRPCRequestBodyBytes = 1 << 20 // 1 MB
 
 type Server struct {
 	server         http.Server
@@ -102,8 +109,14 @@ func spaHandler(fsys fs.FS) http.Handler {
 }
 
 func (s *Server) rpcHandler(writer http.ResponseWriter, request *http.Request) {
-	body, err := io.ReadAll(request.Body)
+	limited := http.MaxBytesReader(writer, request.Body, maxRPCRequestBodyBytes)
+	body, err := io.ReadAll(limited)
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			sendJSONRPCResponse(writer, jsonrpc2.ID{}, nil, fmt.Errorf("%w: request body too large", jsonrpc2.ErrInvalidRequest))
+			return
+		}
 		sendJSONRPCResponse(writer, jsonrpc2.ID{}, nil, jsonrpc2.ErrInternal)
 		return
 	}

--- a/desktopexporter/internal/server/server_test.go
+++ b/desktopexporter/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -98,6 +99,30 @@ func TestRPCHandlerInvalidJSON(t *testing.T) {
 	assert.NotNil(t, response["error"])
 	errorObj := response["error"].(map[string]any)
 	assert.Equal(t, float64(-32700), errorObj["code"]) // Parse error code
+}
+
+func TestRPCHandlerOversizedBody(t *testing.T) {
+	testServer, teardown := setupServer(t)
+	defer teardown()
+
+	oversized := make([]byte, maxRPCRequestBodyBytes+1)
+	res, err := http.Post(fmt.Sprintf("%s/rpc", testServer.URL), "application/json", bytes.NewReader(oversized))
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusOK, res.StatusCode) // JSON-RPC always returns 200
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	var response map[string]any
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "2.0", response["jsonrpc"])
+	assert.NotNil(t, response["error"])
+	errorObj := response["error"].(map[string]any)
+	assert.Equal(t, float64(-32600), errorObj["code"]) // Invalid Request code
 }
 
 func TestRPCHandlerInvalidRequest(t *testing.T) {


### PR DESCRIPTION
The /rpc handler read the request body with an unbounded io.ReadAll, so a buggy or malicious client could exhaust server memory with an arbitrarily large body. This wraps the body in http.MaxBytesReader with a 1 MB cap and returns a spec-compliant JSON-RPC error on overflow instead of crashing or OOMing.

- Added maxRPCRequestBodyBytes = 1 << 20 (1 MB) constant
- Wrapped request.Body with http.MaxBytesReader in rpcHandler. On an oversized body, it detects *http.MaxBytesError and responds with an Invalid Request error (code -32600) by wrapping `jsonrpc2.ErrInvalidRequest`, preserving "request body too large" message.
- Added TestRPCHandlerOversizedBody covering the overflow path.