### PR TITLE
fix: guard sharedcomponent map with a mutex

### DIFF
--- a/desktopexporter/internal/sharedcomponent/sharedcomponent.go
+++ b/desktopexporter/internal/sharedcomponent/sharedcomponent.go
@@ -26,6 +26,7 @@ import (
 // SharedComponents a map that keeps reference of all created instances for a given configuration,
 // and ensures that the shared state is started and stopped only once.
 type SharedComponents[K comparable, V component.Component] struct {
+	mu    sync.Mutex
 	comps map[K]*SharedComponent[V]
 }
 
@@ -39,6 +40,8 @@ func NewSharedComponents[K comparable, V component.Component]() *SharedComponent
 // GetOrAdd returns the already created instance if exists, otherwise creates a new instance
 // and adds it to the map of references.
 func (scs *SharedComponents[K, V]) GetOrAdd(key K, create func() (V, error)) (*SharedComponent[V], error) {
+	scs.mu.Lock()
+	defer scs.mu.Unlock()
 	if c, ok := scs.comps[key]; ok {
 		return c, nil
 	}
@@ -48,7 +51,11 @@ func (scs *SharedComponents[K, V]) GetOrAdd(key K, create func() (V, error)) (*S
 	}
 	newComp := &SharedComponent[V]{
 		component: comp,
+		// Runs from Shutdown's stopOnce, after GetOrAdd has released the
+		// lock, so taking it here cannot deadlock.
 		removeFunc: func() {
+			scs.mu.Lock()
+			defer scs.mu.Unlock()
 			delete(scs.comps, key)
 		},
 	}

--- a/desktopexporter/internal/sharedcomponent/sharedcomponent_test.go
+++ b/desktopexporter/internal/sharedcomponent/sharedcomponent_test.go
@@ -1,0 +1,152 @@
+package sharedcomponent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+type mockComponent struct {
+	startCount    atomic.Int32
+	shutdownCount atomic.Int32
+}
+
+func (m *mockComponent) Start(context.Context, component.Host) error {
+	m.startCount.Add(1)
+	return nil
+}
+
+func (m *mockComponent) Shutdown(context.Context) error {
+	m.shutdownCount.Add(1)
+	return nil
+}
+
+func TestGetOrAddReturnsExistingInstance(t *testing.T) {
+	comps := NewSharedComponents[string, *mockComponent]()
+	createCount := 0
+	create := func() (*mockComponent, error) {
+		createCount++
+		return &mockComponent{}, nil
+	}
+
+	first, err := comps.GetOrAdd("key", create)
+	if err != nil {
+		t.Fatalf("GetOrAdd: %v", err)
+	}
+	second, err := comps.GetOrAdd("key", create)
+	if err != nil {
+		t.Fatalf("GetOrAdd: %v", err)
+	}
+
+	if first != second {
+		t.Error("expected the same *SharedComponent for the same key")
+	}
+	if createCount != 1 {
+		t.Errorf("create called %d times, want 1", createCount)
+	}
+}
+
+func TestGetOrAddPropagatesCreateError(t *testing.T) {
+	comps := NewSharedComponents[string, *mockComponent]()
+	wantErr := errors.New("boom")
+
+	if _, err := comps.GetOrAdd("key", func() (*mockComponent, error) {
+		return nil, wantErr
+	}); !errors.Is(err, wantErr) {
+		t.Errorf("got err %v, want %v", err, wantErr)
+	}
+
+	// A failed create must not poison the key.
+	sc, err := comps.GetOrAdd("key", func() (*mockComponent, error) {
+		return &mockComponent{}, nil
+	})
+	if err != nil || sc == nil {
+		t.Errorf("expected successful create after failure, got (%v, %v)", sc, err)
+	}
+}
+
+func TestStartAndShutdownRunOnce(t *testing.T) {
+	comps := NewSharedComponents[string, *mockComponent]()
+	sc, err := comps.GetOrAdd("key", func() (*mockComponent, error) {
+		return &mockComponent{}, nil
+	})
+	if err != nil {
+		t.Fatalf("GetOrAdd: %v", err)
+	}
+	inner := sc.Unwrap()
+
+	ctx := context.Background()
+	for range 3 {
+		if err := sc.Start(ctx, nil); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+	}
+	if got := inner.startCount.Load(); got != 1 {
+		t.Errorf("underlying Start ran %d times, want 1", got)
+	}
+
+	for range 3 {
+		if err := sc.Shutdown(ctx); err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	}
+	if got := inner.shutdownCount.Load(); got != 1 {
+		t.Errorf("underlying Shutdown ran %d times, want 1", got)
+	}
+}
+
+func TestShutdownRemovesKeyForRecreation(t *testing.T) {
+	comps := NewSharedComponents[string, *mockComponent]()
+	create := func() (*mockComponent, error) { return &mockComponent{}, nil }
+
+	first, _ := comps.GetOrAdd("key", create)
+	if err := first.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	second, _ := comps.GetOrAdd("key", create)
+	if first == second {
+		t.Error("expected a fresh *SharedComponent after Shutdown removed the key")
+	}
+}
+
+// TestConcurrentGetOrAddAndShutdown exercises the map under concurrent
+// GetOrAdd and Shutdown calls; meaningful under -race.
+func TestConcurrentGetOrAddAndShutdown(t *testing.T) {
+	comps := NewSharedComponents[string, *mockComponent]()
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for worker := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range 200 {
+				key := fmt.Sprintf("key-%d", (worker+i)%4)
+				sc, err := comps.GetOrAdd(key, func() (*mockComponent, error) {
+					return &mockComponent{}, nil
+				})
+				if err != nil {
+					t.Errorf("GetOrAdd: %v", err)
+					return
+				}
+				if err := sc.Start(ctx, nil); err != nil {
+					t.Errorf("Start: %v", err)
+					return
+				}
+				if i%3 == 0 {
+					if err := sc.Shutdown(ctx); err != nil {
+						t.Errorf("Shutdown: %v", err)
+						return
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
- Adds a `sync.Mutex` to `SharedComponents`, held in `GetOrAdd` and in the `Shutdown`-time `removeFunc`, closing the unguarded map access flagged in #243.
- Holding the lock across `create()` also means two racing callers can't both construct a `desktopExporter` (one store, one HTTP server — duplicates would fight over port 8000).
- Adds a test suite for the package: same-key reuse, create-error propagation, start/shutdown-once semantics, key removal on shutdown, and an 8-goroutine concurrency hammer.

Closes #243

Test plan:
- [x] `go test -race ./internal/sharedcomponent/` passes
- [x] Same test fails under `-race` with the mutex removed (test has teeth)
- [x] Full `go test ./...` in `desktopexporter` passes