### PR TITLE
feat: add retention limits via configurable store size cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,18 +229,21 @@ Telemetry is stored in memory by default. Use `--db` to persist to a file.
 
 ```bash
 Flags:
-      --browser-port int   Port for the web UI and JSON-RPC API (default 8000)
-      --db string          DuckDB file path (default: in-memory)
-      --grpc int           OTLP gRPC listen port (default 4317)
-      --host string        Host for OTLP receivers and the web UI (default localhost)
-      --http int           OTLP HTTP listen port (default 4318)
-      --open-browser       Open the browser on launch (default true)
-  -h, --help               help for otel-desktop-viewer
-  -v, --version            version for otel-desktop-viewer
+      --browser-port int     Port for the web UI and JSON-RPC API (default 8000)
+      --db string            DuckDB file path (default: in-memory)
+      --db-max-size string   Store size cap, e.g. 512MB or 2GB; oldest telemetry
+                             is pruned past it. 0 disables pruning.
+                             (default: 512MB in-memory, 2GB with --db)
+      --grpc int             OTLP gRPC listen port (default 4317)
+      --host string          Host for OTLP receivers and the web UI (default localhost)
+      --http int             OTLP HTTP listen port (default 4318)
+      --open-browser         Open the browser on launch (default true)
+  -h, --help                 help for otel-desktop-viewer
+  -v, --version              version for otel-desktop-viewer
 ```
 
 ```bash
-otel-desktop-viewer --db ./telemetry.duckdb
+otel-desktop-viewer --db ./telemetry.duckdb --db-max-size 4GB
 ```
 
 ## Configuring Your OpenTelemetry SDK

--- a/desktopexporter/config.go
+++ b/desktopexporter/config.go
@@ -2,6 +2,8 @@ package desktopexporter
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 )
 
 // Config represents the exporter config settings (provided to the collector via command line on launch)
@@ -11,6 +13,12 @@ type Config struct {
 
 	// DBPath defines the path of your database file. Setting an empty string opens DuckDB in in-memory mode
 	Db string `mapstructure:"db"`
+
+	// DbMaxSize caps the size of the telemetry store as a human-readable byte
+	// size (e.g. "512MB", "2GB"). "0" disables retention enforcement. An empty
+	// string picks a default based on the storage mode: 512MB in-memory, 2GB
+	// on disk.
+	DbMaxSize string `mapstructure:"db_max_size"`
 }
 
 // Validate checks if the exporter configuration is valid
@@ -19,5 +27,51 @@ func (cfg *Config) Validate() error {
 		return fmt.Errorf("port 8888 is not supported as it is used internally")
 	}
 
+	if _, err := parseByteSize(cfg.DbMaxSize); err != nil {
+		return fmt.Errorf("invalid db_max_size %q: %w", cfg.DbMaxSize, err)
+	}
+
 	return nil
+}
+
+// parseByteSize converts a human-readable size string ("512MB", "2GB", "0")
+// into a byte count. Units are binary (KB = 1024 bytes) and case-insensitive;
+// a bare number is taken as bytes. An empty string returns -1, meaning
+// "unset: apply the mode-dependent default".
+func parseByteSize(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return -1, nil
+	}
+
+	units := []struct {
+		suffix     string
+		multiplier int64
+	}{
+		{"TB", 1 << 40},
+		{"GB", 1 << 30},
+		{"MB", 1 << 20},
+		{"KB", 1 << 10},
+		{"B", 1},
+	}
+
+	upper := strings.ToUpper(s)
+	multiplier := int64(1)
+	digits := upper
+	for _, u := range units {
+		if strings.HasSuffix(upper, u.suffix) {
+			multiplier = u.multiplier
+			digits = strings.TrimSpace(strings.TrimSuffix(upper, u.suffix))
+			break
+		}
+	}
+
+	value, err := strconv.ParseInt(digits, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("expected a size like 512MB or 2GB: %w", err)
+	}
+	if value < 0 {
+		return 0, fmt.Errorf("size must not be negative")
+	}
+	return value * multiplier, nil
 }

