### PR TITLE
Build frontend in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+**/node_modules
+desktopexporter/internal/frontend/dist
+otel-desktop-viewer
+*.duckdb
+*.db

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -197,6 +197,7 @@ CORS is enabled for local dev (Vite on port 3001).
 **Static assets**
 
 - Embedded via `//go:embed static` after `make build-ts` (which wipes `server/static/` before copying, so stale hashed assets do not accumulate)
+- The root `Dockerfile` builds the frontend in a Node stage before `go build`, so `docker build` embeds the current UI without a local `make build-ts`
 - Frontend iteration uses the Vite dev server (`make dev-ts` on port 3001), which proxies `/rpc` to the Go server
 
 ### JSON-RPC methods
@@ -356,7 +357,6 @@ These appear in older notes or collector capabilities but are **not** part of th
 - `--config` YAML file exposed on the CLI (inline flag-built config only)
 - `batch` processor in default pipelines
 - `exporterhelper.WithRetry()` on the desktop exporter
-- Fresh frontend embed in the Docker image (`Dockerfile` runs `go build` only; use `make build-ts` before building the image, or fix #253)
 
 ## Related files
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+FROM node:24-bookworm AS frontend
+
+WORKDIR /frontend
+COPY desktopexporter/internal/frontend/package.json desktopexporter/internal/frontend/package-lock.json ./
+RUN npm ci
+COPY desktopexporter/internal/frontend/ ./
+RUN npm run build
+
 FROM golang:1.26 AS golang
 
 # Install build and runtime dependencies for CGO
@@ -7,11 +15,17 @@ RUN apt-get update && apt-get install -y \
     libstdc++6 \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy source code
 WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY . .
 
-# Build the application from source
+# Embed the UI built in the frontend stage (not committed static/)
+RUN rm -rf desktopexporter/internal/server/static/*
+COPY --from=frontend /frontend/dist/ desktopexporter/internal/server/static/
+
 RUN go build -o otel-desktop-viewer .
 
 # Full image (not slim): the duckdb-go cgo runtime needs the complete

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ docker pull ghcr.io/ctrlspice/otel-desktop-viewer:latest-amd64
 docker pull ghcr.io/ctrlspice/otel-desktop-viewer:latest-arm64
 ```
 
-Or build locally from source:
+Or build locally from source (compiles the frontend and Go binary inside the image):
 
 ```bash
 docker build --tag otel-desktop-viewer:latest .


### PR DESCRIPTION
Multi-stage `Dockerfile`: Node stage runs `npm ci` + `vite build`, Go stage wipes `static/` and embeds fresh `dist/` before `go build`. Adds `.dockerignore`.

Closes #253 once I make a new release