### PR TITLE
Harden desktop exporter lifecycle (closes #239, #240, #247)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,7 +115,7 @@ OTLP pdata → exporterhelper → pushTraces|pushMetrics|pushLogs → store.With
 
 Ingest writes directly from OpenTelemetry pdata into DuckDB appenders. There are no intermediate Go domain structs between OTLP and storage.
 
-**Lifecycle**: `newDesktopExporter` opens the store and HTTP server; `Start()` launches `ListenAndServe` on a goroutine (the UI is reachable before the first OTLP batch arrives). When a retention cap is configured, a background loop enforces it every 30 seconds. `Shutdown()` cancels the retention loop and waits for it to finish, closes the HTTP server, then closes the store.
+**Lifecycle**: `newDesktopExporter` opens the store and HTTP server using the factory startup context. `Start()` binds the listen address synchronously (bind failures such as port-in-use propagate to the collector), then serves HTTP on a background goroutine. Ingest paths check `ctx.Err()` before work and on every record (metrics pass 1 included); `CloseAppenders` on exit flushes buffered rows. When a retention cap is configured, a background loop enforces it every 30 seconds. `Shutdown()` cancels the retention loop and waits for it to finish, gracefully shuts down the HTTP server and waits for the serve goroutine, then closes the store.
 
 **Retention**: `--db-max-size` sets a byte cap on stored telemetry. When usage exceeds the cap, the oldest traces, logs, and metrics are pruned. `getStats` reports current usage and the configured cap alongside signal counts.
 

--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,8 @@ release-dry-run:
 
 .PHONY: kill-port
 kill-port:
-	@echo "Killing process on port 8888..."
-	@lsof -ti:8888 | xargs kill -9 2>/dev/null || echo "No process found on port 8888"
+	@echo "Killing processes on ports 8000, 4317, 4318..."
+	@lsof -ti:8000,4317,4318 | xargs kill -9 2>/dev/null || echo "No process found on ports 8000, 4317, 4318"
 
 .PHONY: stop
 stop:
@@ -133,5 +133,5 @@ help:
 	@echo ""
 	@echo "Other:"
 	@echo "  release-dry-run      - Trigger release workflow (dry run)"
-	@echo "  kill-port            - Kill process on port 8888"
+	@echo "  kill-port            - Kill processes on ports 8000, 4317, 4318"
 	@echo "  stop              - Stop Go server and Vite dev server"

--- a/desktopexporter/config.go
+++ b/desktopexporter/config.go
@@ -23,10 +23,6 @@ type Config struct {
 
 // Validate checks if the exporter configuration is valid
 func (cfg *Config) Validate() error {
-	if cfg.Endpoint == "localhost:8888" {
-		return fmt.Errorf("port 8888 is not supported as it is used internally")
-	}
-
 	if _, err := parseByteSize(cfg.DbMaxSize); err != nil {
 		return fmt.Errorf("invalid db_max_size %q: %w", cfg.DbMaxSize, err)
 	}

--- a/desktopexporter/config_test.go
+++ b/desktopexporter/config_test.go
@@ -62,11 +62,6 @@ func TestConfigValidate(t *testing.T) {
 			cfg:  Config{Endpoint: "localhost:8000", DbMaxSize: "0"},
 		},
 		{
-			name:    "reserved port",
-			cfg:     Config{Endpoint: "localhost:8888"},
-			wantErr: "port 8888",
-		},
-		{
 			name:    "invalid max size",
 			cfg:     Config{Endpoint: "localhost:8000", DbMaxSize: "lots"},
 			wantErr: "invalid db_max_size",

--- a/desktopexporter/exporter.go
+++ b/desktopexporter/exporter.go
@@ -3,8 +3,6 @@ package desktopexporter
 import (
 	"context"
 	"database/sql/driver"
-	"errors"
-	"net/http"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -40,8 +38,8 @@ type desktopExporter struct {
 	retentionDone   chan struct{}
 }
 
-func newDesktopExporter(cfg *Config, logger *zap.Logger) (*desktopExporter, error) {
-	str, err := store.NewStore(context.Background(), cfg.Db)
+func newDesktopExporter(ctx context.Context, cfg *Config, logger *zap.Logger) (*desktopExporter, error) {
+	str, err := store.NewStore(ctx, cfg.Db)
 	if err != nil {
 		return nil, err
 	}
@@ -116,17 +114,9 @@ func (e *desktopExporter) pushLogs(ctx context.Context, source plog.Logs) error 
 }
 
 func (e *desktopExporter) Start(ctx context.Context, host component.Host) error {
-	go func() {
-		err := e.server.Start()
-
-		if errors.Is(err, http.ErrServerClosed) {
-			return
-		}
-		if err != nil {
-			e.logger.Error("HTTP server listen failed", zap.Error(err))
-		}
-
-	}()
+	if err := e.server.Start(); err != nil {
+		return err
+	}
 
 	if e.store.RetentionCap() > 0 {
 		// The loop gets its own context rather than the startup ctx, which
@@ -147,8 +137,8 @@ func (e *desktopExporter) Shutdown(ctx context.Context) error {
 		<-e.retentionDone
 	}
 
-	// Close server first (stops accepting new requests)
-	if err := e.server.Close(); err != nil {
+	// Shut down the HTTP server and wait for the serve goroutine to exit.
+	if err := e.server.Shutdown(ctx); err != nil {
 		return err
 	}
 

--- a/desktopexporter/exporter_test.go
+++ b/desktopexporter/exporter_test.go
@@ -1,0 +1,131 @@
+package desktopexporter
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/metadata"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/exporter"
+	"go.uber.org/zap"
+)
+
+func testExporterSettings(t *testing.T) exporter.Settings {
+	t.Helper()
+	return exporter.Settings{
+		ID:                component.NewID(metadata.Type),
+		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
+	}
+}
+
+func freeLocalAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+	return addr
+}
+
+func TestCreateExporterNilConfig(t *testing.T) {
+	ctx := context.Background()
+	set := testExporterSettings(t)
+
+	_, err := createMetricsExporter(ctx, set, nil)
+	require.EqualError(t, err, "nil config")
+
+	_, err = createLogsExporter(ctx, set, nil)
+	require.EqualError(t, err, "nil config")
+
+	_, err = createTracesExporter(ctx, set, nil)
+	require.EqualError(t, err, "nil config")
+}
+
+func TestSharedExporterSingleton(t *testing.T) {
+	ctx := context.Background()
+	set := testExporterSettings(t)
+	cfg := &Config{Endpoint: freeLocalAddr(t), DbMaxSize: "0"}
+
+	mExp, err := createMetricsExporter(ctx, set, cfg)
+	require.NoError(t, err)
+	lExp, err := createLogsExporter(ctx, set, cfg)
+	require.NoError(t, err)
+	tExp, err := createTracesExporter(ctx, set, cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, mExp.Start(ctx, componenttest.NewNopHost()))
+	require.NoError(t, lExp.Start(ctx, componenttest.NewNopHost()))
+	require.NoError(t, tExp.Start(ctx, componenttest.NewNopHost()))
+
+	resp, err := http.Get("http://" + cfg.Endpoint + "/")
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.NoError(t, tExp.Shutdown(ctx))
+	require.NoError(t, lExp.Shutdown(ctx))
+	require.NoError(t, mExp.Shutdown(ctx))
+}
+
+func TestExporterStartPortInUse(t *testing.T) {
+	ctx := context.Background()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	defer ln.Close()
+
+	exp, err := newDesktopExporter(ctx, &Config{Endpoint: addr, DbMaxSize: "0"}, zap.NewNop())
+	require.NoError(t, err)
+	defer func() { _ = exp.Shutdown(ctx) }()
+
+	err = exp.Start(ctx, nil)
+	require.Error(t, err)
+}
+
+func TestExporterShutdown(t *testing.T) {
+	ctx := context.Background()
+	cfg := &Config{Endpoint: freeLocalAddr(t), DbMaxSize: "0"}
+
+	exp, err := newDesktopExporter(ctx, cfg, zap.NewNop())
+	require.NoError(t, err)
+
+	require.NoError(t, exp.Start(ctx, nil))
+
+	resp, err := http.Get("http://" + cfg.Endpoint + "/")
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.NoError(t, exp.Shutdown(ctx))
+
+	exp2, err := newDesktopExporter(ctx, cfg, zap.NewNop())
+	require.NoError(t, err)
+	require.NoError(t, exp2.Start(ctx, nil))
+	require.NoError(t, exp2.Shutdown(ctx))
+}
+
+func TestFactoryRecreateAfterShutdown(t *testing.T) {
+	ctx := context.Background()
+	set := testExporterSettings(t)
+	cfg := &Config{Endpoint: freeLocalAddr(t), DbMaxSize: "0"}
+
+	mExp, err := createMetricsExporter(ctx, set, cfg)
+	require.NoError(t, err)
+	require.NoError(t, mExp.Start(ctx, componenttest.NewNopHost()))
+	require.NoError(t, mExp.Shutdown(ctx))
+
+	lExp, err := createLogsExporter(ctx, set, cfg)
+	require.NoError(t, err)
+	require.NoError(t, lExp.Start(ctx, componenttest.NewNopHost()))
+
+	resp, err := http.Get("http://" + cfg.Endpoint + "/")
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.NoError(t, lExp.Shutdown(ctx))
+}

--- a/desktopexporter/factory.go
+++ b/desktopexporter/factory.go
@@ -48,7 +48,7 @@ func createMetricsExporter(ctx context.Context, set exporter.Settings, config co
 	}
 
 	exporter, err := exporters.GetOrAdd(desktopCfg, func() (*desktopExporter, error) {
-		return newDesktopExporter(desktopCfg, set.Logger)
+		return newDesktopExporter(ctx, desktopCfg, set.Logger)
 	})
 	if err != nil {
 		return nil, err
@@ -66,6 +66,10 @@ func createMetricsExporter(ctx context.Context, set exporter.Settings, config co
 }
 
 func createLogsExporter(ctx context.Context, set exporter.Settings, config component.Config) (exporter.Logs, error) {
+	if config == nil {
+		return nil, errors.New("nil config")
+	}
+
 	cfg := config.(*Config)
 	err := cfg.Validate()
 	if err != nil {
@@ -73,7 +77,7 @@ func createLogsExporter(ctx context.Context, set exporter.Settings, config compo
 	}
 
 	e, err := exporters.GetOrAdd(cfg, func() (*desktopExporter, error) {
-		return newDesktopExporter(cfg, set.Logger)
+		return newDesktopExporter(ctx, cfg, set.Logger)
 	})
 	if err != nil {
 		return nil, err
@@ -88,6 +92,10 @@ func createLogsExporter(ctx context.Context, set exporter.Settings, config compo
 }
 
 func createTracesExporter(ctx context.Context, set exporter.Settings, config component.Config) (exporter.Traces, error) {
+	if config == nil {
+		return nil, errors.New("nil config")
+	}
+
 	cfg := config.(*Config)
 	err := cfg.Validate()
 	if err != nil {
@@ -95,7 +103,7 @@ func createTracesExporter(ctx context.Context, set exporter.Settings, config com
 	}
 
 	e, err := exporters.GetOrAdd(cfg, func() (*desktopExporter, error) {
-		return newDesktopExporter(cfg, set.Logger)
+		return newDesktopExporter(ctx, cfg, set.Logger)
 	})
 	if err != nil {
 		return nil, err

--- a/desktopexporter/factory_test.go
+++ b/desktopexporter/factory_test.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/exporter"
-	"go.uber.org/zap"
 )
 
 func testExporterSettings(t *testing.T) exporter.Settings {
@@ -71,29 +70,14 @@ func TestSharedExporterSingleton(t *testing.T) {
 	require.NoError(t, mExp.Shutdown(ctx))
 }
 
-func TestExporterStartPortInUse(t *testing.T) {
+func TestFactoryShutdownAndRestart(t *testing.T) {
 	ctx := context.Background()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	addr := ln.Addr().String()
-	defer ln.Close()
-
-	exp, err := newDesktopExporter(ctx, &Config{Endpoint: addr, DbMaxSize: "0"}, zap.NewNop())
-	require.NoError(t, err)
-	defer func() { _ = exp.Shutdown(ctx) }()
-
-	err = exp.Start(ctx, nil)
-	require.Error(t, err)
-}
-
-func TestExporterShutdown(t *testing.T) {
-	ctx := context.Background()
+	set := testExporterSettings(t)
 	cfg := &Config{Endpoint: freeLocalAddr(t), DbMaxSize: "0"}
 
-	exp, err := newDesktopExporter(ctx, cfg, zap.NewNop())
+	exp, err := createMetricsExporter(ctx, set, cfg)
 	require.NoError(t, err)
-
-	require.NoError(t, exp.Start(ctx, nil))
+	require.NoError(t, exp.Start(ctx, componenttest.NewNopHost()))
 
 	resp, err := http.Get("http://" + cfg.Endpoint + "/")
 	require.NoError(t, err)
@@ -102,9 +86,9 @@ func TestExporterShutdown(t *testing.T) {
 
 	require.NoError(t, exp.Shutdown(ctx))
 
-	exp2, err := newDesktopExporter(ctx, cfg, zap.NewNop())
+	exp2, err := createMetricsExporter(ctx, set, cfg)
 	require.NoError(t, err)
-	require.NoError(t, exp2.Start(ctx, nil))
+	require.NoError(t, exp2.Start(ctx, componenttest.NewNopHost()))
 	require.NoError(t, exp2.Shutdown(ctx))
 }
 

--- a/desktopexporter/internal/server/server.go
+++ b/desktopexporter/internal/server/server.go
@@ -1,14 +1,17 @@
 package server
 
 import (
+	"context"
 	"embed"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"net/http"
 	"path"
 	"strings"
+	"sync"
 
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store"
 	"github.com/rs/cors"
@@ -29,6 +32,9 @@ type Server struct {
 	server         http.Server
 	jsonrpcHandler *JSONRPCHandler
 	logger         *zap.Logger
+
+	serveDone chan struct{}
+	startMu   sync.Mutex
 }
 
 func NewServer(endpoint string, store *store.Store, logger *zap.Logger) (*Server, error) {
@@ -47,8 +53,46 @@ func NewServer(endpoint string, store *store.Store, logger *zap.Logger) (*Server
 	return &s, nil
 }
 
+// Start binds the listen address synchronously, then serves HTTP on a
+// background goroutine. Bind failures (e.g. port in use) return immediately.
 func (s *Server) Start() error {
-	return s.server.ListenAndServe()
+	s.startMu.Lock()
+	defer s.startMu.Unlock()
+
+	if s.serveDone != nil {
+		return errors.New("server already started")
+	}
+
+	ln, err := net.Listen("tcp", s.server.Addr)
+	if err != nil {
+		return err
+	}
+
+	done := make(chan struct{})
+	s.serveDone = done
+	go func() {
+		defer close(done)
+		err := s.server.Serve(ln)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			s.logger.Error("HTTP server failed", zap.Error(err))
+		}
+	}()
+	return nil
+}
+
+// Shutdown drains in-flight requests and waits for the serve goroutine to exit.
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.startMu.Lock()
+	done := s.serveDone
+	s.startMu.Unlock()
+
+	if done == nil {
+		return nil
+	}
+
+	err := s.server.Shutdown(ctx)
+	<-done
+	return err
 }
 
 func (s *Server) initHandler() error {
@@ -161,8 +205,4 @@ func (s *Server) sendJSONRPCResponse(writer http.ResponseWriter, id jsonrpc2.ID,
 
 	writer.Header().Set("Content-Type", "application/json")
 	writer.Write(bytes)
-}
-
-func (s *Server) Close() error {
-	return s.server.Close()
 }

--- a/desktopexporter/internal/server/server_test.go
+++ b/desktopexporter/internal/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -27,7 +28,7 @@ func setupServer(t *testing.T) (*httptest.Server, func()) {
 
 	return testServer, func() {
 		testServer.Close()
-		s.Close()
+		_ = s.Shutdown(context.Background())
 		str.Close()
 	}
 }
@@ -171,4 +172,21 @@ func TestCORSHeaders(t *testing.T) {
 	assert.Equal(t, "http://localhost:5173", res.Header.Get("Access-Control-Allow-Origin"))
 	assert.Contains(t, res.Header.Get("Access-Control-Allow-Methods"), "POST")
 	assert.Contains(t, res.Header.Get("Access-Control-Allow-Headers"), "Content-Type")
+}
+
+func TestStartBindConflict(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	defer ln.Close()
+
+	str, err := store.NewStore(context.Background(), "")
+	require.NoError(t, err)
+	defer str.Close()
+
+	s, err := NewServer(addr, str, zap.NewNop())
+	require.NoError(t, err)
+
+	err = s.Start()
+	require.Error(t, err)
 }

--- a/desktopexporter/internal/store/logs/logs.go
+++ b/desktopexporter/internal/store/logs/logs.go
@@ -49,6 +49,10 @@ func Ingest(ctx context.Context, conn driver.Conn, logs plog.Logs) (err error) {
 		err = errors.Join(err, ingest.CloseAppenders(appenders, tables))
 	}()
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	logCount := 0
 	for _, resourceLogs := range logs.ResourceLogs().All() {
 		resource := resourceLogs.Resource()
@@ -61,6 +65,10 @@ func Ingest(ctx context.Context, conn driver.Conn, logs plog.Logs) (err error) {
 			scope := scopeLogs.Scope()
 
 			for _, log := range scopeLogs.LogRecords().All() {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+
 				logID := duckdb.UUID(uuid.New())
 				var traceUUID *duckdb.UUID
 				if tid := log.TraceID(); !tid.IsEmpty() {

--- a/desktopexporter/internal/store/logs/logs_test.go
+++ b/desktopexporter/internal/store/logs/logs_test.go
@@ -584,6 +584,38 @@ func TestIngestLogs_FlushInterval(t *testing.T) {
 	}
 }
 
+func TestIngest_CanceledContext(t *testing.T) {
+	s, _, teardown := setupStore(t)
+	defer teardown()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := s.WithConn(func(conn driver.Conn) error {
+		return logs.Ingest(ctx, conn, createTestLogsPdataN(time.Now().UnixNano(), 1))
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestIngest_CanceledDuringIngest(t *testing.T) {
+	s, _, teardown := setupStore(t)
+	defer teardown()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ldata := createTestLogsPdataN(time.Now().UnixNano(), 100)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.WithConn(func(conn driver.Conn) error {
+			return logs.Ingest(ctx, conn, ldata)
+		})
+	}()
+	cancel()
+
+	err := <-errCh
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 // TestSearchLogs tests logs.Search with various query types.
 func TestSearchLogs(t *testing.T) {
 	s, ctx, teardown := setupStore(t)

--- a/desktopexporter/internal/store/metrics/metrics.go
+++ b/desktopexporter/internal/store/metrics/metrics.go
@@ -68,6 +68,9 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics) (err error
 		for si, scopeMetric := range resourceMetric.ScopeMetrics().All() {
 			scope := scopeMetric.Scope()
 			for mi, metric := range scopeMetric.Metrics().All() {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
 				identity := streamIdentityFromMetric(metric, scope.Name(), scope.Version(), serviceName)
 				identitySet[identity] = struct{}{}
 				coords = append(coords, identityWithCoord{identity: identity, coord: metricCoord{ri, si, mi}})
@@ -76,6 +79,9 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics) (err error
 	}
 	if len(coords) == 0 {
 		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	identities := make([]streamIdentity, 0, len(identitySet))
 	for id := range identitySet {
@@ -105,6 +111,9 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics) (err error
 	rowPlaceholders := make([]string, len(identities))
 	insertArgs := make([]driver.NamedValue, 0, len(identities)*9)
 	for i, id := range identities {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		newID := uuid.NewString()
 		rowPlaceholders[i] = "(?::uuid, ?, ?, ?, ?, ?, ?, ?, ?)"
 		var err error
@@ -159,6 +168,10 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics) (err error
 	streamIDs := make(map[streamIdentity]duckdb.UUID, len(identities))
 	dest := make([]driver.Value, 9)
 	for {
+		if err := ctx.Err(); err != nil {
+			rows.Close()
+			return err
+		}
 		if err := rows.Next(dest); err != nil {
 			if err.Error() == "EOF" {
 				break
@@ -210,6 +223,9 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics) (err error
 		for _, scopeMetric := range resourceMetric.ScopeMetrics().All() {
 			scope := scopeMetric.Scope()
 			for _, metric := range scopeMetric.Metrics().All() {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
 				identity := streamIdentityFromMetric(metric, scope.Name(), scope.Version(), serviceName)
 				streamID, ok := streamIDs[identity]
 				if !ok {

--- a/desktopexporter/internal/store/metrics/metrics_test.go
+++ b/desktopexporter/internal/store/metrics/metrics_test.go
@@ -1352,6 +1352,37 @@ func TestIngestMetrics_FlushInterval(t *testing.T) {
 	}
 }
 
+func TestIngest_CanceledContext(t *testing.T) {
+	s, _, teardown := setupStore(t)
+	defer teardown()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := s.WithConn(func(conn driver.Conn) error {
+		return metrics.Ingest(ctx, conn, createTestMetricsPdataN(1))
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestIngest_CanceledDuringIngest(t *testing.T) {
+	s, _, teardown := setupStore(t)
+	defer teardown()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.WithConn(func(conn driver.Conn) error {
+			return metrics.Ingest(ctx, conn, createTestMetricsPdataN(100))
+		})
+	}()
+	cancel()
+
+	err := <-errCh
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 // TestSearchSummaries_CardFields verifies the slim summary projection used
 // by drawer cards: stream id, series count, scalar last value, last seen.
 func TestSearchSummaries_CardFields(t *testing.T) {

--- a/desktopexporter/internal/store/spans/spans.go
+++ b/desktopexporter/internal/store/spans/spans.go
@@ -50,6 +50,10 @@ func Ingest(ctx context.Context, conn driver.Conn, traces ptrace.Traces) (err er
 		err = errors.Join(err, ingest.CloseAppenders(appenders, tables))
 	}()
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	spanCount := 0
 	for _, resourceSpan := range traces.ResourceSpans().All() {
 		resource := resourceSpan.Resource()
@@ -64,6 +68,10 @@ func Ingest(ctx context.Context, conn driver.Conn, traces ptrace.Traces) (err er
 			scope := scopeSpan.Scope()
 
 			for _, span := range scopeSpan.Spans().All() {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+
 				traceUUID := duckdb.UUID(span.TraceID())
 
 				spanID := span.SpanID()

--- a/desktopexporter/internal/store/spans/spans_test.go
+++ b/desktopexporter/internal/store/spans/spans_test.go
@@ -968,6 +968,38 @@ func TestIngestSpans_FlushInterval(t *testing.T) {
 	assert.GreaterOrEqual(t, scopeAttr, 1)
 }
 
+func TestIngest_CanceledContext(t *testing.T) {
+	s, _, teardown := setupStore(t)
+	defer teardown()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := s.WithConn(func(conn driver.Conn) error {
+		return spans.Ingest(ctx, conn, createTestTracesPdataN(1))
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestIngest_CanceledDuringIngest(t *testing.T) {
+	s, _, teardown := setupStore(t)
+	defer teardown()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	traces := createTestTracesPdataN(100)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.WithConn(func(conn driver.Conn) error {
+			return spans.Ingest(ctx, conn, traces)
+		})
+	}()
+	cancel()
+
+	err := <-errCh
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 // TestDeleteSpanByID verifies that a single span can be deleted by its SpanID, including child rows.
 func TestDeleteSpanByID(t *testing.T) {
 	s, ctx, teardown := setupStore(t)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.63.0
+	go.opentelemetry.io/collector/component/componenttest v0.157.0
 	go.opentelemetry.io/collector/confmap v1.63.0
 	go.opentelemetry.io/collector/confmap/provider/envprovider v1.63.0
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.63.0
@@ -91,7 +92,6 @@ require (
 	go.opentelemetry.io/collector v0.157.0 // indirect
 	go.opentelemetry.io/collector/client v1.63.0 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.157.0 // indirect
-	go.opentelemetry.io/collector/component/componenttest v0.157.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v1.63.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.63.0 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.157.0 // indirect

--- a/main.go
+++ b/main.go
@@ -99,6 +99,7 @@ func newCommand(set otelcol.CollectorSettings) *cobra.Command {
 				`yaml:service::pipelines::metrics::exporters: [desktop]`,
 				`yaml:service::pipelines::logs::receivers: [otlp]`,
 				`yaml:service::pipelines::logs::exporters: [desktop]`,
+				`yaml:service::telemetry::metrics::level: none`,
 			}
 			set.ConfigProviderSettings.ResolverSettings.DefaultScheme = "env"
 


### PR DESCRIPTION
- **#240 HTTP shutdown:** bind synchronously in `server.Start()`, use `Shutdown(ctx)` with serve-goroutine join; bind failures (port in use) fail collector startup instead of logging in the background.
- **#239 Context propagation:** pass factory `ctx` into `newDesktopExporter` / `NewStore`; ingest checks `ctx.Err()` before work and on every record (metrics pass 1 included); `CloseAppenders` still flushes buffered rows on exit.
- **#247 Lifecycle tests:** nil-config factory guards, shared singleton, port conflict, shutdown/restart, factory map recreation after shutdown, and ingest cancel tests for all three signals.
- **Module hygiene:** mark `componenttest` as a direct dependency for exporter lifecycle tests.
- **Collector self-metrics:** set `service.telemetry.metrics.level: none` so the app no longer binds port 8888 for internal Prometheus metrics; remove the stale `--browser-port 8888` guard and point `make kill-port` at 8000/4317/4318

Closes #239
Closes #240
Closes #247