### PR TITLE
chore: add dependabot config, pin docker base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      opentelemetry:
+        patterns:
+          - "go.opentelemetry.io/*"
+
+  - package-ecosystem: npm
+    directory: /desktopexporter/internal/frontend
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # svelte-check can't run the Go-based TS 7 compiler; expected to be
+      # unblocked by TS 7.1 (~Oct 2026). Remove once svelte-check supports it.
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ COPY . .
 # Build the application from source
 RUN go build -o otel-desktop-viewer .
 
-FROM debian:latest
+# Full image (not slim): the duckdb-go cgo runtime needs the complete
+# library surface, which slim variants have broken before.
+FROM debian:13
 
 # Copy runtime dependencies from build stage
 COPY --from=golang /usr/lib/*/libstdc++.so.6* /usr/lib/


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with weekly update PRs for gomod, npm, and github-actions; collector modules grouped into one PR, npm minors/patches grouped, TypeScript majors ignored until svelte-check supports TS 7 (~7.1, Oct 2026)
- Pin runtime base image from `debian:latest` to `debian:13` for reproducible builds; full image (not slim) because the duckdb-go cgo runtime has broken on slim variants before

## Test plan
- [x] debian:13 is what latest currently resolves to, so no runtime change
- [ ] Release workflow docker build confirms

Made with [Cursor](https://cursor.com)