### PR TITLE
Route backend logging through collector zap

### DIFF
--- a/desktopexporter/exporter.go
+++ b/desktopexporter/exporter.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"database/sql/driver"
 	"errors"
-	"fmt"
-	"log"
 	"net/http"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -35,18 +34,19 @@ const (
 type desktopExporter struct {
 	server *server.Server
 	store  *store.Store
+	logger *zap.Logger
 
 	retentionCancel context.CancelFunc
 	retentionDone   chan struct{}
 }
 
-func newDesktopExporter(cfg *Config) (*desktopExporter, error) {
+func newDesktopExporter(cfg *Config, logger *zap.Logger) (*desktopExporter, error) {
 	str, err := store.NewStore(context.Background(), cfg.Db)
 	if err != nil {
 		return nil, err
 	}
 
-	srv, err := server.NewServer(cfg.Endpoint, str)
+	srv, err := server.NewServer(cfg.Endpoint, str, logger)
 	if err != nil {
 		str.Close()
 		return nil, err
@@ -72,6 +72,7 @@ func newDesktopExporter(cfg *Config) (*desktopExporter, error) {
 	return &desktopExporter{
 		server: srv,
 		store:  str,
+		logger: logger,
 	}, nil
 }
 
@@ -90,7 +91,7 @@ func (e *desktopExporter) runRetentionLoop(ctx context.Context, done chan<- stru
 			return
 		case <-ticker.C:
 			if err := e.store.EnforceRetention(ctx, e.store.RetentionCap()); err != nil {
-				log.Printf("retention enforcement failed: %v", err)
+				e.logger.Error("retention enforcement failed", zap.Error(err))
 			}
 		}
 	}
@@ -119,9 +120,9 @@ func (e *desktopExporter) Start(ctx context.Context, host component.Host) error 
 		err := e.server.Start()
 
 		if errors.Is(err, http.ErrServerClosed) {
-			fmt.Printf("server closed\n")
+			e.logger.Info("HTTP server closed")
 		} else if err != nil {
-			fmt.Printf("error listening for server: %s\n", err)
+			e.logger.Error("HTTP server listen failed", zap.Error(err))
 		}
 
 	}()

--- a/desktopexporter/exporter.go
+++ b/desktopexporter/exporter.go
@@ -120,8 +120,9 @@ func (e *desktopExporter) Start(ctx context.Context, host component.Host) error 
 		err := e.server.Start()
 
 		if errors.Is(err, http.ErrServerClosed) {
-			e.logger.Info("HTTP server closed")
-		} else if err != nil {
+			return
+		}
+		if err != nil {
 			e.logger.Error("HTTP server listen failed", zap.Error(err))
 		}
 

--- a/desktopexporter/factory.go
+++ b/desktopexporter/factory.go
@@ -48,7 +48,7 @@ func createMetricsExporter(ctx context.Context, set exporter.Settings, config co
 	}
 
 	exporter, err := exporters.GetOrAdd(desktopCfg, func() (*desktopExporter, error) {
-		return newDesktopExporter(desktopCfg)
+		return newDesktopExporter(desktopCfg, set.Logger)
 	})
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func createLogsExporter(ctx context.Context, set exporter.Settings, config compo
 	}
 
 	e, err := exporters.GetOrAdd(cfg, func() (*desktopExporter, error) {
-		return newDesktopExporter(cfg)
+		return newDesktopExporter(cfg, set.Logger)
 	})
 	if err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func createTracesExporter(ctx context.Context, set exporter.Settings, config com
 	}
 
 	e, err := exporters.GetOrAdd(cfg, func() (*desktopExporter, error) {
-		return newDesktopExporter(cfg)
+		return newDesktopExporter(cfg, set.Logger)
 	})
 	if err != nil {
 		return nil, err

--- a/desktopexporter/internal/server/jsonrpc_handler.go
+++ b/desktopexporter/internal/server/jsonrpc_handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store"
@@ -13,15 +12,17 @@ import (
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/spans"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/stats"
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 	"golang.org/x/exp/jsonrpc2"
 )
 
 type JSONRPCHandler struct {
-	store *store.Store
+	store  *store.Store
+	logger *zap.Logger
 }
 
-func NewJSONRPCHandler(store *store.Store) *JSONRPCHandler {
-	return &JSONRPCHandler{store: store}
+func NewJSONRPCHandler(store *store.Store, logger *zap.Logger) *JSONRPCHandler {
+	return &JSONRPCHandler{store: store, logger: logger}
 }
 
 func (h *JSONRPCHandler) Handle(ctx context.Context, req *jsonrpc2.Request) (any, error) {
@@ -70,21 +71,21 @@ func (h *JSONRPCHandler) Handle(ctx context.Context, req *jsonrpc2.Request) (any
 func (h *JSONRPCHandler) searchTraces(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		log.Printf("Failed to unmarshal params: %v", err)
+		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
 	if len(params) < 2 || len(params) > 3 {
-		log.Printf("Invalid parameter count: %d (expected 2-3)", len(params))
+		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "2-3"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
-	startTime, err := parseTimestampParam(params[0], "startTime")
+	startTime, err := h.parseTimestampParam(params[0], "startTime")
 	if err != nil {
 		return nil, err
 	}
 
-	endTime, err := parseTimestampParam(params[1], "endTime")
+	endTime, err := h.parseTimestampParam(params[1], "endTime")
 	if err != nil {
 		return nil, err
 	}
@@ -94,10 +95,9 @@ func (h *JSONRPCHandler) searchTraces(ctx context.Context, req *jsonrpc2.Request
 		query = params[2]
 	}
 
-	log.Printf("searchTraces query parameter: %+v", query)
 	summaries, err := spans.SearchTraces(ctx, h.store.DB(), startTime, endTime, query)
 	if err != nil {
-		log.Printf("Error searching traces: %v", err)
+		h.logger.Error("searching traces", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 	return summaries, nil
@@ -106,16 +106,16 @@ func (h *JSONRPCHandler) searchTraces(ctx context.Context, req *jsonrpc2.Request
 func (h *JSONRPCHandler) searchSpans(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		log.Printf("Failed to unmarshal params: %v", err)
+		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
 	if len(params) < 1 || len(params) > 2 {
-		log.Printf("Invalid parameter count: %d (expected 1-2)", len(params))
+		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "1-2"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
-	traceID, err := parseIDParam(params[0], ErrInvalidTraceID, normalizeUUID)
+	traceID, err := h.parseIDParam(params[0], ErrInvalidTraceID, normalizeUUID)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (h *JSONRPCHandler) searchSpans(ctx context.Context, req *jsonrpc2.Request)
 
 	result, err := spans.SearchSpans(ctx, h.store.DB(), traceID, query)
 	if err != nil {
-		log.Printf("Error searching spans: %v", err)
+		h.logger.Error("searching spans", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 	return result, nil
@@ -136,7 +136,7 @@ func (h *JSONRPCHandler) searchSpans(ctx context.Context, req *jsonrpc2.Request)
 func (h *JSONRPCHandler) clearTraces(ctx context.Context) (any, error) {
 	err := spans.Clear(ctx, h.store.DB())
 	if err != nil {
-		log.Printf("Error clearing traces: %v", err)
+		h.logger.Error("clearing traces", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 	return "Traces cleared successfully", nil
@@ -145,18 +145,18 @@ func (h *JSONRPCHandler) clearTraces(ctx context.Context) (any, error) {
 func (h *JSONRPCHandler) searchLogs(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		log.Printf("Failed to unmarshal params: %v", err)
+		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 	if len(params) < 2 || len(params) > 3 {
-		log.Printf("Invalid parameter count: %d (expected 2-3)", len(params))
+		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "2-3"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
-	startTime, err := parseTimestampParam(params[0], "startTime")
+	startTime, err := h.parseTimestampParam(params[0], "startTime")
 	if err != nil {
 		return nil, err
 	}
-	endTime, err := parseTimestampParam(params[1], "endTime")
+	endTime, err := h.parseTimestampParam(params[1], "endTime")
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func (h *JSONRPCHandler) searchLogs(ctx context.Context, req *jsonrpc2.Request) 
 	}
 	result, err := logs.Search(ctx, h.store.DB(), startTime, endTime, query)
 	if err != nil {
-		log.Printf("Error searching logs: %v", err)
+		h.logger.Error("searching logs", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 	return result, nil
@@ -175,7 +175,7 @@ func (h *JSONRPCHandler) searchLogs(ctx context.Context, req *jsonrpc2.Request) 
 func (h *JSONRPCHandler) clearLogs(ctx context.Context) (any, error) {
 	err := logs.Clear(ctx, h.store.DB())
 	if err != nil {
-		log.Printf("Error clearing logs: %v", err)
+		h.logger.Error("clearing logs", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 	return "Logs cleared successfully", nil
@@ -186,20 +186,20 @@ func (h *JSONRPCHandler) clearLogs(ctx context.Context) (any, error) {
 func (h *JSONRPCHandler) getLog(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		log.Printf("Failed to unmarshal params: %v", err)
+		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 	if len(params) != 1 {
-		log.Printf("Invalid parameter count: %d (expected 1)", len(params))
+		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "1"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
-	logID, err := parseIDParam(params[0], ErrInvalidLogID, normalizeUUID)
+	logID, err := h.parseIDParam(params[0], ErrInvalidLogID, normalizeUUID)
 	if err != nil {
 		return nil, err
 	}
 	result, err := logs.Get(ctx, h.store.DB(), logID)
 	if err != nil {
-		log.Printf("Error getting log: %v", err)
+		h.logger.Error("getting log", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 	return result, nil
@@ -208,18 +208,18 @@ func (h *JSONRPCHandler) getLog(ctx context.Context, req *jsonrpc2.Request) (any
 func (h *JSONRPCHandler) searchMetricSummaries(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		log.Printf("Failed to unmarshal params: %v", err)
+		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 	if len(params) < 2 || len(params) > 3 {
-		log.Printf("Invalid parameter count: %d (expected 2-3)", len(params))
+		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "2-3"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
-	startTime, err := parseTimestampParam(params[0], "startTime")
+	startTime, err := h.parseTimestampParam(params[0], "startTime")
 	if err != nil {
 		return nil, err
 	}
-	endTime, err := parseTimestampParam(params[1], "endTime")
+	endTime, err := h.parseTimestampParam(params[1], "endTime")
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (h *JSONRPCHandler) searchMetricSummaries(ctx context.Context, req *jsonrpc
 	}
 	summaries, err := metrics.SearchSummaries(ctx, h.store.DB(), startTime, endTime, query)
 	if err != nil {
-		log.Printf("Error searching metric summaries: %v", err)
+		h.logger.Error("searching metric summaries", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 	return summaries, nil
@@ -238,28 +238,28 @@ func (h *JSONRPCHandler) searchMetricSummaries(ctx context.Context, req *jsonrpc
 func (h *JSONRPCHandler) getMetric(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		log.Printf("Failed to unmarshal params: %v", err)
+		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 	if len(params) != 3 {
-		log.Printf("Invalid parameter count: %d (expected 3: streamId, startTime, endTime)", len(params))
+		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "3: streamId, startTime, endTime"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
-	streamID, err := parseIDParam(params[0], ErrInvalidStreamID, normalizeUUID)
+	streamID, err := h.parseIDParam(params[0], ErrInvalidStreamID, normalizeUUID)
 	if err != nil {
 		return nil, err
 	}
-	startTime, err := parseTimestampParam(params[1], "startTime")
+	startTime, err := h.parseTimestampParam(params[1], "startTime")
 	if err != nil {
 		return nil, err
 	}
-	endTime, err := parseTimestampParam(params[2], "endTime")
+	endTime, err := h.parseTimestampParam(params[2], "endTime")
 	if err != nil {
 		return nil, err
 	}
 	result, err := metrics.GetMetric(ctx, h.store.DB(), streamID, startTime, endTime)
 	if err != nil {
-		log.Printf("Error getting metric: %v", err)
+		h.logger.Error("getting metric", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 	return result, nil
@@ -268,7 +268,7 @@ func (h *JSONRPCHandler) getMetric(ctx context.Context, req *jsonrpc2.Request) (
 func (h *JSONRPCHandler) clearMetrics(ctx context.Context) (any, error) {
 	err := metrics.Clear(ctx, h.store.DB())
 	if err != nil {
-		log.Printf("Error clearing metrics: %v", err)
+		h.logger.Error("clearing metrics", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 	return "Metrics cleared successfully", nil
@@ -276,13 +276,13 @@ func (h *JSONRPCHandler) clearMetrics(ctx context.Context) (any, error) {
 
 // deleteSpansByTraceID deletes all spans for one or more traces.
 func (h *JSONRPCHandler) deleteSpansByTraceID(ctx context.Context, req *jsonrpc2.Request) (any, error) {
-	traceIDs, err := parseIDParams(req, ErrInvalidTraceID, normalizeUUID)
+	traceIDs, err := h.parseIDParams(req, ErrInvalidTraceID, normalizeUUID)
 	if err != nil {
 		return nil, err
 	}
 
 	if err := spans.DeleteSpansByTraceIDs(ctx, h.store.DB(), traceIDs); err != nil {
-		log.Printf("Error deleting spans by trace IDs: %v", err)
+		h.logger.Error("deleting spans by trace IDs", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 
@@ -294,13 +294,13 @@ func (h *JSONRPCHandler) deleteSpansByTraceID(ctx context.Context, req *jsonrpc2
 
 // deleteSpanByID deletes one or more specific spans by their IDs.
 func (h *JSONRPCHandler) deleteSpanByID(ctx context.Context, req *jsonrpc2.Request) (any, error) {
-	spanIDs, err := parseIDParams(req, ErrInvalidSpanID, normalizeSpanID)
+	spanIDs, err := h.parseIDParams(req, ErrInvalidSpanID, normalizeSpanID)
 	if err != nil {
 		return nil, err
 	}
 
 	if err := spans.DeleteSpansByIDs(ctx, h.store.DB(), spanIDs); err != nil {
-		log.Printf("Error deleting spans by IDs: %v", err)
+		h.logger.Error("deleting spans by IDs", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 
@@ -312,13 +312,13 @@ func (h *JSONRPCHandler) deleteSpanByID(ctx context.Context, req *jsonrpc2.Reque
 
 // deleteLogByID deletes one or more specific logs by their IDs.
 func (h *JSONRPCHandler) deleteLogByID(ctx context.Context, req *jsonrpc2.Request) (any, error) {
-	logIDs, err := parseIDParams(req, ErrInvalidLogID, normalizeUUID)
+	logIDs, err := h.parseIDParams(req, ErrInvalidLogID, normalizeUUID)
 	if err != nil {
 		return nil, err
 	}
 
 	if err := logs.DeleteLogsByIDs(ctx, h.store.DB(), logIDs); err != nil {
-		log.Printf("Error deleting logs by IDs: %v", err)
+		h.logger.Error("deleting logs by IDs", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 
@@ -331,28 +331,28 @@ func (h *JSONRPCHandler) deleteLogByID(ctx context.Context, req *jsonrpc2.Reques
 func (h *JSONRPCHandler) getTraceAttributes(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		log.Printf("Failed to unmarshal params: %v", err)
+		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
 	if len(params) != 2 {
-		log.Printf("Invalid parameter count: %d (expected 2)", len(params))
+		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "2"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
-	startTime, err := parseTimestampParam(params[0], "startTime")
+	startTime, err := h.parseTimestampParam(params[0], "startTime")
 	if err != nil {
 		return nil, err
 	}
 
-	endTime, err := parseTimestampParam(params[1], "endTime")
+	endTime, err := h.parseTimestampParam(params[1], "endTime")
 	if err != nil {
 		return nil, err
 	}
 
 	attributes, err := spans.GetTraceAttributes(ctx, h.store.DB(), startTime, endTime)
 	if err != nil {
-		log.Printf("Error getting trace attributes: %v", err)
+		h.logger.Error("getting trace attributes", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 
@@ -362,28 +362,28 @@ func (h *JSONRPCHandler) getTraceAttributes(ctx context.Context, req *jsonrpc2.R
 func (h *JSONRPCHandler) getLogAttributes(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		log.Printf("Failed to unmarshal params: %v", err)
+		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
 	if len(params) != 2 {
-		log.Printf("Invalid parameter count: %d (expected 2)", len(params))
+		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "2"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
-	startTime, err := parseTimestampParam(params[0], "startTime")
+	startTime, err := h.parseTimestampParam(params[0], "startTime")
 	if err != nil {
 		return nil, err
 	}
 
-	endTime, err := parseTimestampParam(params[1], "endTime")
+	endTime, err := h.parseTimestampParam(params[1], "endTime")
 	if err != nil {
 		return nil, err
 	}
 
 	attributes, err := logs.GetLogAttributes(ctx, h.store.DB(), startTime, endTime)
 	if err != nil {
-		log.Printf("Error getting log attributes: %v", err)
+		h.logger.Error("getting log attributes", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 
@@ -393,28 +393,28 @@ func (h *JSONRPCHandler) getLogAttributes(ctx context.Context, req *jsonrpc2.Req
 func (h *JSONRPCHandler) getMetricAttributes(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		log.Printf("Failed to unmarshal params: %v", err)
+		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
 	if len(params) != 2 {
-		log.Printf("Invalid parameter count: %d (expected 2)", len(params))
+		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "2"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
-	startTime, err := parseTimestampParam(params[0], "startTime")
+	startTime, err := h.parseTimestampParam(params[0], "startTime")
 	if err != nil {
 		return nil, err
 	}
 
-	endTime, err := parseTimestampParam(params[1], "endTime")
+	endTime, err := h.parseTimestampParam(params[1], "endTime")
 	if err != nil {
 		return nil, err
 	}
 
 	attributes, err := metrics.GetMetricAttributes(ctx, h.store.DB(), startTime, endTime)
 	if err != nil {
-		log.Printf("Error getting metric attributes: %v", err)
+		h.logger.Error("getting metric attributes", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 
@@ -424,23 +424,23 @@ func (h *JSONRPCHandler) getMetricAttributes(ctx context.Context, req *jsonrpc2.
 func (h *JSONRPCHandler) getAttributesByTraceID(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		log.Printf("Failed to unmarshal params: %v", err)
+		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
 	if len(params) != 1 {
-		log.Printf("Invalid parameter count: %d (expected 1)", len(params))
+		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "1"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
-	traceID, err := parseIDParam(params[0], ErrInvalidTraceID, normalizeUUID)
+	traceID, err := h.parseIDParam(params[0], ErrInvalidTraceID, normalizeUUID)
 	if err != nil {
 		return nil, err
 	}
 
 	attributes, err := spans.GetAttributesByTraceID(ctx, h.store.DB(), traceID)
 	if err != nil {
-		log.Printf("Error getting attributes by trace ID: %v", err)
+		h.logger.Error("getting attributes by trace ID", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 
@@ -455,13 +455,13 @@ func (h *JSONRPCHandler) getTraceSpanCount(ctx context.Context, req *jsonrpc2.Re
 	if len(params) != 1 {
 		return nil, jsonrpc2.ErrInvalidParams
 	}
-	traceID, err := parseIDParam(params[0], ErrInvalidTraceID, normalizeUUID)
+	traceID, err := h.parseIDParam(params[0], ErrInvalidTraceID, normalizeUUID)
 	if err != nil {
 		return nil, err
 	}
 	count, err := stats.GetTraceSpanCount(ctx, h.store.DB(), traceID)
 	if err != nil {
-		log.Printf("Error getting trace span count: %v", err)
+		h.logger.Error("getting trace span count", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 	return count, nil
@@ -470,13 +470,13 @@ func (h *JSONRPCHandler) getTraceSpanCount(ctx context.Context, req *jsonrpc2.Re
 func (h *JSONRPCHandler) getStats(ctx context.Context) (any, error) {
 	sizeBytes, err := h.store.SizeBytes(ctx)
 	if err != nil {
-		log.Printf("Error measuring store size: %v", err)
+		h.logger.Error("measuring store size", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 
 	result, err := stats.GetStats(ctx, h.store.DB(), sizeBytes, h.store.RetentionCap())
 	if err != nil {
-		log.Printf("Error getting stats: %v", err)
+		h.logger.Error("getting stats", zap.Error(err))
 		return nil, mapStoreError(err)
 	}
 	return result, nil
@@ -488,15 +488,15 @@ func (h *JSONRPCHandler) getStats(ctx context.Context) (any, error) {
 // returns invalidIDErr (the signal-specific -3200x code). Previously these
 // params went straight into SQL, where a non-string or non-UUID value became
 // a DB cast error reported as a generic internal error.
-func parseIDParams(req *jsonrpc2.Request, invalidIDErr error, normalize func(string) (string, error)) ([]any, error) {
+func (h *JSONRPCHandler) parseIDParams(req *jsonrpc2.Request, invalidIDErr error, normalize func(string) (string, error)) ([]any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		log.Printf("Failed to unmarshal params: %v", err)
+		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
 	if len(params) == 0 {
-		log.Printf("Invalid parameter count: 0 (expected at least 1 ID)")
+		h.logger.Debug("invalid RPC parameter count", zap.Int("count", 0), zap.String("expected", "at least 1 ID"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
@@ -504,12 +504,12 @@ func parseIDParams(req *jsonrpc2.Request, invalidIDErr error, normalize func(str
 	for _, param := range params {
 		s, ok := param.(string)
 		if !ok {
-			log.Printf("Invalid ID type: %T (expected string)", param)
+			h.logger.Debug("invalid ID type", zap.String("expected", "string"), zap.Any("param", param))
 			return nil, invalidIDErr
 		}
 		id, err := normalize(s)
 		if err != nil {
-			log.Printf("Invalid ID %q: %v", s, err)
+			h.logger.Debug("invalid ID", zap.String("id", s), zap.Error(err))
 			return nil, invalidIDErr
 		}
 		ids = append(ids, id)
@@ -521,15 +521,15 @@ func parseIDParams(req *jsonrpc2.Request, invalidIDErr error, normalize func(str
 // paths: searchSpans, getLog, getMetric, getAttributesByTraceID,
 // getTraceSpanCount). Like parseIDParams, a bad value returns the
 // signal-specific -3200x code instead of reaching SQL as a cast error.
-func parseIDParam(param any, invalidIDErr error, normalize func(string) (string, error)) (string, error) {
+func (h *JSONRPCHandler) parseIDParam(param any, invalidIDErr error, normalize func(string) (string, error)) (string, error) {
 	s, ok := param.(string)
 	if !ok {
-		log.Printf("Invalid ID type: %T (expected string)", param)
+		h.logger.Debug("invalid ID type", zap.String("expected", "string"), zap.Any("param", param))
 		return "", invalidIDErr
 	}
 	id, err := normalize(s)
 	if err != nil {
-		log.Printf("Invalid ID %q: %v", s, err)
+		h.logger.Debug("invalid ID", zap.String("id", s), zap.Error(err))
 		return "", invalidIDErr
 	}
 	return id, nil
@@ -567,15 +567,15 @@ func normalizeSpanID(s string) (string, error) {
 // parseTimestampParam parses a timestamp parameter that must be a JSON string
 // containing a base-10 int64. Large integers travel as strings to avoid
 // float64 precision loss in JSON.
-func parseTimestampParam(param any, paramName string) (int64, error) {
+func (h *JSONRPCHandler) parseTimestampParam(param any, paramName string) (int64, error) {
 	s, ok := param.(string)
 	if !ok {
-		log.Printf("Invalid %s type: %T, value: %v (expected string)", paramName, param, param)
+		h.logger.Debug("invalid timestamp param type", zap.String("param", paramName), zap.Any("value", param))
 		return 0, jsonrpc2.ErrInvalidParams
 	}
 	parsed, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
-		log.Printf("Invalid %s string: %v", paramName, err)
+		h.logger.Debug("invalid timestamp param", zap.String("param", paramName), zap.Error(err))
 		return 0, jsonrpc2.ErrInvalidParams
 	}
 	return parsed, nil

--- a/desktopexporter/internal/server/jsonrpc_handler.go
+++ b/desktopexporter/internal/server/jsonrpc_handler.go
@@ -25,6 +25,20 @@ func NewJSONRPCHandler(store *store.Store, logger *zap.Logger) *JSONRPCHandler {
 	return &JSONRPCHandler{store: store, logger: logger}
 }
 
+// handleStoreError maps store errors to JSON-RPC codes and logs only unexpected
+// failures (those that become -32603). Expected outcomes like not-found or
+// invalid query are returned to the client without logging.
+func (h *JSONRPCHandler) handleStoreError(err error) error {
+	if err == nil {
+		return nil
+	}
+	mapped := mapStoreError(err)
+	if mapped == jsonrpc2.ErrInternal {
+		h.logger.Error("store error", zap.Error(err))
+	}
+	return mapped
+}
+
 func (h *JSONRPCHandler) Handle(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	switch req.Method {
 	case "searchTraces":
@@ -71,12 +85,10 @@ func (h *JSONRPCHandler) Handle(ctx context.Context, req *jsonrpc2.Request) (any
 func (h *JSONRPCHandler) searchTraces(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
 	if len(params) < 2 || len(params) > 3 {
-		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "2-3"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
@@ -97,8 +109,7 @@ func (h *JSONRPCHandler) searchTraces(ctx context.Context, req *jsonrpc2.Request
 
 	summaries, err := spans.SearchTraces(ctx, h.store.DB(), startTime, endTime, query)
 	if err != nil {
-		h.logger.Error("searching traces", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 	return summaries, nil
 }
@@ -106,12 +117,10 @@ func (h *JSONRPCHandler) searchTraces(ctx context.Context, req *jsonrpc2.Request
 func (h *JSONRPCHandler) searchSpans(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
 	if len(params) < 1 || len(params) > 2 {
-		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "1-2"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
@@ -127,8 +136,7 @@ func (h *JSONRPCHandler) searchSpans(ctx context.Context, req *jsonrpc2.Request)
 
 	result, err := spans.SearchSpans(ctx, h.store.DB(), traceID, query)
 	if err != nil {
-		h.logger.Error("searching spans", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 	return result, nil
 }
@@ -136,8 +144,7 @@ func (h *JSONRPCHandler) searchSpans(ctx context.Context, req *jsonrpc2.Request)
 func (h *JSONRPCHandler) clearTraces(ctx context.Context) (any, error) {
 	err := spans.Clear(ctx, h.store.DB())
 	if err != nil {
-		h.logger.Error("clearing traces", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 	return "Traces cleared successfully", nil
 }
@@ -145,11 +152,9 @@ func (h *JSONRPCHandler) clearTraces(ctx context.Context) (any, error) {
 func (h *JSONRPCHandler) searchLogs(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 	if len(params) < 2 || len(params) > 3 {
-		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "2-3"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 	startTime, err := h.parseTimestampParam(params[0], "startTime")
@@ -166,8 +171,7 @@ func (h *JSONRPCHandler) searchLogs(ctx context.Context, req *jsonrpc2.Request) 
 	}
 	result, err := logs.Search(ctx, h.store.DB(), startTime, endTime, query)
 	if err != nil {
-		h.logger.Error("searching logs", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 	return result, nil
 }
@@ -175,8 +179,7 @@ func (h *JSONRPCHandler) searchLogs(ctx context.Context, req *jsonrpc2.Request) 
 func (h *JSONRPCHandler) clearLogs(ctx context.Context) (any, error) {
 	err := logs.Clear(ctx, h.store.DB())
 	if err != nil {
-		h.logger.Error("clearing logs", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 	return "Logs cleared successfully", nil
 }
@@ -186,11 +189,9 @@ func (h *JSONRPCHandler) clearLogs(ctx context.Context) (any, error) {
 func (h *JSONRPCHandler) getLog(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 	if len(params) != 1 {
-		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "1"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 	logID, err := h.parseIDParam(params[0], ErrInvalidLogID, normalizeUUID)
@@ -199,8 +200,7 @@ func (h *JSONRPCHandler) getLog(ctx context.Context, req *jsonrpc2.Request) (any
 	}
 	result, err := logs.Get(ctx, h.store.DB(), logID)
 	if err != nil {
-		h.logger.Error("getting log", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 	return result, nil
 }
@@ -208,11 +208,9 @@ func (h *JSONRPCHandler) getLog(ctx context.Context, req *jsonrpc2.Request) (any
 func (h *JSONRPCHandler) searchMetricSummaries(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 	if len(params) < 2 || len(params) > 3 {
-		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "2-3"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 	startTime, err := h.parseTimestampParam(params[0], "startTime")
@@ -229,8 +227,7 @@ func (h *JSONRPCHandler) searchMetricSummaries(ctx context.Context, req *jsonrpc
 	}
 	summaries, err := metrics.SearchSummaries(ctx, h.store.DB(), startTime, endTime, query)
 	if err != nil {
-		h.logger.Error("searching metric summaries", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 	return summaries, nil
 }
@@ -238,11 +235,9 @@ func (h *JSONRPCHandler) searchMetricSummaries(ctx context.Context, req *jsonrpc
 func (h *JSONRPCHandler) getMetric(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 	if len(params) != 3 {
-		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "3: streamId, startTime, endTime"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 	streamID, err := h.parseIDParam(params[0], ErrInvalidStreamID, normalizeUUID)
@@ -259,8 +254,7 @@ func (h *JSONRPCHandler) getMetric(ctx context.Context, req *jsonrpc2.Request) (
 	}
 	result, err := metrics.GetMetric(ctx, h.store.DB(), streamID, startTime, endTime)
 	if err != nil {
-		h.logger.Error("getting metric", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 	return result, nil
 }
@@ -268,8 +262,7 @@ func (h *JSONRPCHandler) getMetric(ctx context.Context, req *jsonrpc2.Request) (
 func (h *JSONRPCHandler) clearMetrics(ctx context.Context) (any, error) {
 	err := metrics.Clear(ctx, h.store.DB())
 	if err != nil {
-		h.logger.Error("clearing metrics", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 	return "Metrics cleared successfully", nil
 }
@@ -282,8 +275,7 @@ func (h *JSONRPCHandler) deleteSpansByTraceID(ctx context.Context, req *jsonrpc2
 	}
 
 	if err := spans.DeleteSpansByTraceIDs(ctx, h.store.DB(), traceIDs); err != nil {
-		h.logger.Error("deleting spans by trace IDs", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 
 	return map[string]any{
@@ -300,8 +292,7 @@ func (h *JSONRPCHandler) deleteSpanByID(ctx context.Context, req *jsonrpc2.Reque
 	}
 
 	if err := spans.DeleteSpansByIDs(ctx, h.store.DB(), spanIDs); err != nil {
-		h.logger.Error("deleting spans by IDs", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 
 	return map[string]any{
@@ -318,8 +309,7 @@ func (h *JSONRPCHandler) deleteLogByID(ctx context.Context, req *jsonrpc2.Reques
 	}
 
 	if err := logs.DeleteLogsByIDs(ctx, h.store.DB(), logIDs); err != nil {
-		h.logger.Error("deleting logs by IDs", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 
 	return map[string]any{
@@ -331,12 +321,10 @@ func (h *JSONRPCHandler) deleteLogByID(ctx context.Context, req *jsonrpc2.Reques
 func (h *JSONRPCHandler) getTraceAttributes(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
 	if len(params) != 2 {
-		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "2"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
@@ -352,8 +340,7 @@ func (h *JSONRPCHandler) getTraceAttributes(ctx context.Context, req *jsonrpc2.R
 
 	attributes, err := spans.GetTraceAttributes(ctx, h.store.DB(), startTime, endTime)
 	if err != nil {
-		h.logger.Error("getting trace attributes", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 
 	return attributes, nil
@@ -362,12 +349,10 @@ func (h *JSONRPCHandler) getTraceAttributes(ctx context.Context, req *jsonrpc2.R
 func (h *JSONRPCHandler) getLogAttributes(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
 	if len(params) != 2 {
-		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "2"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
@@ -383,8 +368,7 @@ func (h *JSONRPCHandler) getLogAttributes(ctx context.Context, req *jsonrpc2.Req
 
 	attributes, err := logs.GetLogAttributes(ctx, h.store.DB(), startTime, endTime)
 	if err != nil {
-		h.logger.Error("getting log attributes", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 
 	return attributes, nil
@@ -393,12 +377,10 @@ func (h *JSONRPCHandler) getLogAttributes(ctx context.Context, req *jsonrpc2.Req
 func (h *JSONRPCHandler) getMetricAttributes(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
 	if len(params) != 2 {
-		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "2"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
@@ -414,8 +396,7 @@ func (h *JSONRPCHandler) getMetricAttributes(ctx context.Context, req *jsonrpc2.
 
 	attributes, err := metrics.GetMetricAttributes(ctx, h.store.DB(), startTime, endTime)
 	if err != nil {
-		h.logger.Error("getting metric attributes", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 
 	return attributes, nil
@@ -424,12 +405,10 @@ func (h *JSONRPCHandler) getMetricAttributes(ctx context.Context, req *jsonrpc2.
 func (h *JSONRPCHandler) getAttributesByTraceID(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
 	if len(params) != 1 {
-		h.logger.Debug("invalid RPC parameter count", zap.Int("count", len(params)), zap.String("expected", "1"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
@@ -440,8 +419,7 @@ func (h *JSONRPCHandler) getAttributesByTraceID(ctx context.Context, req *jsonrp
 
 	attributes, err := spans.GetAttributesByTraceID(ctx, h.store.DB(), traceID)
 	if err != nil {
-		h.logger.Error("getting attributes by trace ID", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 
 	return attributes, nil
@@ -461,8 +439,7 @@ func (h *JSONRPCHandler) getTraceSpanCount(ctx context.Context, req *jsonrpc2.Re
 	}
 	count, err := stats.GetTraceSpanCount(ctx, h.store.DB(), traceID)
 	if err != nil {
-		h.logger.Error("getting trace span count", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 	return count, nil
 }
@@ -470,14 +447,12 @@ func (h *JSONRPCHandler) getTraceSpanCount(ctx context.Context, req *jsonrpc2.Re
 func (h *JSONRPCHandler) getStats(ctx context.Context) (any, error) {
 	sizeBytes, err := h.store.SizeBytes(ctx)
 	if err != nil {
-		h.logger.Error("measuring store size", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 
 	result, err := stats.GetStats(ctx, h.store.DB(), sizeBytes, h.store.RetentionCap())
 	if err != nil {
-		h.logger.Error("getting stats", zap.Error(err))
-		return nil, mapStoreError(err)
+		return nil, h.handleStoreError(err)
 	}
 	return result, nil
 }
@@ -491,12 +466,10 @@ func (h *JSONRPCHandler) getStats(ctx context.Context) (any, error) {
 func (h *JSONRPCHandler) parseIDParams(req *jsonrpc2.Request, invalidIDErr error, normalize func(string) (string, error)) ([]any, error) {
 	var params []any
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		h.logger.Debug("invalid RPC params", zap.Error(err))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
 	if len(params) == 0 {
-		h.logger.Debug("invalid RPC parameter count", zap.Int("count", 0), zap.String("expected", "at least 1 ID"))
 		return nil, jsonrpc2.ErrInvalidParams
 	}
 
@@ -504,12 +477,10 @@ func (h *JSONRPCHandler) parseIDParams(req *jsonrpc2.Request, invalidIDErr error
 	for _, param := range params {
 		s, ok := param.(string)
 		if !ok {
-			h.logger.Debug("invalid ID type", zap.String("expected", "string"), zap.Any("param", param))
 			return nil, invalidIDErr
 		}
 		id, err := normalize(s)
 		if err != nil {
-			h.logger.Debug("invalid ID", zap.String("id", s), zap.Error(err))
 			return nil, invalidIDErr
 		}
 		ids = append(ids, id)
@@ -524,12 +495,10 @@ func (h *JSONRPCHandler) parseIDParams(req *jsonrpc2.Request, invalidIDErr error
 func (h *JSONRPCHandler) parseIDParam(param any, invalidIDErr error, normalize func(string) (string, error)) (string, error) {
 	s, ok := param.(string)
 	if !ok {
-		h.logger.Debug("invalid ID type", zap.String("expected", "string"), zap.Any("param", param))
 		return "", invalidIDErr
 	}
 	id, err := normalize(s)
 	if err != nil {
-		h.logger.Debug("invalid ID", zap.String("id", s), zap.Error(err))
 		return "", invalidIDErr
 	}
 	return id, nil
@@ -570,12 +539,10 @@ func normalizeSpanID(s string) (string, error) {
 func (h *JSONRPCHandler) parseTimestampParam(param any, paramName string) (int64, error) {
 	s, ok := param.(string)
 	if !ok {
-		h.logger.Debug("invalid timestamp param type", zap.String("param", paramName), zap.Any("value", param))
 		return 0, jsonrpc2.ErrInvalidParams
 	}
 	parsed, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
-		h.logger.Debug("invalid timestamp param", zap.String("param", paramName), zap.Error(err))
 		return 0, jsonrpc2.ErrInvalidParams
 	}
 	return parsed, nil

--- a/desktopexporter/internal/server/jsonrpc_handler_test.go
+++ b/desktopexporter/internal/server/jsonrpc_handler_test.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
 	"golang.org/x/exp/jsonrpc2"
 )
 
@@ -26,7 +27,7 @@ func setupHandler(t *testing.T) (*JSONRPCHandler, func()) {
 	t.Helper()
 	s, err := store.NewStore(context.Background(), "")
 	require.NoError(t, err)
-	handler := NewJSONRPCHandler(s)
+	handler := NewJSONRPCHandler(s, zap.NewNop())
 	return handler, func() {
 		s.Close()
 	}
@@ -66,7 +67,7 @@ func setupHandlerWithData(t *testing.T) (*JSONRPCHandler, func()) {
 	t.Helper()
 	s, err := store.NewStore(context.Background(), "")
 	require.NoError(t, err)
-	handler := NewJSONRPCHandler(s)
+	handler := NewJSONRPCHandler(s, zap.NewNop())
 	ctx := context.Background()
 
 	err = s.WithConn(func(conn driver.Conn) error {
@@ -764,7 +765,7 @@ func setupHandlerWithMetrics(t *testing.T) (*JSONRPCHandler, func()) {
 	t.Helper()
 	s, err := store.NewStore(context.Background(), "")
 	require.NoError(t, err)
-	handler := NewJSONRPCHandler(s)
+	handler := NewJSONRPCHandler(s, zap.NewNop())
 	ctx := context.Background()
 
 	err = s.WithConn(func(conn driver.Conn) error {

--- a/desktopexporter/internal/server/server.go
+++ b/desktopexporter/internal/server/server.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"net/http"
 	"path"
 	"strings"
 
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store"
 	"github.com/rs/cors"
+	"go.uber.org/zap"
 	"golang.org/x/exp/jsonrpc2"
 )
 
@@ -28,14 +28,16 @@ const maxRPCRequestBodyBytes = 1 << 20 // 1 MB
 type Server struct {
 	server         http.Server
 	jsonrpcHandler *JSONRPCHandler
+	logger         *zap.Logger
 }
 
-func NewServer(endpoint string, store *store.Store) (*Server, error) {
+func NewServer(endpoint string, store *store.Store, logger *zap.Logger) (*Server, error) {
 	s := Server{
 		server: http.Server{
 			Addr: endpoint,
 		},
-		jsonrpcHandler: NewJSONRPCHandler(store),
+		jsonrpcHandler: NewJSONRPCHandler(store, logger),
+		logger:         logger,
 	}
 
 	if err := s.initHandler(); err != nil {
@@ -61,7 +63,7 @@ func (s *Server) initHandler() error {
 	if err != nil {
 		return err
 	}
-	mux.Handle("/", spaHandler(fsys))
+	mux.Handle("/", spaHandler(fsys, s.logger))
 
 	// CORS for the Vite frontend
 	c := cors.New(cors.Options{
@@ -82,12 +84,12 @@ func staticFS() (fs.FS, error) {
 // client router owns the route (e.g. a deep-linked /traces/{id} or a refreshed
 // /metrics). Paths with a file extension that do not exist 404 normally. Non-GET
 // requests fall through to the file server.
-func spaHandler(fsys fs.FS) http.Handler {
+func spaHandler(fsys fs.FS, logger *zap.Logger) http.Handler {
 	fileServer := http.FileServerFS(fsys)
 	serveIndex := func(writer http.ResponseWriter) {
 		bytes, err := fs.ReadFile(fsys, "index.html")
 		if err != nil {
-			log.Printf("Error reading index.html: %v", err)
+			logger.Error("reading index.html", zap.Error(err))
 			http.Error(writer, "Failed to load page", http.StatusInternalServerError)
 			return
 		}
@@ -114,48 +116,45 @@ func (s *Server) rpcHandler(writer http.ResponseWriter, request *http.Request) {
 	if err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
-			sendJSONRPCResponse(writer, jsonrpc2.ID{}, nil, fmt.Errorf("%w: request body too large", jsonrpc2.ErrInvalidRequest))
+			s.sendJSONRPCResponse(writer, jsonrpc2.ID{}, nil, fmt.Errorf("%w: request body too large", jsonrpc2.ErrInvalidRequest))
 			return
 		}
-		sendJSONRPCResponse(writer, jsonrpc2.ID{}, nil, jsonrpc2.ErrInternal)
+		s.sendJSONRPCResponse(writer, jsonrpc2.ID{}, nil, jsonrpc2.ErrInternal)
 		return
 	}
 
 	message, err := jsonrpc2.DecodeMessage(body)
 	if err != nil {
-		sendJSONRPCResponse(writer, jsonrpc2.ID{}, nil, jsonrpc2.ErrParse)
+		s.sendJSONRPCResponse(writer, jsonrpc2.ID{}, nil, jsonrpc2.ErrParse)
 		return
 	}
 
 	rpcRequest, ok := message.(*jsonrpc2.Request)
 	if !ok {
-		sendJSONRPCResponse(writer, jsonrpc2.ID{}, nil, jsonrpc2.ErrInvalidRequest)
+		s.sendJSONRPCResponse(writer, jsonrpc2.ID{}, nil, jsonrpc2.ErrInvalidRequest)
 		return
 	}
 
 	result, err := s.jsonrpcHandler.Handle(request.Context(), rpcRequest)
 	if err != nil {
-		sendJSONRPCResponse(writer, rpcRequest.ID, nil, err)
+		s.sendJSONRPCResponse(writer, rpcRequest.ID, nil, err)
 		return
 	}
 
-	sendJSONRPCResponse(writer, rpcRequest.ID, result, nil)
+	s.sendJSONRPCResponse(writer, rpcRequest.ID, result, nil)
 }
 
-// sendJSONRPCResponse encodes and writes a spec-compliant JSON-RPC response body
-// It handles both success and error cases, with fallback http response
-// if our error handling creates new and exciting errors
-func sendJSONRPCResponse(writer http.ResponseWriter, id jsonrpc2.ID, result any, rpcError error) {
+func (s *Server) sendJSONRPCResponse(writer http.ResponseWriter, id jsonrpc2.ID, result any, rpcError error) {
 	response, err := jsonrpc2.NewResponse(id, result, rpcError)
 	if err != nil {
-		log.Printf("Error creating JSON-RPC response: %v", err)
+		s.logger.Error("creating JSON-RPC response", zap.Error(err))
 		http.Error(writer, "Internal server error", http.StatusInternalServerError)
 		return
 	}
 
 	bytes, err := jsonrpc2.EncodeMessage(response)
 	if err != nil {
-		log.Printf("Error encoding JSON-RPC response: %v", err)
+		s.logger.Error("encoding JSON-RPC response", zap.Error(err))
 		http.Error(writer, "Internal server error", http.StatusInternalServerError)
 		return
 	}

--- a/desktopexporter/internal/server/server_test.go
+++ b/desktopexporter/internal/server/server_test.go
@@ -14,13 +14,14 @@ import (
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func setupServer(t *testing.T) (*httptest.Server, func()) {
 	t.Helper()
 	str, err := store.NewStore(context.Background(), "")
 	require.NoError(t, err)
-	s, err := NewServer("localhost:8000", str)
+	s, err := NewServer("localhost:8000", str, zap.NewNop())
 	require.NoError(t, err)
 	testServer := httptest.NewServer(s.server.Handler)
 

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	go.opentelemetry.io/collector/processor/batchprocessor v0.157.0
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.157.0
 	go.opentelemetry.io/collector/service v0.157.0
+	go.uber.org/zap v1.28.0
 	golang.org/x/exp/jsonrpc2 v0.0.0-20260718201538-764159d718ef
 	golang.org/x/sys v0.47.0
 )
@@ -162,7 +163,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.28.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20260527015227-08cc5374adb3 // indirect


### PR DESCRIPTION
## Summary
Replaces stdlib `log`/`fmt.Printf` with the collector's zap logger and trims noise.

**Wiring**
- `exporter.Settings.Logger` → shared `desktopExporter` → HTTP server → JSON-RPC handler

**Removed**
- Per-request `searchTraces` query-tree debug dump (#251 trigger)
- All client-validation logging (bad params/IDs return JSON-RPC errors; no duplicate logs)
- Per-RPC Error logs for expected outcomes (not-found, invalid query, etc.)

**What still logs (Error only)**
| Message | When |
|---------|------|
| `store error` | Store failure mapped to `-32603` |
| `retention enforcement failed` | Prune loop error |
| `HTTP server listen failed` | Port bind failure |
| `reading index.html` | Broken embedded static |
| `creating/encoding JSON-RPC response` | Response encoder failure |

Closes #251