--- a/desktopexporter/config_test.go
+++ b/desktopexporter/config_test.go
@@ -1,0 +1,87 @@
+package desktopexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseByteSize(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    int64
+		wantErr bool
+	}{
+		{input: "", want: -1},
+		{input: "  ", want: -1},
+		{input: "0", want: 0},
+		{input: "1024", want: 1024},
+		{input: "512MB", want: 512 << 20},
+		{input: "2GB", want: 2 << 30},
+		{input: "1TB", want: 1 << 40},
+		{input: "10kb", want: 10 << 10},
+		{input: "1gB", want: 1 << 30},
+		{input: "100 KB", want: 100 << 10},
+		{input: "7B", want: 7},
+		{input: "banana", wantErr: true},
+		{input: "12XB", wantErr: true},
+		{input: "-5MB", wantErr: true},
+		{input: "1.5GB", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got, err := parseByteSize(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{
+			name: "defaults are valid",
+			cfg:  Config{Endpoint: "localhost:8000"},
+		},
+		{
+			name: "valid max size",
+			cfg:  Config{Endpoint: "localhost:8000", DbMaxSize: "2GB"},
+		},
+		{
+			name: "zero disables retention",
+			cfg:  Config{Endpoint: "localhost:8000", DbMaxSize: "0"},
+		},
+		{
+			name:    "reserved port",
+			cfg:     Config{Endpoint: "localhost:8888"},
+			wantErr: "port 8888",
+		},
+		{
+			name:    "invalid max size",
+			cfg:     Config{Endpoint: "localhost:8000", DbMaxSize: "lots"},
+			wantErr: "invalid db_max_size",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}

--- a/desktopexporter/exporter.go
+++ b/desktopexporter/exporter.go
@@ -5,7 +5,9 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -19,9 +21,23 @@ import (
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/spans"
 )
 
+const (
+	// retentionInterval is how often the retention loop checks the store size.
+	retentionInterval = 30 * time.Second
+
+	// Default store size caps applied when db_max_size is unset. In-memory
+	// mode gets a tighter default because the data competes with everything
+	// else for RAM; a database file can afford more room.
+	defaultMaxSizeInMemory = 512 << 20 // 512 MB
+	defaultMaxSizeOnDisk   = 2 << 30   // 2 GB
+)
+
 type desktopExporter struct {
 	server *server.Server
 	store  *store.Store
+
+	retentionCancel context.CancelFunc
+	retentionDone   chan struct{}
 }
 
 func newDesktopExporter(cfg *Config) (*desktopExporter, error) {
@@ -36,10 +52,48 @@ func newDesktopExporter(cfg *Config) (*desktopExporter, error) {
 		return nil, err
 	}
 
+	// Config is already validated, so the only parse outcomes are a size,
+	// 0 (disabled), or -1 (unset: apply the mode-dependent default).
+	maxBytes, err := parseByteSize(cfg.DbMaxSize)
+	if err != nil {
+		str.Close()
+		return nil, err
+	}
+	if maxBytes < 0 {
+		if cfg.Db == "" {
+			maxBytes = defaultMaxSizeInMemory
+		} else {
+			maxBytes = defaultMaxSizeOnDisk
+		}
+	}
+	// The cap lives on the store so getStats can report it alongside usage.
+	str.SetRetentionCap(maxBytes)
+
 	return &desktopExporter{
 		server: srv,
 		store:  str,
 	}, nil
+}
+
+// runRetentionLoop enforces the store size cap every retentionInterval until
+// ctx is cancelled. It closes done on exit so Shutdown can wait for the last
+// enforcement pass to finish before closing the store underneath it.
+func (e *desktopExporter) runRetentionLoop(ctx context.Context, done chan<- struct{}) {
+	defer close(done)
+
+	ticker := time.NewTicker(retentionInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := e.store.EnforceRetention(ctx, e.store.RetentionCap()); err != nil {
+				log.Printf("retention enforcement failed: %v", err)
+			}
+		}
+	}
 }
 
 func (e *desktopExporter) pushTraces(ctx context.Context, source ptrace.Traces) error {
@@ -71,10 +125,26 @@ func (e *desktopExporter) Start(ctx context.Context, host component.Host) error 
 		}
 
 	}()
+
+	if e.store.RetentionCap() > 0 {
+		// The loop gets its own context rather than the startup ctx, which
+		// the collector cancels once Start returns.
+		retentionCtx, cancel := context.WithCancel(context.Background())
+		e.retentionCancel = cancel
+		e.retentionDone = make(chan struct{})
+		go e.runRetentionLoop(retentionCtx, e.retentionDone)
+	}
 	return nil
 }
 
 func (e *desktopExporter) Shutdown(ctx context.Context) error {
+	// Stop the retention loop and wait for any in-flight enforcement pass,
+	// so the store isn't closed out from under it.
+	if e.retentionCancel != nil {
+		e.retentionCancel()
+		<-e.retentionDone
+	}
+
 	// Close server first (stops accepting new requests)
 	if err := e.server.Close(); err != nil {
 		return err

--- a/desktopexporter/internal/server/jsonrpc_handler.go
+++ b/desktopexporter/internal/server/jsonrpc_handler.go
@@ -485,7 +485,13 @@ func (h *JSONRPCHandler) getTraceSpanCount(ctx context.Context, req *jsonrpc2.Re
 }
 
 func (h *JSONRPCHandler) getStats(ctx context.Context) (any, error) {
-	result, err := stats.GetStats(ctx, h.store.DB())
+	sizeBytes, err := h.store.SizeBytes(ctx)
+	if err != nil {
+		log.Printf("Error measuring store size: %v", err)
+		return nil, mapStoreError(err)
+	}
+
+	result, err := stats.GetStats(ctx, h.store.DB(), sizeBytes, h.store.RetentionCap())
 	if err != nil {
 		log.Printf("Error getting stats: %v", err)
 		return nil, mapStoreError(err)

--- a/desktopexporter/internal/store/retention.go
+++ b/desktopexporter/internal/store/retention.go
@@ -1,0 +1,199 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+)
+
+var ErrRetentionInternal = errors.New("retention internal error")
+
+const (
+	// pruneFraction is the share of the oldest telemetry (by time percentile)
+	// deleted per pruning round. Small enough that one round rarely erases
+	// history someone is actively looking at; EnforceRetention loops when a
+	// single round doesn't free enough space.
+	pruneFraction = 0.10
+
+	// maxPruneRounds bounds the prune-measure loop within one enforcement
+	// pass. Deleted bytes don't map linearly to rows, so a round can
+	// under-deliver; three compounding rounds (~27%) is plenty for one pass,
+	// and the next pass picks up from there.
+	maxPruneRounds = 3
+)
+
+// SizeBytes reports the current size of the telemetry store.
+//
+// In disk mode this is the size of the database file plus its write-ahead
+// log, which is what actually occupies the user's disk. In in-memory mode
+// it is the total tracked by DuckDB's duckdb_memory() table function, since
+// there is no file to measure.
+func (s *Store) SizeBytes(ctx context.Context) (int64, error) {
+	if s.dbPath == "" {
+		var size int64
+		err := s.db.QueryRowContext(ctx,
+			`select coalesce(sum(memory_usage_bytes), 0) from duckdb_memory()`,
+		).Scan(&size)
+		if err != nil {
+			return 0, fmt.Errorf("SizeBytes: %w: %w", ErrRetentionInternal, err)
+		}
+		return size, nil
+	}
+
+	var total int64
+	for _, path := range []string{s.dbPath, s.dbPath + ".wal"} {
+		info, err := os.Stat(path)
+		if errors.Is(err, fs.ErrNotExist) {
+			// The WAL is transient; it not existing is normal.
+			continue
+		}
+		if err != nil {
+			return 0, fmt.Errorf("SizeBytes: %w: %w", ErrRetentionInternal, err)
+		}
+		total += info.Size()
+	}
+	return total, nil
+}
+
+// EnforceRetention prunes the oldest telemetry until the store fits within
+// maxBytes. maxBytes <= 0 disables enforcement. Each round deletes the oldest
+// pruneFraction of every signal (by time percentile) and checkpoints so
+// DuckDB reclaims the space, re-measuring between rounds.
+func (s *Store) EnforceRetention(ctx context.Context, maxBytes int64) error {
+	if maxBytes <= 0 {
+		return nil
+	}
+
+	for round := 0; round < maxPruneRounds; round++ {
+		size, err := s.SizeBytes(ctx)
+		if err != nil {
+			return err
+		}
+		if size <= maxBytes {
+			return nil
+		}
+
+		if err := s.pruneOldestSpans(ctx); err != nil {
+			return err
+		}
+		if err := s.pruneOldestLogs(ctx); err != nil {
+			return err
+		}
+		if err := s.pruneOldestDatapoints(ctx); err != nil {
+			return err
+		}
+
+		// Checkpoint flushes the WAL and lets DuckDB reuse the freed blocks;
+		// without it the file/memory measurement would not move.
+		if _, err := s.db.ExecContext(ctx, `checkpoint`); err != nil {
+			return fmt.Errorf("EnforceRetention: %w: %w", ErrRetentionInternal, err)
+		}
+	}
+	return nil
+}
+
+// pruneCutoff returns the timestamp below which rows should be deleted,
+// i.e. the pruneFraction percentile of the given time expression. Returns
+// (0, false) when the table is empty.
+func (s *Store) pruneCutoff(ctx context.Context, query string) (int64, bool, error) {
+	var cutoff sql.NullInt64
+	if err := s.db.QueryRowContext(ctx, query, pruneFraction).Scan(&cutoff); err != nil {
+		return 0, false, fmt.Errorf("pruneCutoff: %w: %w", ErrRetentionInternal, err)
+	}
+	return cutoff.Int64, cutoff.Valid, nil
+}
+
+// pruneOldestSpans deletes the oldest fraction of spans along with their
+// events, links, and attributes. Attribute rows for events and links carry
+// the owning span_id (enforced by chk_attributes_one_owner), so a single
+// span_id predicate covers all three owners. Leaves first, spans last.
+func (s *Store) pruneOldestSpans(ctx context.Context) error {
+	cutoff, ok, err := s.pruneCutoff(ctx,
+		`select cast(quantile_cont(start_time, ?) as bigint) from spans`)
+	if err != nil || !ok {
+		return err
+	}
+
+	for _, q := range []string{
+		`delete from attributes where span_id in (select span_id from spans where start_time < ?)`,
+		`delete from links where span_id in (select span_id from spans where start_time < ?)`,
+		`delete from events where span_id in (select span_id from spans where start_time < ?)`,
+		`delete from spans where start_time < ?`,
+	} {
+		if _, err := s.db.ExecContext(ctx, q, cutoff); err != nil {
+			return fmt.Errorf("pruneOldestSpans: %w: %w", ErrRetentionInternal, err)
+		}
+	}
+	return nil
+}
+
+// pruneOldestLogs deletes the oldest fraction of logs and their attributes.
+// Logs may arrive with timestamp = 0 (unset); observed_timestamp is the
+// fallback, mirroring how GetStats computes lastReceived.
+func (s *Store) pruneOldestLogs(ctx context.Context) error {
+	const logTime = `coalesce(nullif(timestamp, 0), observed_timestamp)`
+
+	cutoff, ok, err := s.pruneCutoff(ctx,
+		`select cast(quantile_cont(`+logTime+`, ?) as bigint) from logs`)
+	if err != nil || !ok {
+		return err
+	}
+
+	for _, q := range []string{
+		`delete from attributes where log_id in (select id from logs where ` + logTime + ` < ?)`,
+		`delete from logs where ` + logTime + ` < ?`,
+	} {
+		if _, err := s.db.ExecContext(ctx, q, cutoff); err != nil {
+			return fmt.Errorf("pruneOldestLogs: %w: %w", ErrRetentionInternal, err)
+		}
+	}
+	return nil
+}
+
+// pruneOldestDatapoints deletes the oldest fraction of datapoints with their
+// exemplars and attributes, then sweeps metric_ingests and metric_streams
+// rows that no longer own any datapoints. The identity sweep matters:
+// metric_ingests grows by one row per OTLP batch, so leaving orphans behind
+// would let the store creep back over the cap with rows pruning can't touch.
+// A swept stream that is still live gets recreated by ingest's find-or-insert.
+func (s *Store) pruneOldestDatapoints(ctx context.Context) error {
+	cutoff, ok, err := s.pruneCutoff(ctx,
+		`select cast(quantile_cont(timestamp, ?) as bigint) from datapoints`)
+	if err != nil || !ok {
+		return err
+	}
+
+	doomed := `(select id from datapoints where timestamp < ?)`
+	for _, q := range []string{
+		`delete from attributes where exemplar_id in (select id from exemplars where datapoint_id in ` + doomed + `)`,
+		`delete from attributes where datapoint_id in ` + doomed,
+		`delete from exemplars where datapoint_id in ` + doomed,
+		`delete from datapoints where timestamp < ?`,
+	} {
+		if _, err := s.db.ExecContext(ctx, q, cutoff); err != nil {
+			return fmt.Errorf("pruneOldestDatapoints: %w: %w", ErrRetentionInternal, err)
+		}
+	}
+
+	// Orphan sweep: ingest batches whose datapoints are all gone, then
+	// streams whose ingest batches are all gone. Ordering matters for the
+	// FK chain (attributes -> metric_ingests -> metric_streams).
+	for _, q := range []string{
+		`delete from attributes where metric_ingest_id in (
+			select id from metric_ingests mi
+			where not exists (select 1 from datapoints d where d.metric_ingest_id = mi.id)
+		)`,
+		`delete from metric_ingests mi
+			where not exists (select 1 from datapoints d where d.metric_ingest_id = mi.id)`,
+		`delete from metric_streams ms
+			where not exists (select 1 from metric_ingests mi where mi.stream_id = ms.id)`,
+	} {
+		if _, err := s.db.ExecContext(ctx, q); err != nil {
+			return fmt.Errorf("pruneOldestDatapoints: %w: %w", ErrRetentionInternal, err)
+		}
+	}
+	return nil
+}

--- a/desktopexporter/internal/store/retention_test.go
+++ b/desktopexporter/internal/store/retention_test.go
@@ -1,0 +1,179 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedSpans inserts n spans with start_time = i * 1ms (i in [0, n)), each with
+// one fat attribute row so pruning visibly moves the size measurement.
+func seedSpans(t *testing.T, s *Store, n int) {
+	t.Helper()
+	_, err := s.DB().Exec(`
+		insert into spans (trace_id, span_id, name, start_time, end_time)
+		select uuid(), uuid(), 'span-' || range, range * 1000000, range * 1000000 + 500
+		from range(?)`, n)
+	require.NoError(t, err)
+	_, err = s.DB().Exec(`
+		insert into attributes (span_id, scope, key, value, type)
+		select span_id, 'span', 'pad', repeat('x', 500), 'string' from spans`)
+	require.NoError(t, err)
+}
+
+// seedLogs inserts n logs. Odd rows get timestamp = 0 to exercise the
+// observed_timestamp fallback in the prune cutoff.
+func seedLogs(t *testing.T, s *Store, n int) {
+	t.Helper()
+	_, err := s.DB().Exec(`
+		insert into logs (id, timestamp, observed_timestamp, body)
+		select uuid(),
+			case when range % 2 = 0 then range * 1000000 else 0 end,
+			range * 1000000,
+			repeat('y', 200)
+		from range(?)`, n)
+	require.NoError(t, err)
+}
+
+// seedDatapoints inserts n datapoints for the given stream/ingest pair with
+// timestamp = startTime + i * 1ms.
+func seedDatapoints(t *testing.T, s *Store, streamID, ingestID string, n int, startTime int64) {
+	t.Helper()
+	_, err := s.DB().Exec(`insert into metric_streams (id, name, metric_type) values (?, 'metric-' || ?, 'Gauge') on conflict do nothing`, streamID, streamID)
+	require.NoError(t, err)
+	_, err = s.DB().Exec(`insert into metric_ingests (id, stream_id) values (?, ?)`, ingestID, streamID)
+	require.NoError(t, err)
+	_, err = s.DB().Exec(`
+		insert into datapoints (id, stream_id, metric_ingest_id, timestamp, double_value, value_type)
+		select uuid(), ?::uuid, ?::uuid, ? + range * 1000000, range, 'double'
+		from range(?)`, streamID, ingestID, startTime, n)
+	require.NoError(t, err)
+}
+
+func count(t *testing.T, s *Store, table string) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, s.DB().QueryRow(`select count(*) from `+table).Scan(&n))
+	return n
+}
+
+func TestSizeBytesInMemory(t *testing.T) {
+	ctx := context.Background()
+	s, err := NewStore(ctx, "")
+	require.NoError(t, err)
+	defer s.Close()
+
+	empty, err := s.SizeBytes(ctx)
+	require.NoError(t, err)
+
+	seedSpans(t, s, 5000)
+
+	seeded, err := s.SizeBytes(ctx)
+	require.NoError(t, err)
+	assert.Greater(t, seeded, empty, "size should grow with data")
+}
+
+func TestSizeBytesOnDisk(t *testing.T) {
+	ctx := context.Background()
+	s, err := NewStore(ctx, filepath.Join(t.TempDir(), "retention_test.db"))
+	require.NoError(t, err)
+	defer s.Close()
+
+	seedSpans(t, s, 5000)
+	_, err = s.DB().Exec(`checkpoint`)
+	require.NoError(t, err)
+
+	size, err := s.SizeBytes(ctx)
+	require.NoError(t, err)
+	assert.Positive(t, size, "database file should have a measurable size")
+}
+
+func TestEnforceRetentionPrunesOldest(t *testing.T) {
+	ctx := context.Background()
+	s, err := NewStore(ctx, "")
+	require.NoError(t, err)
+	defer s.Close()
+
+	const n = 10000
+	seedSpans(t, s, n)
+	seedLogs(t, s, n)
+	seedDatapoints(t, s, "11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222", n, 0)
+
+	// A cap of 1 byte is unreachable: enforcement should prune its bounded
+	// number of rounds and stop, not loop forever.
+	require.NoError(t, s.EnforceRetention(ctx, 1))
+
+	for _, table := range []string{"spans", "logs", "datapoints"} {
+		remaining := count(t, s, table)
+		assert.Less(t, remaining, int64(n), "%s should have been pruned", table)
+		assert.Positive(t, remaining, "%s should not have been emptied", table)
+	}
+
+	// The survivors must be the newest rows.
+	var minStart int64
+	require.NoError(t, s.DB().QueryRow(`select min(start_time) from spans`).Scan(&minStart))
+	assert.Positive(t, minStart, "the oldest spans should be gone")
+
+	// No dangling attributes: every attribute's span must still exist.
+	var orphans int64
+	require.NoError(t, s.DB().QueryRow(`
+		select count(*) from attributes a
+		where a.span_id is not null
+		and not exists (select 1 from spans sp where sp.span_id = a.span_id)`).Scan(&orphans))
+	assert.Zero(t, orphans, "pruning must not leave orphaned attributes")
+}
+
+func TestEnforceRetentionSweepsOrphanedMetricIdentity(t *testing.T) {
+	ctx := context.Background()
+	s, err := NewStore(ctx, "")
+	require.NoError(t, err)
+	defer s.Close()
+
+	const oldStream = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	const oldIngest = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	const liveStream = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+	const liveIngest = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+
+	// One stream whose datapoints are all ancient, one with recent data far
+	// enough ahead that pruning rounds never reach it.
+	seedDatapoints(t, s, oldStream, oldIngest, 1000, 0)
+	seedDatapoints(t, s, liveStream, liveIngest, 9000, 1_000_000_000_000)
+
+	require.NoError(t, s.EnforceRetention(ctx, 1))
+
+	var oldStreams, oldIngests, liveStreams int64
+	require.NoError(t, s.DB().QueryRow(`select count(*) from metric_streams where id = ?::uuid`, oldStream).Scan(&oldStreams))
+	require.NoError(t, s.DB().QueryRow(`select count(*) from metric_ingests where id = ?::uuid`, oldIngest).Scan(&oldIngests))
+	require.NoError(t, s.DB().QueryRow(`select count(*) from metric_streams where id = ?::uuid`, liveStream).Scan(&liveStreams))
+
+	assert.Zero(t, oldStreams, "fully-pruned stream should be swept")
+	assert.Zero(t, oldIngests, "ingest with no remaining datapoints should be swept")
+	assert.Equal(t, int64(1), liveStreams, "stream with surviving datapoints must remain")
+}
+
+func TestEnforceRetentionDisabled(t *testing.T) {
+	ctx := context.Background()
+	s, err := NewStore(ctx, "")
+	require.NoError(t, err)
+	defer s.Close()
+
+	seedSpans(t, s, 1000)
+
+	require.NoError(t, s.EnforceRetention(ctx, 0))
+	assert.Equal(t, int64(1000), count(t, s, "spans"), "cap of 0 must disable pruning")
+}
+
+func TestEnforceRetentionUnderCap(t *testing.T) {
+	ctx := context.Background()
+	s, err := NewStore(ctx, "")
+	require.NoError(t, err)
+	defer s.Close()
+
+	seedSpans(t, s, 1000)
+
+	require.NoError(t, s.EnforceRetention(ctx, 1<<40 /* 1 TB */))
+	assert.Equal(t, int64(1000), count(t, s, "spans"), "store under the cap must not be pruned")
+}

--- a/desktopexporter/internal/store/stats/stats.go
+++ b/desktopexporter/internal/store/stats/stats.go
@@ -21,10 +21,17 @@ func GetTraceSpanCount(ctx context.Context, db *sql.DB, traceID string) (int64, 
 }
 
 // GetStats returns aggregate counts across all telemetry signals as a single
-// JSON object built entirely by DuckDB.
-func GetStats(ctx context.Context, db *sql.DB) (json.RawMessage, error) {
+// JSON object built entirely by DuckDB. sizeBytes and maxSizeBytes describe
+// current storage usage and the retention cap (0 = retention disabled); they
+// are measured by the caller because size lives outside the SQL schema
+// (file stat or duckdb_memory, depending on mode).
+func GetStats(ctx context.Context, db *sql.DB, sizeBytes int64, maxSizeBytes int64) (json.RawMessage, error) {
 	query := `
 		select cast(json_object(
+			'storage', json_object(
+				'sizeBytes',    ?::bigint,
+				'maxSizeBytes', ?::bigint
+			),
 			'traces', (select json_object(
 				'traceCount',   count(distinct trace_id),
 				'spanCount',    count(*),
@@ -61,7 +68,7 @@ func GetStats(ctx context.Context, db *sql.DB) (json.RawMessage, error) {
 	`
 
 	var raw []byte
-	if err := db.QueryRowContext(ctx, query).Scan(&raw); err != nil {
+	if err := db.QueryRowContext(ctx, query, sizeBytes, maxSizeBytes).Scan(&raw); err != nil {
 		return nil, fmt.Errorf("GetStats: %w: %w", ErrStatsInternal, err)
 	}
 	if raw == nil {

--- a/desktopexporter/internal/store/stats/stats_test.go
+++ b/desktopexporter/internal/store/stats/stats_test.go
@@ -51,9 +51,15 @@ func mustDecodeSpanID(s string) [8]byte {
 }
 
 type statsJSON struct {
-	Traces  traceStatsJSON  `json:"traces"`
-	Logs    logStatsJSON    `json:"logs"`
-	Metrics metricStatsJSON `json:"metrics"`
+	Storage storageStatsJSON `json:"storage"`
+	Traces  traceStatsJSON   `json:"traces"`
+	Logs    logStatsJSON     `json:"logs"`
+	Metrics metricStatsJSON  `json:"metrics"`
+}
+
+type storageStatsJSON struct {
+	SizeBytes    float64 `json:"sizeBytes"`
+	MaxSizeBytes float64 `json:"maxSizeBytes"`
 }
 
 type traceStatsJSON struct {
@@ -78,7 +84,9 @@ type metricStatsJSON struct {
 
 func getStats(t *testing.T, s *store.Store, ctx context.Context) statsJSON {
 	t.Helper()
-	raw, err := stats.GetStats(ctx, s.DB())
+	sizeBytes, err := s.SizeBytes(ctx)
+	require.NoError(t, err)
+	raw, err := stats.GetStats(ctx, s.DB(), sizeBytes, s.RetentionCap())
 	require.NoError(t, err)
 	var result statsJSON
 	require.NoError(t, json.Unmarshal(raw, &result))

--- a/desktopexporter/internal/store/store.go
+++ b/desktopexporter/internal/store/store.go
@@ -21,9 +21,26 @@ var (
 )
 
 type Store struct {
-	db   *sql.DB
-	conn driver.Conn
-	mu   sync.Mutex
+	db     *sql.DB
+	conn   driver.Conn
+	dbPath string // empty means in-memory mode
+	mu     sync.Mutex
+
+	// retentionCapBytes is the store size cap enforced by EnforceRetention
+	// and reported by getStats. 0 means retention is disabled. Set once via
+	// SetRetentionCap before the store is shared; read without locking.
+	retentionCapBytes int64
+}
+
+// SetRetentionCap sets the store size cap in bytes. Call before the store is
+// shared across goroutines.
+func (s *Store) SetRetentionCap(bytes int64) {
+	s.retentionCapBytes = bytes
+}
+
+// RetentionCap returns the store size cap in bytes; 0 means disabled.
+func (s *Store) RetentionCap() int64 {
+	return s.retentionCapBytes
 }
 
 // NewStore creates a new store for the given database path.
@@ -75,8 +92,9 @@ func NewStore(ctx context.Context, dbPath string) (*Store, error) {
 	}
 
 	return &Store{
-		db:   db,
-		conn: conn,
+		db:     db,
+		conn:   conn,
+		dbPath: dbPath,
 	}, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func runInteractive(params otelcol.CollectorSettings) error {
 
 func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 	var httpPortFlag, grpcPortFlag, browserPortFlag int
-	var hostFlag, dbFlag string
+	var hostFlag, dbFlag, dbMaxSizeFlag string
 	var openBrowserFlag bool
 
 	rootCmd := &cobra.Command{
@@ -92,6 +92,7 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 				`yaml:receivers::otlp::protocols::grpc::endpoint: "` + endpoint(grpcPortFlag) + `"`,
 				`yaml:exporters::desktop::endpoint: "` + endpoint(browserPortFlag) + `"`,
 				`yaml:exporters::desktop::db: ` + dbFlag,
+				`yaml:exporters::desktop::db_max_size: "` + dbMaxSizeFlag + `"`,
 				`yaml:service::pipelines::traces::receivers: [otlp]`,
 				`yaml:service::pipelines::traces::exporters: [desktop]`,
 				`yaml:service::pipelines::metrics::receivers: [otlp]`,
@@ -124,6 +125,7 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 	rootCmd.Flags().IntVar(&browserPortFlag, "browser-port", 8000, "The port number where we expose our data")
 	rootCmd.Flags().StringVar(&hostFlag, "host", "localhost", "The host where we expose our all endpoints (OTLP receivers and browser). Use '::' or '0.0.0.0' to listen on all interfaces.")
 	rootCmd.Flags().StringVar(&dbFlag, "db", "", "The path of your database file. Omitting this flag opens DuckDB in in-memory mode, with no data persisted to disk.")
+	rootCmd.Flags().StringVar(&dbMaxSizeFlag, "db-max-size", "", "Maximum size of the telemetry store (e.g. 512MB, 2GB). The oldest telemetry is pruned once the limit is reached. Use 0 to disable pruning. Defaults to 512MB in in-memory mode and 2GB with a database file.")
 
 	return rootCmd
 }


### PR DESCRIPTION
1. --db-max-size flag: human-readable cap that defaults to 512MB in-memory or 2GB on-disk when unset. Passing 0 disables the cap. Wired through main.go → yaml config → Config with parse validation, though this will likely change because I'm about to poke at the collector again.
2. `Store.SizeBytes`: measures usage via file stat (db + WAL) on disk, duckdb_memory() in-memory
3. `Store.EnforceRetention`: when over the cap, prunes the oldest 10% of each signal (spans, logs, datapoints) by time percentile, FK-safe leaves-first deletes, then CHECKPOINT; loops up to 3 rounds. Sweeps orphaned metric_ingests/metric_streams so identity tables can't creep and/or be weirdos and generally remain aware of what the hell they are doing here.
4. Retention loop in the exporter: 30s ticker started in Start with its own context, cancelled and awaited in Shutdown before the store closes
5. `getStats` now reports storage.sizeBytes / storage.maxSizeBytes so the UI can warn
6. Tests: retention suite (pruning, orphan sweep, disabled/under-cap no-ops, both size modes) plus config/parser table tests
7. README flag documented with defaults and example.
Side quest: filed [#256](https://github.com/CtrlSpice/otel-desktop-viewer/issues/256) to bump the collector deps (v0.126.0 → v0.156.0) on its own branch later.

Closes #237 when it lands. 