### PR TITLE
Restore generics in SignalListDrawer and PageLayout

### DIFF
--- a/desktopexporter/internal/frontend/src/components/shared/Drawer/SignalListDrawer.svelte
+++ b/desktopexporter/internal/frontend/src/components/shared/Drawer/SignalListDrawer.svelte
@@ -17,7 +17,7 @@
   }
 </script>
 
-<script lang="ts">
+<script lang="ts" generics="T">
   import type { Snippet } from 'svelte'
   import { onMount } from 'svelte'
   import VirtualList from '@humanspeak/svelte-virtual-list'
@@ -67,7 +67,9 @@
     drawerId,
     label,
     itemSnippet,
-    itemKey = (item: any) => item.id,
+    // Default assumes items carry an `id` (logs, metrics); pages whose
+    // items key differently (traces: traceID) must pass itemKey.
+    itemKey = (item: T) => (item as { id: string }).id,
     onRefresh,
     refreshPulse = false,
     refreshAsideTip = '',
@@ -77,7 +79,7 @@
     drawerSearch,
     footer,
     children,
-  }: Props<any> = $props()
+  }: Props<T> = $props()
 
   /*
    * Drawer open/closed is a single global preference shared by every

--- a/desktopexporter/internal/frontend/src/components/shared/Drawer/SignalListDrawer.test.ts
+++ b/desktopexporter/internal/frontend/src/components/shared/Drawer/SignalListDrawer.test.ts
@@ -46,8 +46,12 @@ beforeAll(() => {
   }
 })
 
+// Instantiation expression pins the drawer's generic to DrawerItem; passing
+// the bare component would collapse T to unknown and reject our snippet.
+const TypedDrawer = SignalListDrawer<DrawerItem>
+
 function renderDrawer(props: Record<string, unknown> = {}) {
-  return renderWithContexts(SignalListDrawer, {
+  return renderWithContexts(TypedDrawer, {
     items,
     selectedId: null,
     drawerId: 'traces-drawer',

--- a/desktopexporter/internal/frontend/src/components/shared/PageLayout.svelte
+++ b/desktopexporter/internal/frontend/src/components/shared/PageLayout.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script lang="ts" generics="T">
   /*
    * PageLayout: the single top-level layout used by every route.
    *
@@ -97,17 +97,17 @@
     minMainPx,
     minDetailPx,
     resizableStorageKey,
-  }: Props<any> = $props()
+  }: Props<T> = $props()
 
   // No-op snippet for railOnly pages (Home) that render no list -- the
   // drawer's effectivelyOpen=false guarantees this never renders,
   // but the prop is required so we satisfy the type.
-  const noopItem: Snippet<[item: any, selected: boolean]> = $derived(
+  const noopItem: Snippet<[item: T, selected: boolean]> = $derived(
     itemSnippet ?? noopFallback
   )
 </script>
 
-{#snippet noopFallback(_item: any, _selected: boolean)}{/snippet}
+{#snippet noopFallback(_item: T, _selected: boolean)}{/snippet}
 
 <div class="page-layout">
   <SignalListDrawer


### PR DESCRIPTION
- `SignalListDrawer` and `PageLayout` declared `Props<T>` but instantiated it as `Props<any>`, so item types never reached `itemKey` or `itemSnippet`. Both now use Svelte 5's `generics="T"` attribute so `T` is inferred from `items`.
- The drawer's `itemKey` default keeps its `.id` assumption (logs, metrics) via a narrow cast, with a comment noting that differently-keyed pages (traces) must pass their own — all three pages already do.
- The drawer test pins `T` with an instantiation expression (`SignalListDrawer<DrawerItem>`), since passing the bare generic component collapses `T` to `unknown`.

No runtime change: the rebuilt static assets were byte-identical, so this is a type-level-only diff.

Closes #249
