### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,17 +28,17 @@ jobs:
               GOARCH: arm64
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Set up Go
-      uses: actions/setup-go@v7
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
       with:
         go-version: '1.26'
 
     # MSYS2 provides GCC and build tools needed for CGO compilation on Windows
     - name: Set up MSYS2 (Windows)
       if: matrix.os == 'windows-latest'
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
       with:
         msystem: UCRT64
         update: true
@@ -72,10 +72,10 @@ jobs:
         working-directory: desktopexporter/internal/frontend
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Set up Node
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         node-version: '24'
         cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: npm
@@ -28,7 +28,7 @@ jobs:
       - name: Build embedded frontend
         run: make build-ts
       - name: Upload embedded frontend
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: embedded-frontend
           path: desktopexporter/internal/server/static/
@@ -62,23 +62,23 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
       - name: Download embedded frontend
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: embedded-frontend
           path: desktopexporter/internal/server/static/
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: '1.26'
       - name: Tidy Go module
         run: go mod tidy
       - name: Set up MSYS2 (Windows)
         if: matrix.os == 'windows-latest'
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
           msystem: UCRT64
           update: true
@@ -91,17 +91,17 @@ jobs:
           echo "C:\msys64\ucrt64\bin" >> $env:GITHUB_PATH
       - name: Set up Docker Buildx
         if: matrix.goos == 'linux'
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - name: Log in to GitHub Container Registry
         if: matrix.goos == 'linux'
-        uses: docker/login-action@v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
         id: goreleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser-pro
           version: v2.16.0
@@ -134,7 +134,7 @@ jobs:
           echo "Partial artifacts ready in $dir:"
           find "$dir" -type f | head -20
       - name: Cache GoReleaser contexts
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: dist/${{ matrix.goos }}_${{ matrix.goarch }}
           key: ${{ matrix.goos }}-${{ matrix.goarch }}-${{ github.sha }}
@@ -147,35 +147,35 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: '1.26'
       - name: Restore GoReleaser build artifacts (darwin-amd64)
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: dist/darwin_amd64
           key: darwin-amd64-${{ github.sha }}
       - name: Restore GoReleaser build artifacts (darwin-arm64)
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: dist/darwin_arm64
           key: darwin-arm64-${{ github.sha }}
       - name: Restore GoReleaser build artifacts (linux-amd64)
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: dist/linux_amd64
           key: linux-amd64-${{ github.sha }}
       - name: Restore GoReleaser build artifacts (linux-arm64)
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: dist/linux_arm64
           key: linux-arm64-${{ github.sha }}
       - name: Restore GoReleaser build artifacts (windows-amd64)
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: dist/windows_amd64
           key: windows-amd64-${{ github.sha }}
@@ -207,7 +207,7 @@ jobs:
           find dist -type f | head -50
       - name: Generate release app token
         id: release-app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -216,17 +216,17 @@ jobs:
             otel-desktop-viewer
             homebrew-otel-desktop-viewer
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Complete release
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser-pro
           version: v2.16.0

--- a/.github/workflows/test-go-install.yml
+++ b/.github/workflows/test-go-install.yml
@@ -10,16 +10,16 @@ jobs:
   test-go-install-windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Set up Go
-      uses: actions/setup-go@v7
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
       with:
         go-version: '1.26'
 
     # MSYS2 provides GCC and build tools needed for CGO compilation on Windows
     - name: Set up MSYS2 (Windows)
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
       with:
         msystem: UCRT64
         update: true


### PR DESCRIPTION
## Summary
- Pins all 31 action references across the three workflows to full commit SHAs, with the version tag preserved as a comment (e.g. `actions/checkout@3d3c42e... # v7`).
- Mutable tags like `@v7` can be moved by whoever controls the action's repo, so a hijacked action can silently run malicious code with our workflow tokens — the `tj-actions/changed-files` compromise worked exactly this way. SHAs freeze what runs.
- Dependabot's existing `github-actions` config bumps pinned SHAs the same way it bumps tags, so the pins won't go stale.
- Resolves all 10 open CodeQL `actions/unpinned-tag` alerts from the security-extended suite.

## Test plan
- [x] `rg 'uses:.*@v\d'` finds no remaining tag-pinned actions
- [x] Each SHA resolved directly from the action repo's tag via the GitHub API
- [ ] CI on this PR exercises checkout/setup-go/setup-node/msys2 pins; release-only pins get exercised on the next release

Made with [Cursor](https://cursor.com)