### PR TITLE
Extract shared signal list page composable (#244)

### DIFF
--- a/desktopexporter/internal/frontend/src/components/shared/Drawer/SignalDrawerFooter.svelte
+++ b/desktopexporter/internal/frontend/src/components/shared/Drawer/SignalDrawerFooter.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { TrashIcon } from '@/icons'
+
+  type SignalLabel = 'trace' | 'log' | 'metric'
+
+  interface Props {
+    count: number
+    label: SignalLabel
+    onDeleteAll: () => void
+  }
+
+  let { count, label, onDeleteAll }: Props = $props()
+
+  const PLURAL: Record<SignalLabel, string> = {
+    trace: 'traces',
+    log: 'logs',
+    metric: 'metrics',
+  }
+
+  let countLabel = $derived(
+    `${count} ${count === 1 ? label : PLURAL[label]}`
+  )
+
+  let deleteAriaLabel = $derived(`Delete all ${PLURAL[label]}`)
+</script>
+
+<div class="flex items-center justify-between">
+  <span class="text-xs tabular-nums text-base-content/50">
+    {countLabel}
+  </span>
+  <button
+    type="button"
+    class="btn btn-ghost btn-xs text-error"
+    onclick={onDeleteAll}
+    aria-label={deleteAriaLabel}
+  >
+    <TrashIcon class="h-3 w-3" aria-hidden="true" />
+    Delete all
+  </button>
+</div>

--- a/desktopexporter/internal/frontend/src/components/shared/Drawer/SignalDrawerFooter.test.ts
+++ b/desktopexporter/internal/frontend/src/components/shared/Drawer/SignalDrawerFooter.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/svelte'
+import userEvent from '@testing-library/user-event'
+import SignalDrawerFooter from './SignalDrawerFooter.svelte'
+import { renderWithContexts, setTestUrl } from '@/test/render-helpers'
+
+function renderFooter(
+  props: {
+    count: number
+    label: 'trace' | 'log' | 'metric'
+    onDeleteAll?: () => void
+  }
+) {
+  setTestUrl('/logs')
+  const onDeleteAll = props.onDeleteAll ?? vi.fn()
+  renderWithContexts(SignalDrawerFooter, {
+    count: props.count,
+    label: props.label,
+    onDeleteAll,
+  })
+  return onDeleteAll
+}
+
+describe('SignalDrawerFooter', () => {
+  it('uses singular label for a single item', () => {
+    renderFooter({ count: 1, label: 'log' })
+    expect(screen.getByText('1 log')).toBeInTheDocument()
+  })
+
+  it('uses plural label for multiple items', () => {
+    renderFooter({ count: 3, label: 'trace' })
+    expect(screen.getByText('3 traces')).toBeInTheDocument()
+  })
+
+  it('uses text-base-content/50 for the count', () => {
+    renderFooter({ count: 2, label: 'metric' })
+    const count = screen.getByText('2 metrics')
+    expect(count.className).toContain('text-base-content/50')
+  })
+
+  it('calls onDeleteAll when the button is clicked', async () => {
+    const onDeleteAll = renderFooter({ count: 0, label: 'log' })
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Delete all logs' })
+    )
+    expect(onDeleteAll).toHaveBeenCalledTimes(1)
+  })
+})

--- a/desktopexporter/internal/frontend/src/components/shared/Drawer/SignalDrawerFooter.test.ts
+++ b/desktopexporter/internal/frontend/src/components/shared/Drawer/SignalDrawerFooter.test.ts
@@ -5,13 +5,11 @@ import userEvent from '@testing-library/user-event'
 import SignalDrawerFooter from './SignalDrawerFooter.svelte'
 import { renderWithContexts, setTestUrl } from '@/test/render-helpers'
 
-function renderFooter(
-  props: {
-    count: number
-    label: 'trace' | 'log' | 'metric'
-    onDeleteAll?: () => void
-  }
-) {
+function renderFooter(props: {
+  count: number
+  label: 'trace' | 'log' | 'metric'
+  onDeleteAll?: () => void
+}) {
   setTestUrl('/logs')
   const onDeleteAll = props.onDeleteAll ?? vi.fn()
   renderWithContexts(SignalDrawerFooter, {

--- a/desktopexporter/internal/frontend/src/components/shared/Search/SearchEditor.svelte
+++ b/desktopexporter/internal/frontend/src/components/shared/Search/SearchEditor.svelte
@@ -23,6 +23,7 @@
   } from '@/contexts/time-context.svelte'
   import type { TimeContext } from '@/contexts/time-context.svelte'
   import type { SearchResultEvent } from '@/types/api-types'
+  import { beginListUpdate, cancelPendingListUpdates } from '@/components/shared/utils/list-update-seq'
   import type { FilterDescriptor } from '@/components/shared/Toolbar/filter-types'
   import { queryLanguageSupport } from './codemirror/query-language'
   import { createQueryCompletionSource } from './codemirror/completions'
@@ -131,6 +132,7 @@
   let editorContainer = $state<HTMLDivElement | null>(null)
   let editorView: EditorView | null = null
   let searchError = $state<string | null>(null)
+  let alive = true
   const placeholderCompartment = new Compartment()
 
   // --- state: filter popover ---
@@ -254,21 +256,23 @@
   }
 
   /** Fetch without any search filter and deliver via onSearchResults. */
-  function fetchClean() {
+  function fetchClean(updateSeq: number) {
     const ctx = currentSearchContext()
     const fn = buildSearchFn(ctx)
     fn?.()
       .then(results => {
-        emitResults(results)
+        emitResults(results, undefined, updateSeq)
       })
       .catch(err => {
+        if (!alive) return
         searchError = 'Search failed: ' + err.message
       })
   }
 
   /** Emit results with the query tree attached so consumers can reuse it. */
-  function emitResults(results: any, queryTree?: QueryNode) {
-    onSearchResults?.({ signal, results, queryTree } as SearchResultEvent)
+  function emitResults(results: any, queryTree?: QueryNode, updateSeq?: number) {
+    if (!alive || updateSeq === undefined) return
+    onSearchResults?.({ signal, results, queryTree, updateSeq } as SearchResultEvent)
   }
 
   function onSubmit() {
@@ -276,7 +280,7 @@
 
     if (!text.trim()) {
       searchError = null
-      fetchClean()
+      fetchClean(beginListUpdate(signal))
       return
     }
 
@@ -284,7 +288,7 @@
       const queryTree: QueryNode | null = parseQuery(text, availableFields)
       searchError = null
       if (!queryTree) {
-        fetchClean()
+        fetchClean(beginListUpdate(signal))
         return
       }
 
@@ -297,15 +301,17 @@
       const searchCtx = currentSearchContext()
       const searchFn = buildSearchFn(searchCtx, queryTree)
       if (!searchFn) {
-        fetchClean()
+        fetchClean(beginListUpdate(signal))
         return
       }
 
+      const updateSeq = beginListUpdate(signal)
       searchFn()
         .then(results => {
-          emitResults(results, queryTree)
+          emitResults(results, queryTree, updateSeq)
         })
         .catch(err => {
+          if (!alive) return
           searchError = 'Search failed: ' + err.message
         })
     } catch (err) {
@@ -404,6 +410,8 @@
   })
 
   onDestroy(() => {
+    alive = false
+    cancelPendingListUpdates(signal)
     editorView?.destroy()
   })
 </script>

--- a/desktopexporter/internal/frontend/src/components/shared/utils/list-update-seq.ts
+++ b/desktopexporter/internal/frontend/src/components/shared/utils/list-update-seq.ts
@@ -1,0 +1,33 @@
+// Per-signal monotonic sequence for list updates (full fetch vs search results).
+// Each operation calls beginListUpdate(signal) when it *starts*; completions
+// apply only if their seq is still the latest for that signal.
+
+import type { SignalName } from '@/route'
+
+const latestListUpdateSeq = new Map<SignalName, number>()
+
+function latestSeq(signal: SignalName): number {
+  return latestListUpdateSeq.get(signal) ?? 0
+}
+
+/** Call when a list fetch or search submit begins. Returns this operation's seq. */
+export function beginListUpdate(signal: SignalName): number {
+  const next = latestSeq(signal) + 1
+  latestListUpdateSeq.set(signal, next)
+  return next
+}
+
+/** True when no newer list update has started for `signal` since `seq` was issued. */
+export function isLatestListUpdate(signal: SignalName, seq: number): boolean {
+  return seq === latestSeq(signal)
+}
+
+/** Invalidate in-flight list fetches/searches for `signal` (e.g. on page unmount). */
+export function cancelPendingListUpdates(signal: SignalName): void {
+  beginListUpdate(signal)
+}
+
+/** Test-only reset. */
+export function resetListUpdateSeqForTests(): void {
+  latestListUpdateSeq.clear()
+}

--- a/desktopexporter/internal/frontend/src/contexts/signal-list-page.integration.test.ts
+++ b/desktopexporter/internal/frontend/src/contexts/signal-list-page.integration.test.ts
@@ -27,7 +27,7 @@ describe('createSignalListPage integration', () => {
   it('loads the list on mount and exposes sorted items', async () => {
     const items = [
       { id: 'c', name: 'charlie' },
-      { id: 'a', name: 'alpha' },
+      { id: 'a', name: 'alfa' },
       { id: 'b', name: 'bravo' },
     ]
     const fetchList = vi.fn(async () => items)
@@ -72,7 +72,7 @@ describe('createSignalListPage integration', () => {
 
   it('selectByOffset navigates with replace mode', async () => {
     const items = [
-      { id: 'a', name: 'alpha' },
+      { id: 'a', name: 'alfa' },
       { id: 'b', name: 'bravo' },
     ]
     let page: import('@/contexts/signal-list-page.svelte').SignalListPage<Item> | undefined
@@ -93,8 +93,8 @@ describe('createSignalListPage integration', () => {
   })
 
   it('refetches when navigateToItem changes the route after mount', async () => {
-    const fetchList = vi.fn(async () => [{ id: 'a', name: 'alpha' }])
-    renderProbe('/logs', [{ id: 'a', name: 'alpha' }], fetchList)
+    const fetchList = vi.fn(async () => [{ id: 'a', name: 'alfa' }])
+    renderProbe('/logs', [{ id: 'a', name: 'alfa' }], fetchList)
     await waitForMounted()
 
     navigateToItem('logs', 'a')

--- a/desktopexporter/internal/frontend/src/contexts/signal-list-page.integration.test.ts
+++ b/desktopexporter/internal/frontend/src/contexts/signal-list-page.integration.test.ts
@@ -57,7 +57,10 @@ describe('createSignalListPage integration', () => {
   })
 
   it('derives selectedId from the URL path', async () => {
-    renderProbe('/logs/log-b', [{ id: 'log-a', name: 'a' }, { id: 'log-b', name: 'b' }])
+    renderProbe('/logs/log-b', [
+      { id: 'log-a', name: 'a' },
+      { id: 'log-b', name: 'b' },
+    ])
     await waitForListLoaded()
 
     expect(screen.getByTestId('selected-id').textContent).toBe('log-b')
@@ -92,7 +95,9 @@ describe('createSignalListPage integration', () => {
       { id: 'a', name: 'alfa' },
       { id: 'b', name: 'bravo' },
     ]
-    let page: import('@/contexts/signal-list-page.svelte').SignalListPage<Item> | undefined
+    let page:
+      | import('@/contexts/signal-list-page.svelte').SignalListPage<Item>
+      | undefined
 
     setTestUrl('/logs/a')
     renderWithContexts(SignalListPageProbe, {
@@ -122,7 +127,9 @@ describe('createSignalListPage integration', () => {
       })
     })
 
-    let page: import('@/contexts/signal-list-page.svelte').SignalListPage<Item> | undefined
+    let page:
+      | import('@/contexts/signal-list-page.svelte').SignalListPage<Item>
+      | undefined
     setTestUrl('/logs')
     renderWithContexts(SignalListPageProbe, {
       fetchList,
@@ -166,7 +173,9 @@ describe('createSignalListPage integration', () => {
       })
     })
 
-    let page: import('@/contexts/signal-list-page.svelte').SignalListPage<Item> | undefined
+    let page:
+      | import('@/contexts/signal-list-page.svelte').SignalListPage<Item>
+      | undefined
     setTestUrl('/logs')
     renderWithContexts(SignalListPageProbe, {
       fetchList,
@@ -197,7 +206,7 @@ describe('createSignalListPage integration', () => {
     expect(screen.getByTestId('item-ids').textContent).toBe('x,y')
   })
 
-  it('does not let one signal\'s list update invalidate another signal\'s seq', () => {
+  it("does not let one signal's list update invalidate another signal's seq", () => {
     const logsSeq = beginListUpdate('logs')
     beginListUpdate('metrics')
 

--- a/desktopexporter/internal/frontend/src/contexts/signal-list-page.integration.test.ts
+++ b/desktopexporter/internal/frontend/src/contexts/signal-list-page.integration.test.ts
@@ -29,6 +29,13 @@ async function waitForMounted() {
   })
 }
 
+async function waitForListLoaded() {
+  await waitForMounted()
+  await vi.waitFor(() => {
+    expect(screen.getByTestId('loading').textContent).toBe('false')
+  })
+}
+
 describe('createSignalListPage integration', () => {
   beforeEach(() => {
     resetListUpdateSeqForTests()
@@ -42,16 +49,16 @@ describe('createSignalListPage integration', () => {
     ]
     const fetchList = vi.fn(async () => items)
     renderProbe('/logs', items, fetchList)
-    await waitForMounted()
+    await waitForListLoaded()
 
-    expect(fetchList).toHaveBeenCalledTimes(2)
+    expect(fetchList).toHaveBeenCalledTimes(1)
     expect(screen.getByTestId('item-count').textContent).toBe('3')
     expect(screen.getByTestId('item-ids').textContent).toBe('a,b,c')
   })
 
   it('derives selectedId from the URL path', async () => {
     renderProbe('/logs/log-b', [{ id: 'log-a', name: 'a' }, { id: 'log-b', name: 'b' }])
-    await waitForMounted()
+    await waitForListLoaded()
 
     expect(screen.getByTestId('selected-id').textContent).toBe('log-b')
     expect(screen.getByTestId('selected-index').textContent).toBe('1')
@@ -73,7 +80,7 @@ describe('createSignalListPage integration', () => {
     expect(window.location.pathname).toBe('/logs/deep-link-id')
 
     resolveFetch([{ id: 'other', name: 'other' }])
-    await waitForMounted()
+    await waitForListLoaded()
     await tick()
 
     // Stale id should trigger fallback navigation, not an immediate clobber mid-fetch.
@@ -94,7 +101,7 @@ describe('createSignalListPage integration', () => {
         page = ctx
       },
     })
-    await waitForMounted()
+    await waitForListLoaded()
 
     page!.selectByOffset(1)
     await tick()
@@ -107,7 +114,7 @@ describe('createSignalListPage integration', () => {
     let fetchCalls = 0
     const fetchList = vi.fn(async () => {
       fetchCalls++
-      if (fetchCalls <= 2) {
+      if (fetchCalls <= 1) {
         return [{ id: 'a', name: 'alfa' }]
       }
       return new Promise<Item[]>(resolve => {
@@ -123,7 +130,7 @@ describe('createSignalListPage integration', () => {
         page = ctx
       },
     })
-    await waitForMounted()
+    await waitForListLoaded()
 
     const slowFetch = page!.runListFetch()
     const searchSeq = beginListUpdate('logs')
@@ -151,7 +158,7 @@ describe('createSignalListPage integration', () => {
     let fetchCalls = 0
     const fetchList = vi.fn(async () => {
       fetchCalls++
-      if (fetchCalls <= 2) {
+      if (fetchCalls <= 1) {
         return [{ id: 'a', name: 'alfa' }]
       }
       return new Promise<Item[]>(resolve => {
@@ -167,7 +174,7 @@ describe('createSignalListPage integration', () => {
         page = ctx
       },
     })
-    await waitForMounted()
+    await waitForListLoaded()
 
     const staleSearchSeq = beginListUpdate('logs')
     const slowFetch = page!.runListFetch()

--- a/desktopexporter/internal/frontend/src/contexts/signal-list-page.integration.test.ts
+++ b/desktopexporter/internal/frontend/src/contexts/signal-list-page.integration.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { tick } from 'svelte'
+import { screen } from '@testing-library/svelte'
+import SignalListPageProbe from '@/test/SignalListPageProbe.svelte'
+import { navigateToItem } from '@/route'
+import { renderWithContexts, setTestUrl } from '@/test/render-helpers'
+
+type Item = { id: string; name: string }
+
+function renderProbe(
+  url: string,
+  items: Item[],
+  fetchList = vi.fn(async () => items)
+) {
+  setTestUrl(url)
+  return renderWithContexts(SignalListPageProbe, { fetchList })
+}
+
+async function waitForMounted() {
+  await vi.waitFor(() => {
+    expect(screen.getByTestId('mounted').textContent).toBe('true')
+  })
+}
+
+describe('createSignalListPage integration', () => {
+  it('loads the list on mount and exposes sorted items', async () => {
+    const items = [
+      { id: 'c', name: 'charlie' },
+      { id: 'a', name: 'alpha' },
+      { id: 'b', name: 'bravo' },
+    ]
+    const fetchList = vi.fn(async () => items)
+    renderProbe('/logs', items, fetchList)
+    await waitForMounted()
+
+    expect(fetchList).toHaveBeenCalledTimes(2)
+    expect(screen.getByTestId('item-count').textContent).toBe('3')
+    expect(screen.getByTestId('item-ids').textContent).toBe('a,b,c')
+  })
+
+  it('derives selectedId from the URL path', async () => {
+    renderProbe('/logs/log-b', [{ id: 'log-a', name: 'a' }, { id: 'log-b', name: 'b' }])
+    await waitForMounted()
+
+    expect(screen.getByTestId('selected-id').textContent).toBe('log-b')
+    expect(screen.getByTestId('selected-index').textContent).toBe('1')
+  })
+
+  it('does not clobber a shared-link id before the list finishes loading', async () => {
+    let resolveFetch!: (items: Item[]) => void
+    const fetchList = vi.fn(
+      () =>
+        new Promise<Item[]>(resolve => {
+          resolveFetch = resolve
+        })
+    )
+
+    setTestUrl('/logs/deep-link-id')
+    renderWithContexts(SignalListPageProbe, { fetchList })
+
+    expect(screen.getByTestId('loading').textContent).toBe('true')
+    expect(window.location.pathname).toBe('/logs/deep-link-id')
+
+    resolveFetch([{ id: 'other', name: 'other' }])
+    await waitForMounted()
+    await tick()
+
+    // Stale id should trigger fallback navigation, not an immediate clobber mid-fetch.
+    expect(window.location.pathname).toBe('/logs/other')
+  })
+
+  it('selectByOffset navigates with replace mode', async () => {
+    const items = [
+      { id: 'a', name: 'alpha' },
+      { id: 'b', name: 'bravo' },
+    ]
+    let page: import('@/contexts/signal-list-page.svelte').SignalListPage<Item> | undefined
+
+    setTestUrl('/logs/a')
+    renderWithContexts(SignalListPageProbe, {
+      fetchList: async () => items,
+      onContext: ctx => {
+        page = ctx
+      },
+    })
+    await waitForMounted()
+
+    page!.selectByOffset(1)
+    await tick()
+
+    expect(window.location.pathname).toBe('/logs/b')
+  })
+
+  it('refetches when navigateToItem changes the route after mount', async () => {
+    const fetchList = vi.fn(async () => [{ id: 'a', name: 'alpha' }])
+    renderProbe('/logs', [{ id: 'a', name: 'alpha' }], fetchList)
+    await waitForMounted()
+
+    navigateToItem('logs', 'a')
+    await tick()
+
+    // Initial mount fetch only; time-range effect may fire once mounted.
+    expect(fetchList.mock.calls.length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/desktopexporter/internal/frontend/src/contexts/signal-list-page.integration.test.ts
+++ b/desktopexporter/internal/frontend/src/contexts/signal-list-page.integration.test.ts
@@ -1,10 +1,16 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { tick } from 'svelte'
 import { screen } from '@testing-library/svelte'
 import SignalListPageProbe from '@/test/SignalListPageProbe.svelte'
 import { navigateToItem } from '@/route'
 import { renderWithContexts, setTestUrl } from '@/test/render-helpers'
+import {
+  beginListUpdate,
+  cancelPendingListUpdates,
+  isLatestListUpdate,
+  resetListUpdateSeqForTests,
+} from '@/components/shared/utils/list-update-seq'
 
 type Item = { id: string; name: string }
 
@@ -24,6 +30,10 @@ async function waitForMounted() {
 }
 
 describe('createSignalListPage integration', () => {
+  beforeEach(() => {
+    resetListUpdateSeqForTests()
+  })
+
   it('loads the list on mount and exposes sorted items', async () => {
     const items = [
       { id: 'c', name: 'charlie' },
@@ -92,15 +102,108 @@ describe('createSignalListPage integration', () => {
     expect(window.location.pathname).toBe('/logs/b')
   })
 
-  it('refetches when navigateToItem changes the route after mount', async () => {
-    const fetchList = vi.fn(async () => [{ id: 'a', name: 'alfa' }])
-    renderProbe('/logs', [{ id: 'a', name: 'alfa' }], fetchList)
+  it('does not let a stale list fetch overwrite newer search results', async () => {
+    let resolveSlowFetch!: (items: Item[]) => void
+    let fetchCalls = 0
+    const fetchList = vi.fn(async () => {
+      fetchCalls++
+      if (fetchCalls <= 2) {
+        return [{ id: 'a', name: 'alfa' }]
+      }
+      return new Promise<Item[]>(resolve => {
+        resolveSlowFetch = resolve
+      })
+    })
+
+    let page: import('@/contexts/signal-list-page.svelte').SignalListPage<Item> | undefined
+    setTestUrl('/logs')
+    renderWithContexts(SignalListPageProbe, {
+      fetchList,
+      onContext: ctx => {
+        page = ctx
+      },
+    })
     await waitForMounted()
 
-    navigateToItem('logs', 'a')
+    const slowFetch = page!.runListFetch()
+    const searchSeq = beginListUpdate('logs')
+    page!.handleSearchResults({
+      signal: 'logs',
+      updateSeq: searchSeq,
+      results: [{ id: 'search-only', name: 'search-only' }],
+    } as unknown as import('@/types/api-types').SearchResultEvent)
     await tick()
 
-    // Initial mount fetch only; time-range effect may fire once mounted.
-    expect(fetchList.mock.calls.length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByTestId('item-ids').textContent).toBe('search-only')
+
+    resolveSlowFetch([
+      { id: 'x', name: 'x-ray' },
+      { id: 'y', name: 'yankee' },
+    ])
+    await slowFetch
+    await tick()
+
+    expect(screen.getByTestId('item-ids').textContent).toBe('search-only')
+  })
+
+  it('does not let a stale search overwrite a newer list fetch', async () => {
+    let resolveSlowFetch!: (items: Item[]) => void
+    let fetchCalls = 0
+    const fetchList = vi.fn(async () => {
+      fetchCalls++
+      if (fetchCalls <= 2) {
+        return [{ id: 'a', name: 'alfa' }]
+      }
+      return new Promise<Item[]>(resolve => {
+        resolveSlowFetch = resolve
+      })
+    })
+
+    let page: import('@/contexts/signal-list-page.svelte').SignalListPage<Item> | undefined
+    setTestUrl('/logs')
+    renderWithContexts(SignalListPageProbe, {
+      fetchList,
+      onContext: ctx => {
+        page = ctx
+      },
+    })
+    await waitForMounted()
+
+    const staleSearchSeq = beginListUpdate('logs')
+    const slowFetch = page!.runListFetch()
+    page!.handleSearchResults({
+      signal: 'logs',
+      updateSeq: staleSearchSeq,
+      results: [{ id: 'stale-search', name: 'stale' }],
+    } as unknown as import('@/types/api-types').SearchResultEvent)
+    await tick()
+
+    expect(screen.getByTestId('item-ids').textContent).toBe('a')
+
+    resolveSlowFetch([
+      { id: 'x', name: 'x-ray' },
+      { id: 'y', name: 'yankee' },
+    ])
+    await slowFetch
+    await tick()
+
+    expect(screen.getByTestId('item-ids').textContent).toBe('x,y')
+  })
+
+  it('does not let one signal\'s list update invalidate another signal\'s seq', () => {
+    const logsSeq = beginListUpdate('logs')
+    beginListUpdate('metrics')
+
+    expect(isLatestListUpdate('logs', logsSeq)).toBe(true)
+  })
+
+  it('cancelPendingListUpdates invalidates in-flight ops for that signal only', () => {
+    const logsSeq = beginListUpdate('logs')
+    const metricsSeq = beginListUpdate('metrics')
+
+    cancelPendingListUpdates('logs')
+
+    expect(isLatestListUpdate('logs', logsSeq)).toBe(false)
+    expect(isLatestListUpdate('metrics', metricsSeq)).toBe(true)
   })
 })

--- a/desktopexporter/internal/frontend/src/contexts/signal-list-page.svelte.ts
+++ b/desktopexporter/internal/frontend/src/contexts/signal-list-page.svelte.ts
@@ -7,7 +7,7 @@
 //
 // File extension is `.svelte.ts` because we use `$state` / `$effect` inside.
 
-import { onMount } from 'svelte'
+import { onMount, onDestroy } from 'svelte'
 import { getTimeContext } from '@/contexts/time-context.svelte'
 import { getRouteContext } from '@/contexts/route-context.svelte'
 import {
@@ -18,6 +18,11 @@ import {
 } from '@/route'
 import type { SearchResultEvent } from '@/types/api-types'
 import type { SearchEditorAPI } from '@/components/shared/Search/search-editor-api'
+import {
+  beginListUpdate,
+  cancelPendingListUpdates,
+  isLatestListUpdate,
+} from '@/components/shared/utils/list-update-seq'
 
 export type SortDirection = 'asc' | 'desc'
 
@@ -182,15 +187,19 @@ export function createSignalListPage<TItem>(
   })
 
   async function runListFetch() {
+    const updateSeq = beginListUpdate(opts.signal)
     try {
       loading = true
       error = null
-      items = await opts.fetchList()
+      const next = await opts.fetchList()
+      if (!isLatestListUpdate(opts.signal, updateSeq)) return
+      items = next
       updateRefreshIndicator()
     } catch (err) {
+      if (!isLatestListUpdate(opts.signal, updateSeq)) return
       error = err instanceof Error ? err.message : 'Failed to load list'
     } finally {
-      loading = false
+      if (isLatestListUpdate(opts.signal, updateSeq)) loading = false
     }
   }
 
@@ -227,14 +236,19 @@ export function createSignalListPage<TItem>(
 
   function handleSearchResults(event: SearchResultEvent) {
     if (event.signal !== opts.signal) return
-    loading = false
+    if (!isLatestListUpdate(event.signal, event.updateSeq)) return
     error = null
     items = event.results as TItem[]
+    loading = false
   }
 
   onMount(async () => {
     await runListFetch()
     mounted = true
+  })
+
+  onDestroy(() => {
+    cancelPendingListUpdates(opts.signal)
   })
 
   return {

--- a/desktopexporter/internal/frontend/src/contexts/signal-list-page.svelte.ts
+++ b/desktopexporter/internal/frontend/src/contexts/signal-list-page.svelte.ts
@@ -1,0 +1,292 @@
+// Shared list-page orchestration for traces / logs / metrics pages.
+//
+// Owns the duplicated wiring: mount/fetch, sort, URL-driven selection with
+// shared-link-safe auto-select, time-range refetch, stats polling refresh
+// indicator, footer keyboard nav, and search-result override. Callers keep
+// signal-specific sort fns, detail fetching, and Svelte snippets.
+//
+// File extension is `.svelte.ts` because we use `$state` / `$effect` inside.
+
+import { onMount } from 'svelte'
+import { getTimeContext } from '@/contexts/time-context.svelte'
+import { getRouteContext } from '@/contexts/route-context.svelte'
+import {
+  navigateToItem,
+  signalIdFromPath,
+  type HistoryMode,
+  type SignalName,
+} from '@/route'
+import type { SearchResultEvent } from '@/types/api-types'
+import type { SearchEditorAPI } from '@/components/shared/Search/search-editor-api'
+
+export type SortDirection = 'asc' | 'desc'
+
+export type SignalListPageOptions<TItem> = {
+  signal: SignalName
+  getItemId: (item: TItem) => string
+  fetchList: () => Promise<TItem[]>
+  compare: (
+    a: TItem,
+    b: TItem,
+    column: string,
+    direction: SortDirection
+  ) => number
+  initialSort: { column: string; direction: SortDirection }
+  /** Called after each poll interval; update polled stat counters here. */
+  pollStats?: () => Promise<void>
+  /** Derive refresh pulse + aside tip from baseline vs polled counters. */
+  refreshFromStats?: () => { pulse: boolean; tip: string }
+}
+
+export type SignalListPage<TItem> = {
+  readonly items: TItem[]
+  readonly loading: boolean
+  readonly error: string | null
+  readonly mounted: boolean
+  readonly sortColumn: string
+  readonly sortDirection: SortDirection
+  readonly sortedItems: TItem[]
+  readonly selectedId: string | null
+  readonly selectedIndex: number
+  readonly selectedSummary: TItem | undefined
+  readonly refreshPulse: boolean
+  readonly refreshAsideTip: string
+  searchEditorApi: SearchEditorAPI | null
+  handleSortChange(value: string, direction: SortDirection): void
+  selectItem(id: string, mode?: HistoryMode): void
+  selectByOffset(delta: number): void
+  selectFirst(): void
+  selectLast(): void
+  handleRefresh(): void
+  handleSearchResults(event: SearchResultEvent): void
+  runListFetch(): Promise<void>
+}
+
+const POLL_INTERVAL_MS = 3000
+
+/** Index of the item whose id matches, or -1 when id is missing / not found. */
+export function findItemIndexById<T>(
+  items: readonly T[],
+  id: string | null | undefined,
+  getItemId: (item: T) => string
+): number {
+  if (!id) return -1
+  return items.findIndex(item => getItemId(item) === id)
+}
+
+/** Clamps selectedIndex + delta into [0, length - 1]; -1 when nav is impossible. */
+export function clampNavTargetIndex(
+  selectedIndex: number,
+  delta: number,
+  length: number
+): number {
+  if (selectedIndex < 0 || length === 0) return -1
+  return Math.max(0, Math.min(length - 1, selectedIndex + delta))
+}
+
+/** Row index to select when the URL id is stale or missing from the list. */
+export function resolveFallbackIndex(
+  lastValidIndex: number,
+  listLength: number
+): number {
+  if (listLength === 0) return 0
+  return Math.min(lastValidIndex, listLength - 1)
+}
+
+export function createSignalListPage<TItem>(
+  opts: SignalListPageOptions<TItem>
+): SignalListPage<TItem> {
+  const timeContext = getTimeContext()
+  const routeContext = getRouteContext()
+
+  let items = $state<TItem[]>([])
+  let loading = $state(true)
+  let error = $state<string | null>(null)
+  let mounted = $state(false)
+
+  let sortColumn = $state(opts.initialSort.column)
+  let sortDirection = $state<SortDirection>(opts.initialSort.direction)
+
+  let searchEditorApi = $state<SearchEditorAPI | null>(null)
+  let refreshPulse = $state(false)
+  let refreshAsideTip = $state('')
+
+  let lastValidIndex = $state(0)
+
+  let selectedId = $derived(
+    signalIdFromPath(opts.signal, routeContext.route.path)
+  )
+
+  let sortedItems = $derived.by(() => {
+    const col = sortColumn
+    const dir = sortDirection
+    const rows = [...items]
+    rows.sort((a, b) => opts.compare(a, b, col, dir))
+    return rows
+  })
+
+  let selectedIndex = $derived(
+    findItemIndexById(sortedItems, selectedId, opts.getItemId)
+  )
+
+  let selectedSummary = $derived(
+    selectedId
+      ? sortedItems.find(item => opts.getItemId(item) === selectedId)
+      : undefined
+  )
+
+  function updateRefreshIndicator() {
+    if (!opts.refreshFromStats) return
+    const next = opts.refreshFromStats()
+    refreshPulse = next.pulse
+    refreshAsideTip = next.tip
+  }
+
+  // Guarded behind mounted + !loading so a URL-provided id (shared link) is
+  // never replaced before the list has finished fetching.
+  $effect(() => {
+    if (!mounted || loading) return
+    const id = selectedId
+    const idx = findItemIndexById(sortedItems, id, opts.getItemId)
+    if (idx >= 0) {
+      lastValidIndex = idx
+    } else if (sortedItems.length > 0) {
+      const fallback =
+        sortedItems[resolveFallbackIndex(lastValidIndex, sortedItems.length)]
+      if (fallback) {
+        navigateToItem(opts.signal, opts.getItemId(fallback), 'replace')
+      }
+    } else if (id) {
+      navigateToItem(opts.signal, null, 'replace')
+    }
+  })
+
+  $effect(() => {
+    void timeContext.selection
+    if (mounted) {
+      void runListFetch()
+    }
+  })
+
+  $effect(() => {
+    if (!mounted || !opts.pollStats) return
+    const id = setInterval(async () => {
+      try {
+        await opts.pollStats!()
+        updateRefreshIndicator()
+      } catch {
+        /* polling failures are silent */
+      }
+    }, POLL_INTERVAL_MS)
+    return () => clearInterval(id)
+  })
+
+  async function runListFetch() {
+    try {
+      loading = true
+      error = null
+      items = await opts.fetchList()
+      updateRefreshIndicator()
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to load list'
+    } finally {
+      loading = false
+    }
+  }
+
+  function handleSortChange(value: string, direction: SortDirection) {
+    sortColumn = value
+    sortDirection = direction
+  }
+
+  function selectItem(id: string, mode: HistoryMode = 'push') {
+    navigateToItem(opts.signal, id, mode)
+  }
+
+  function selectByOffset(delta: number) {
+    const target = clampNavTargetIndex(selectedIndex, delta, sortedItems.length)
+    if (target < 0 || target === selectedIndex) return
+    const next = sortedItems[target]
+    if (next) navigateToItem(opts.signal, opts.getItemId(next), 'replace')
+  }
+
+  function selectFirst() {
+    const first = sortedItems[0]
+    if (first) navigateToItem(opts.signal, opts.getItemId(first), 'replace')
+  }
+
+  function selectLast() {
+    const last = sortedItems[sortedItems.length - 1]
+    if (last) navigateToItem(opts.signal, opts.getItemId(last), 'replace')
+  }
+
+  function handleRefresh() {
+    searchEditorApi?.clear()
+    void runListFetch()
+  }
+
+  function handleSearchResults(event: SearchResultEvent) {
+    if (event.signal !== opts.signal) return
+    loading = false
+    error = null
+    items = event.results as TItem[]
+  }
+
+  onMount(async () => {
+    await runListFetch()
+    mounted = true
+  })
+
+  return {
+    get items() {
+      return items
+    },
+    get loading() {
+      return loading
+    },
+    get error() {
+      return error
+    },
+    get mounted() {
+      return mounted
+    },
+    get sortColumn() {
+      return sortColumn
+    },
+    get sortDirection() {
+      return sortDirection
+    },
+    get sortedItems() {
+      return sortedItems
+    },
+    get selectedId() {
+      return selectedId
+    },
+    get selectedIndex() {
+      return selectedIndex
+    },
+    get selectedSummary() {
+      return selectedSummary
+    },
+    get refreshPulse() {
+      return refreshPulse
+    },
+    get refreshAsideTip() {
+      return refreshAsideTip
+    },
+    get searchEditorApi() {
+      return searchEditorApi
+    },
+    set searchEditorApi(next: SearchEditorAPI | null) {
+      searchEditorApi = next
+    },
+    handleSortChange,
+    selectItem,
+    selectByOffset,
+    selectFirst,
+    selectLast,
+    handleRefresh,
+    handleSearchResults,
+    runListFetch,
+  }
+}

--- a/desktopexporter/internal/frontend/src/contexts/signal-list-page.svelte.ts
+++ b/desktopexporter/internal/frontend/src/contexts/signal-list-page.svelte.ts
@@ -242,8 +242,7 @@ export function createSignalListPage<TItem>(
     loading = false
   }
 
-  onMount(async () => {
-    await runListFetch()
+  onMount(() => {
     mounted = true
   })
 

--- a/desktopexporter/internal/frontend/src/contexts/signal-list-page.test.ts
+++ b/desktopexporter/internal/frontend/src/contexts/signal-list-page.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import {
+  clampNavTargetIndex,
+  findItemIndexById,
+  resolveFallbackIndex,
+} from '@/contexts/signal-list-page.svelte'
+
+describe('findItemIndexById', () => {
+  const items = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
+  const getId = (item: { id: string }) => item.id
+
+  it('returns -1 when id is null', () => {
+    expect(findItemIndexById(items, null, getId)).toBe(-1)
+  })
+
+  it('returns -1 when id is not in the list', () => {
+    expect(findItemIndexById(items, 'missing', getId)).toBe(-1)
+  })
+
+  it('returns the matching index', () => {
+    expect(findItemIndexById(items, 'b', getId)).toBe(1)
+  })
+})
+
+describe('clampNavTargetIndex', () => {
+  it('returns -1 when the list is empty', () => {
+    expect(clampNavTargetIndex(0, 1, 0)).toBe(-1)
+  })
+
+  it('returns -1 when nothing is selected', () => {
+    expect(clampNavTargetIndex(-1, 1, 3)).toBe(-1)
+  })
+
+  it('clamps at the first row', () => {
+    expect(clampNavTargetIndex(0, -1, 3)).toBe(0)
+  })
+
+  it('clamps at the last row', () => {
+    expect(clampNavTargetIndex(2, 1, 3)).toBe(2)
+  })
+
+  it('moves within range', () => {
+    expect(clampNavTargetIndex(1, 1, 3)).toBe(2)
+  })
+})
+
+describe('resolveFallbackIndex', () => {
+  it('returns 0 for an empty list', () => {
+    expect(resolveFallbackIndex(5, 0)).toBe(0)
+  })
+
+  it('clamps lastValidIndex to list length - 1', () => {
+    expect(resolveFallbackIndex(9, 3)).toBe(2)
+  })
+
+  it('preserves lastValidIndex when in range', () => {
+    expect(resolveFallbackIndex(1, 5)).toBe(1)
+  })
+})

--- a/desktopexporter/internal/frontend/src/pages/LogsPage.svelte
+++ b/desktopexporter/internal/frontend/src/pages/LogsPage.svelte
@@ -46,248 +46,118 @@
 </script>
 
 <script lang="ts">
-  import { onMount } from 'svelte'
   import { telemetryAPI } from '@/services/telemetry-service'
   import {
     getTimeContext,
     selectionToQueryRangeMs,
   } from '@/contexts/time-context.svelte'
-  import { signalIdFromPath, navigateToItem } from '@/route'
-  import { getRouteContext } from '@/contexts/route-context.svelte'
-  import type { LogData, SearchResultEvent } from '@/types/api-types'
+  import { navigateToItem } from '@/route'
+  import type { LogData } from '@/types/api-types'
+  import { createSignalListPage } from '@/contexts/signal-list-page.svelte'
   import { createDebouncedDetailFetcher } from '@/components/shared/utils/debounced-detail-fetcher.svelte'
-  import type { SearchEditorAPI } from '@/components/shared/Search/search-editor-api'
   import PageLayout from '@/components/shared/PageLayout.svelte'
   import DrawerSearchPanel from '@/components/shared/Drawer/DrawerSearchPanel.svelte'
+  import SignalDrawerFooter from '@/components/shared/Drawer/SignalDrawerFooter.svelte'
   import LogCard from '@/components/logs/LogCard.svelte'
   import LogDetailPanel from '@/components/logs/LogDetailView.svelte'
   import SignalFooter from '@/components/shared/SignalFooter.svelte'
-  import { TrashIcon } from '@/icons'
 
-  // --- context ---
   let timeContext = getTimeContext()
 
-  // --- URL is the source of truth for the selected log (`/logs/<id>`) ---
-  const routeContext = getRouteContext()
+  let baselineLogCount = $state(0)
+  let polledLogCount = $state(0)
+  let actionError = $state<string | null>(null)
 
-  // --- state: API / list ---
-  let logs = $state<LogSummary[]>([])
-  let loading = $state(true)
-  let error = $state<string | null>(null)
-  let mounted = $state(false)
+  const page = createSignalListPage<LogSummary>({
+    signal: 'logs',
+    getItemId: log => log.id,
+    initialSort: { column: 'timestamp', direction: 'desc' },
+    compare: (a, b, col, dir) =>
+      compareLogs(a, b, col as LogSortColumn, dir as LogSortDirection),
+    fetchList: async () => {
+      const { start: startTime, end: endTime } = selectionToQueryRangeMs(
+        timeContext.selection,
+        Date.now()
+      )
+      const results = await telemetryAPI.searchLogs(startTime, endTime, undefined)
+      const s = await telemetryAPI.getStats()
+      baselineLogCount = s.logs.logCount
+      polledLogCount = s.logs.logCount
+      return results
+    },
+    pollStats: async () => {
+      const s = await telemetryAPI.getStats()
+      polledLogCount = s.logs.logCount
+    },
+    refreshFromStats: () => {
+      const delta = polledLogCount - baselineLogCount
+      const pending = delta > 0 ? delta : 0
+      return {
+        pulse: pending > 0,
+        tip:
+          pending > 0
+            ? `+${pending.toLocaleString()} log${pending !== 1 ? 's' : ''}`
+            : '',
+      }
+    },
+  })
 
-  // --- state: sort ---
-  let sortColumn = $state<LogSortColumn>('timestamp')
-  let sortDirection = $state<LogSortDirection>('desc')
-
-  // --- selection (derived from URL) ---
-  //
-  // selectedLogId is the user's pick from the list (the LogSummary
-  // `id`), read from the route path. The detail fetcher round-trips to
-  // getLog(id) for the full LogData on demand, with a debounce that keeps
-  // held-arrow keyboard nav from firing a request per row. Detail loading/
-  // error state lives on the fetcher object, not on the page.
-  let selectedLogId = $derived(signalIdFromPath('logs', routeContext.route.path))
+  // selectedLogId is the user's pick from the list (the LogSummary `id`),
+  // read from the route path. The detail fetcher round-trips to getLog(id) for
+  // the full LogData on demand, with a debounce that keeps held-arrow keyboard
+  // nav from firing a request per row.
   const detailFetcher = createDebouncedDetailFetcher<string, LogData>({
     fetch: id => telemetryAPI.getLog(id),
     keysEqual: (a, b) => a === b,
     fallbackErrorMessage: 'Failed to load log details',
   })
 
-  // --- state: polling / refresh ---
-  let searchEditorApi = $state<SearchEditorAPI | null>(null)
-  let baselineLogCount = $state(0)
-  let polledLogCount = $state(0)
-  const POLL_INTERVAL_MS = 3000
-
-  // --- derived ---
-  let sortedLogs = $derived.by(() => {
-    const col = sortColumn
-    const dir = sortDirection
-    const rows = [...logs]
-    rows.sort((a, b) => compareLogs(a, b, col, dir))
-    return rows
-  })
-
-  let hasLogRows = $derived(logs.length > 0)
-
-  // The current selection from the list-side perspective: a
-  // LogSummary, used for footer/nav rendering that doesn't need the
-  // full body/attributes. The full LogData for the detail panel
-  // lives in selectedLogDetail (fetched in an effect below).
-  let selectedSummary = $derived(
-    selectedLogId ? sortedLogs.find(l => l.id === selectedLogId) : undefined
-  )
-
-  let pendingNewLogCount = $derived.by(() => {
-    const delta = polledLogCount - baselineLogCount
-    return delta > 0 ? delta : 0
-  })
-
-  let refreshPulse = $derived(pendingNewLogCount > 0)
-
-  let refreshAsideTip = $derived(
-    pendingNewLogCount > 0
-      ? `+${pendingNewLogCount.toLocaleString()} log${pendingNewLogCount !== 1 ? 's' : ''}`
-      : ''
-  )
-
-  // --- effects ---
-  let lastValidIndex = $state(0)
-
-  // Guarded behind mounted + !loading so a URL-provided id (shared link) is
-  // never replaced before the list has finished fetching.
-  $effect(() => {
-    if (!mounted || loading) return
-    const id = selectedLogId
-    const idx = id ? sortedLogs.findIndex(l => l.id === id) : -1
-    if (idx >= 0) {
-      lastValidIndex = idx
-    } else if (sortedLogs.length > 0) {
-      const fallback = sortedLogs[Math.min(lastValidIndex, sortedLogs.length - 1)]
-      if (fallback) navigateToItem('logs', fallback.id, 'replace')
-    } else if (id) {
-      navigateToItem('logs', null, 'replace')
-    }
-  })
+  let hasLogRows = $derived(page.items.length > 0)
+  let displayError = $derived(page.error ?? actionError)
 
   $effect(() => {
-    void timeContext.selection
-    if (mounted) {
-      fetchLogs()
-    }
+    detailFetcher.key = page.selectedId
   })
-
-  $effect(() => {
-    if (!mounted) return
-    const id = setInterval(async () => {
-      try {
-        const s = await telemetryAPI.getStats()
-        polledLogCount = s.logs.logCount
-      } catch {
-        /* polling failures are silent */
-      }
-    }, POLL_INTERVAL_MS)
-    return () => clearInterval(id)
-  })
-
-  // Pipe selection into the detail fetcher. The fetcher's $effect
-  // handles the debounce + race-guarded round-trip and exposes
-  // loading/error/data as reactive reads. Single source of truth
-  // remains selectedLogId; the fetcher just mirrors it.
-  $effect(() => {
-    detailFetcher.key = selectedLogId
-  })
-
-  // --- handlers ---
-  function handleSortChange(value: string, direction: 'asc' | 'desc') {
-    sortColumn = value as LogSortColumn
-    sortDirection = direction
-  }
 
   function selectLog(logId: string) {
-    // Explicit click is navigational: push so back returns to the prior log.
-    navigateToItem('logs', logId)
-  }
-
-  // --- nav: walk sortedLogs ---
-
-  let selectedIndex = $derived(
-    selectedLogId ? sortedLogs.findIndex(l => l.id === selectedLogId) : -1
-  )
-
-  function selectByOffset(delta: number) {
-    if (selectedIndex < 0 || sortedLogs.length === 0) return
-    const target = Math.max(
-      0,
-      Math.min(sortedLogs.length - 1, selectedIndex + delta)
-    )
-    if (target === selectedIndex) return
-    const next = sortedLogs[target]
-    if (next) navigateToItem('logs', next.id, 'replace')
-  }
-
-  function selectFirst() {
-    const first = sortedLogs[0]
-    if (first) navigateToItem('logs', first.id, 'replace')
-  }
-
-  function selectLast() {
-    const last = sortedLogs[sortedLogs.length - 1]
-    if (last) navigateToItem('logs', last.id, 'replace')
-  }
-
-  async function fetchLogs() {
-    try {
-      loading = true
-      error = null
-      const { start: startTime, end: endTime } = selectionToQueryRangeMs(
-        timeContext.selection,
-        Date.now()
-      )
-      logs = await telemetryAPI.searchLogs(startTime, endTime, undefined)
-      const s = await telemetryAPI.getStats()
-      baselineLogCount = s.logs.logCount
-      polledLogCount = s.logs.logCount
-    } catch (err) {
-      error = err instanceof Error ? err.message : 'Failed to load logs'
-    } finally {
-      loading = false
-    }
-  }
-
-  function handleRefresh() {
-    searchEditorApi?.clear()
-    fetchLogs()
-  }
-
-  function handleSearchResults(event: SearchResultEvent) {
-    if (event.signal === 'logs') {
-      loading = false
-      error = null
-      logs = event.results
-    }
+    page.selectItem(logId)
   }
 
   async function handleDeleteLog(logId: string) {
+    actionError = null
     try {
       await telemetryAPI.deleteLogByID(logId)
-      if (selectedLogId === logId) {
+      if (page.selectedId === logId) {
         navigateToItem('logs', null, 'replace')
       }
-      await fetchLogs()
+      await page.runListFetch()
     } catch (err) {
-      error = err instanceof Error ? err.message : 'Failed to delete log'
+      actionError = err instanceof Error ? err.message : 'Failed to delete log'
     }
   }
 
   async function handleDeleteAllLogs() {
+    actionError = null
     try {
       await telemetryAPI.clearLogs()
       navigateToItem('logs', null, 'replace')
-      await fetchLogs()
+      await page.runListFetch()
     } catch (err) {
-      error = err instanceof Error ? err.message : 'Failed to delete logs'
+      actionError = err instanceof Error ? err.message : 'Failed to delete logs'
     }
   }
-
-  // --- lifecycle ---
-  onMount(async () => {
-    await fetchLogs()
-    mounted = true
-  })
 </script>
 
 <div class="logs-page">
   <PageLayout
-    items={sortedLogs}
-    selectedId={selectedLogId}
+    items={page.sortedItems}
+    selectedId={page.selectedId}
     drawerId="signal-drawer"
     drawerLabel="Logs"
-    onRefresh={handleRefresh}
-    {refreshPulse}
-    {refreshAsideTip}
-    {loading}
+    onRefresh={page.handleRefresh}
+    refreshPulse={page.refreshPulse}
+    refreshAsideTip={page.refreshAsideTip}
+    loading={page.loading}
     itemKey={l => l.id}
   >
     {#snippet drawerChromeToolbar()}
@@ -295,9 +165,9 @@
         segment="toolbar"
         signal="logs"
         sortOptions={SORT_OPTIONS}
-        sortValue={sortColumn}
-        {sortDirection}
-        onSortChange={handleSortChange}
+        sortValue={page.sortColumn}
+        sortDirection={page.sortDirection}
+        onSortChange={page.handleSortChange}
       />
     {/snippet}
 
@@ -306,11 +176,11 @@
         segment="search"
         signal="logs"
         sortOptions={SORT_OPTIONS}
-        sortValue={sortColumn}
-        {sortDirection}
-        onSortChange={handleSortChange}
-        onSearchResults={handleSearchResults}
-        onSearchReady={api => (searchEditorApi = api)}
+        sortValue={page.sortColumn}
+        sortDirection={page.sortDirection}
+        onSortChange={page.handleSortChange}
+        onSearchResults={page.handleSearchResults}
+        onSearchReady={api => (page.searchEditorApi = api)}
       />
     {/snippet}
 
@@ -319,30 +189,21 @@
     {/snippet}
 
     {#snippet drawerFooter()}
-      <div class="flex items-center justify-between">
-        <span class="text-xs tabular-nums text-base-content/50">
-          {sortedLogs.length} log{sortedLogs.length !== 1 ? 's' : ''}
-        </span>
-        <button
-          type="button"
-          class="btn btn-ghost btn-xs text-error"
-          onclick={handleDeleteAllLogs}
-          aria-label="Delete all logs"
-        >
-          <TrashIcon class="h-3 w-3" aria-hidden="true" />
-          Delete all
-        </button>
-      </div>
+      <SignalDrawerFooter
+        count={page.sortedItems.length}
+        label="log"
+        onDeleteAll={handleDeleteAllLogs}
+      />
     {/snippet}
 
     {#snippet main()}
-      {#if error}
+      {#if displayError}
           <div class="logs-page__placeholder alert alert-error">
-            <span>Error: {error}</span>
+            <span>Error: {displayError}</span>
           </div>
-        {:else if loading && !hasLogRows}
+        {:else if page.loading && !hasLogRows}
           <div class="logs-page__placeholder logs-empty">Loading logs…</div>
-        {:else if !loading && !hasLogRows}
+        {:else if !page.loading && !hasLogRows}
           <div class="logs-page__placeholder logs-empty">
             <p class="text-rp-subtle">No logs in this time range</p>
             <p class="mt-2 text-sm text-rp-muted">
@@ -364,15 +225,15 @@
 
     {#snippet pageFooter()}
       <SignalFooter
-        index={selectedIndex}
-        total={sortedLogs.length}
+        index={page.selectedIndex}
+        total={page.sortedItems.length}
         label="log"
-        onFirst={selectFirst}
-        onPrev={() => selectByOffset(-1)}
-        onNext={() => selectByOffset(1)}
-        onLast={selectLast}
-        onDelete={selectedSummary
-          ? () => handleDeleteLog(selectedSummary.id)
+        onFirst={page.selectFirst}
+        onPrev={() => page.selectByOffset(-1)}
+        onNext={() => page.selectByOffset(1)}
+        onLast={page.selectLast}
+        onDelete={page.selectedSummary
+          ? () => handleDeleteLog(page.selectedSummary!.id)
           : undefined}
       />
     {/snippet}

--- a/desktopexporter/internal/frontend/src/pages/MetricsPage.svelte
+++ b/desktopexporter/internal/frontend/src/pages/MetricsPage.svelte
@@ -72,23 +72,18 @@
 </script>
 
 <script lang="ts">
-  import { onMount, untrack } from 'svelte'
+  import { untrack } from 'svelte'
   import { telemetryAPI } from '@/services/telemetry-service'
-  import { metricTypeBadgeClass, metricTypeLabel } from '@/components/metrics/utils/metric-type'
   import {
     getTimeContext,
     selectionToQueryRangeMs,
   } from '@/contexts/time-context.svelte'
-  import { signalIdFromPath, navigateToItem } from '@/route'
-  import { getRouteContext } from '@/contexts/route-context.svelte'
-  import type {
-    MetricData,
-    MetricStats,
-    SearchResultEvent,
-  } from '@/types/api-types'
-  import type { SearchEditorAPI } from '@/components/shared/Search/search-editor-api'
+  import { navigateToItem } from '@/route'
+  import type { MetricData, MetricStats } from '@/types/api-types'
+  import { createSignalListPage } from '@/contexts/signal-list-page.svelte'
   import PageLayout from '@/components/shared/PageLayout.svelte'
   import DrawerSearchPanel from '@/components/shared/Drawer/DrawerSearchPanel.svelte'
+  import SignalDrawerFooter from '@/components/shared/Drawer/SignalDrawerFooter.svelte'
   import MetricCard from '@/components/metrics/MetricCard.svelte'
   import SignalBadges from '@/components/shared/SignalBadges.svelte'
   import MetricChartView from '@/components/metrics/Charts/MetricChartView.svelte'
@@ -103,214 +98,98 @@
     getMetricViewContext,
     type HistogramTab,
   } from '@/contexts/metric-view-context.svelte'
-  import { TrashIcon } from '@/icons'
 
-  // --- context ---
   let timeContext = getTimeContext()
 
-  // --- URL is the source of truth for the selected metric (`/metrics/<id>`) ---
-  const routeContext = getRouteContext()
+  let baselineStats = $state<MetricStats | null>(null)
+  let polledStats = $state<MetricStats | null>(null)
+  let actionError = $state<string | null>(null)
 
-  // --- state: API / list ---
-  let metrics = $state<MetricSummary[]>([])
-  let loading = $state(true)
-  let error = $state<string | null>(null)
-  let mounted = $state(false)
+  const page = createSignalListPage<MetricSummary>({
+    signal: 'metrics',
+    getItemId: metricSummaryKey,
+    initialSort: { column: 'lastSeen', direction: 'desc' },
+    compare: (a, b, col, dir) =>
+      compareMetrics(a, b, col as MetricSortColumn, dir as MetricSortDirection),
+    fetchList: async () => {
+      const { start: startTime, end: endTime } = selectionToQueryRangeMs(
+        timeContext.selection,
+        Date.now()
+      )
+      const results = await telemetryAPI.searchMetricSummaries(startTime, endTime)
+      const s = await telemetryAPI.getStats()
+      baselineStats = s.metrics
+      polledStats = s.metrics
+      return results
+    },
+    pollStats: async () => {
+      const s = await telemetryAPI.getStats()
+      polledStats = s.metrics
+    },
+    refreshFromStats: () => {
+      if (!baselineStats || !polledStats) {
+        return { pulse: false, tip: '' }
+      }
+      const parts: string[] = []
+      const metricDelta = polledStats.metricCount - baselineStats.metricCount
+      if (metricDelta > 0) {
+        parts.push(`+${metricDelta} metric${metricDelta !== 1 ? 's' : ''}`)
+      }
+      const dpDelta = polledStats.dataPointCount - baselineStats.dataPointCount
+      if (dpDelta > 0) {
+        parts.push(`+${dpDelta} dp${dpDelta !== 1 ? 's' : ''}`)
+      }
+      return { pulse: parts.length > 0, tip: parts.join(', ') }
+    },
+  })
 
-  // --- state: sort ---
-  let sortColumn = $state<MetricSortColumn>('lastSeen')
-  let sortDirection = $state<MetricSortDirection>('desc')
-
-  // --- selection (derived from URL) ---
-  let selectedKey = $derived(signalIdFromPath('metrics', routeContext.route.path))
   let selectedMetric = $state<MetricData | undefined>(undefined)
   let detailLoading = $state(false)
 
-  // --- metric-view context ---
-  // Owns per-metric reactive state shared by MetricChartView and
-  // MetricDetailView (selection, expansion, histogram tab, legend
-  // visibility, bucket-series fetches, plus all the cheap derivations
-  // both panes need). We pass a getter so the context's identity stays
-  // stable for this page's lifetime even as the user navigates between
-  // metrics; the factory's effects re-seed per-metric state when the
-  // metric.id changes.
   createMetricViewContext(() => selectedMetric)
   const metricCtx = getMetricViewContext()
 
-  // --- state: polling / refresh indicator ---
-  let searchEditorApi = $state<SearchEditorAPI | null>(null)
-  let baselineStats = $state<MetricStats | null>(null)
-  let polledStats = $state<MetricStats | null>(null)
-  const POLL_INTERVAL_MS = 3000
-
-  // --- derived ---
-  let sortedMetrics = $derived.by(() => {
-    const col = sortColumn
-    const dir = sortDirection
-    const rows = [...metrics]
-    rows.sort((a, b) => compareMetrics(a, b, col, dir))
-    return rows
-  })
-
-  let hasMetricRows = $derived(metrics.length > 0)
-
-  let selectedSummary = $derived(
-    selectedKey
-      ? sortedMetrics.find(m => metricSummaryKey(m) === selectedKey)
-      : undefined
-  )
+  let hasMetricRows = $derived(page.items.length > 0)
+  let displayError = $derived(page.error ?? actionError)
 
   let chartAggregationTabs = $derived(
     aggregationViewTabs(metricCtx.availableAggregationViews)
   )
 
   let showChartAggregationTabs = $derived(
-    (selectedSummary?.metricType === 'Sum' ||
-      selectedSummary?.metricType === 'Gauge') &&
+    (page.selectedSummary?.metricType === 'Sum' ||
+      page.selectedSummary?.metricType === 'Gauge') &&
       chartAggregationTabs.length > 1
   )
 
   let showChartHistogramTabs = $derived(
-    selectedSummary?.metricType === 'Histogram' ||
-      selectedSummary?.metricType === 'ExponentialHistogram'
+    page.selectedSummary?.metricType === 'Histogram' ||
+      page.selectedSummary?.metricType === 'ExponentialHistogram'
   )
 
   let showChartTitleTabs = $derived(
     showChartAggregationTabs || showChartHistogramTabs
   )
 
-  // Position of the currently-selected metric in the sorted list.
-  // SignalFooter that lives in PageLayout's pageFooter slot
-  // (page-level chrome spanning main + detail). Returns -1 when
-  // nothing is selected (DetailNav renders all buttons disabled in
-  // that case).
-  let selectedIndex = $derived.by(() => {
-    if (!selectedKey) return -1
-    return sortedMetrics.findIndex(m => metricSummaryKey(m) === selectedKey)
-  })
-
-  function selectByIndex(i: number) {
-    const target = sortedMetrics[i]
-    if (target) navigateToItem('metrics', metricSummaryKey(target), 'replace')
-  }
-  function navFirst() {
-    selectByIndex(0)
-  }
-  function navPrev() {
-    if (selectedIndex > 0) selectByIndex(selectedIndex - 1)
-  }
-  function navNext() {
-    if (selectedIndex >= 0 && selectedIndex < sortedMetrics.length - 1) {
-      selectByIndex(selectedIndex + 1)
-    }
-  }
-  function navLast() {
-    selectByIndex(sortedMetrics.length - 1)
-  }
-
-  let refreshIndicatorText = $derived.by(() => {
-    if (!baselineStats || !polledStats) return ''
-    const parts: string[] = []
-    const metricDelta = polledStats.metricCount - baselineStats.metricCount
-    if (metricDelta > 0)
-      parts.push(`+${metricDelta} metric${metricDelta !== 1 ? 's' : ''}`)
-    const dpDelta = polledStats.dataPointCount - baselineStats.dataPointCount
-    if (dpDelta > 0) parts.push(`+${dpDelta} dp${dpDelta !== 1 ? 's' : ''}`)
-    return parts.join(', ')
-  })
-
-  // --- effects ---
-  let lastValidIndex = $state(0)
-
-  // Guarded behind mounted + !loading so a URL-provided id (shared link) is
-  // never replaced before the list has finished fetching.
+  // Re-fetch metric detail ONLY when the selected metric's identity changes --
+  // not when the summary object reference churns. Polling rebuilds the list
+  // every few seconds with fresh object references; depending on the summary
+  // object directly would re-fetch on every poll and clobber per-metric view
+  // state (AggregationView, legend selections, etc.).
   $effect(() => {
-    if (!mounted || loading) return
-    const id = selectedKey
-    const idx = id ? sortedMetrics.findIndex(m => metricSummaryKey(m) === id) : -1
-    if (idx >= 0) {
-      lastValidIndex = idx
-    } else if (sortedMetrics.length > 0) {
-      const fallback =
-        sortedMetrics[Math.min(lastValidIndex, sortedMetrics.length - 1)]
-      if (fallback) {
-        navigateToItem('metrics', metricSummaryKey(fallback), 'replace')
-      }
-    } else if (id) {
-      navigateToItem('metrics', null, 'replace')
-    }
-  })
-
-  // Re-fetch metric detail ONLY when the selected metric's identity
-  // changes -- not when the summary object reference churns. Polling
-  // rebuilds `metrics` (and therefore `sortedMetrics`/`selectedSummary`)
-  // every few seconds with fresh object references; if we depended on
-  // the summary object directly the effect would re-fetch on every
-  // poll, which would also re-fire the context's per-metric reset and
-  // clobber per-metric view state (e.g. AggregationView, legend selections).
-  // We read the *id* reactively (stable per metric) and grab the
-  // current summary via untrack so its identity churn doesn't count
-  // as a dep.
-  $effect(() => {
-    const id = selectedSummary
-      ? metricSummaryKey(selectedSummary)
+    const id = page.selectedSummary
+      ? metricSummaryKey(page.selectedSummary)
       : null
     if (!id) {
       selectedMetric = undefined
       return
     }
-    const summary = untrack(() => selectedSummary)
+    const summary = untrack(() => page.selectedSummary)
     if (summary) fetchMetricDetail(summary)
   })
 
-  $effect(() => {
-    void timeContext.selection
-    if (mounted) {
-      fetchMetrics()
-    }
-  })
-
-  $effect(() => {
-    if (!mounted) return
-    const id = setInterval(async () => {
-      try {
-        const s = await telemetryAPI.getStats()
-        polledStats = s.metrics
-      } catch {
-        /* polling failures are silent */
-      }
-    }, POLL_INTERVAL_MS)
-    return () => clearInterval(id)
-  })
-
-  // --- handlers ---
-  function handleSortChange(value: string, direction: 'asc' | 'desc') {
-    sortColumn = value as MetricSortColumn
-    sortDirection = direction
-  }
-
   function selectMetric(key: string) {
-    // Explicit click is navigational: push so back returns to the prior metric.
-    navigateToItem('metrics', key)
-  }
-
-  async function fetchMetrics() {
-    try {
-      loading = true
-      error = null
-      const { start: startTime, end: endTime } = selectionToQueryRangeMs(
-        timeContext.selection,
-        Date.now()
-      )
-      metrics = await telemetryAPI.searchMetricSummaries(startTime, endTime)
-      const s = await telemetryAPI.getStats()
-      baselineStats = s.metrics
-      polledStats = s.metrics
-    } catch (err) {
-      error = err instanceof Error ? err.message : 'Failed to load metrics'
-    } finally {
-      loading = false
-    }
+    page.selectItem(key)
   }
 
   async function fetchMetricDetail(summary: MetricSummary) {
@@ -331,47 +210,30 @@
     }
   }
 
-  function handleSearchResults(event: SearchResultEvent) {
-    if (event.signal === 'metrics') {
-      loading = false
-      error = null
-      metrics = event.results
-    }
-  }
-
-  function handleRefresh() {
-    searchEditorApi?.clear()
-    fetchMetrics()
-  }
-
   async function handleDeleteAllMetrics() {
+    actionError = null
     try {
       await telemetryAPI.clearMetrics()
       navigateToItem('metrics', null, 'replace')
       selectedMetric = undefined
-      await fetchMetrics()
+      await page.runListFetch()
     } catch (err) {
-      error = err instanceof Error ? err.message : 'Failed to delete metrics'
+      actionError =
+        err instanceof Error ? err.message : 'Failed to delete metrics'
     }
   }
-
-  // --- lifecycle ---
-  onMount(async () => {
-    await fetchMetrics()
-    mounted = true
-  })
 </script>
 
 <div class="metrics-page">
   <PageLayout
-    items={sortedMetrics}
-    selectedId={selectedKey}
+    items={page.sortedItems}
+    selectedId={page.selectedId}
     drawerId="signal-drawer"
     drawerLabel="Metrics"
-    onRefresh={handleRefresh}
-    refreshPulse={!!refreshIndicatorText}
-    refreshAsideTip={refreshIndicatorText}
-    {loading}
+    onRefresh={page.handleRefresh}
+    refreshPulse={page.refreshPulse}
+    refreshAsideTip={page.refreshAsideTip}
+    loading={page.loading}
     itemKey={metricSummaryKey}
     resizableStorageKey="metric-detail-panels"
     minDetailPx={352}
@@ -381,9 +243,9 @@
         segment="toolbar"
         signal="metrics"
         sortOptions={SORT_OPTIONS}
-        sortValue={sortColumn}
-        {sortDirection}
-        onSortChange={handleSortChange}
+        sortValue={page.sortColumn}
+        sortDirection={page.sortDirection}
+        onSortChange={page.handleSortChange}
       />
     {/snippet}
 
@@ -392,11 +254,11 @@
         segment="search"
         signal="metrics"
         sortOptions={SORT_OPTIONS}
-        sortValue={sortColumn}
-        {sortDirection}
-        onSortChange={handleSortChange}
-        onSearchResults={handleSearchResults}
-        onSearchReady={api => (searchEditorApi = api)}
+        sortValue={page.sortColumn}
+        sortDirection={page.sortDirection}
+        onSortChange={page.handleSortChange}
+        onSearchResults={page.handleSearchResults}
+        onSearchReady={api => (page.searchEditorApi = api)}
       />
     {/snippet}
 
@@ -405,20 +267,11 @@
     {/snippet}
 
     {#snippet drawerFooter()}
-      <div class="flex items-center justify-between">
-        <span class="text-xs tabular-nums text-rp-muted">
-          {sortedMetrics.length} metric{sortedMetrics.length !== 1 ? 's' : ''}
-        </span>
-        <button
-          type="button"
-          class="btn btn-ghost btn-xs text-error"
-          onclick={handleDeleteAllMetrics}
-          aria-label="Delete all metrics"
-        >
-          <TrashIcon class="h-3 w-3" aria-hidden="true" />
-          Delete all
-        </button>
-      </div>
+      <SignalDrawerFooter
+        count={page.sortedItems.length}
+        label="metric"
+        onDeleteAll={handleDeleteAllMetrics}
+      />
     {/snippet}
 
     {#snippet main()}
@@ -429,7 +282,8 @@
            snippet below): always present, spans main + detail
            regardless of content state, and DetailNav self-disables
            when there is nothing to navigate. -->
-        {#if selectedSummary}
+        {#if page.selectedSummary}
+        {@const selectedSummary = page.selectedSummary}
         {#snippet metricChartHeaderBadge()}
           <SignalBadges
             signal="metric"
@@ -474,15 +328,15 @@
           </PaneHeader>
         {/if}
       {/if}
-        {#if error}
+        {#if displayError}
           <div class="metrics-page__placeholder alert alert-error">
-            <span>Error: {error}</span>
+            <span>Error: {displayError}</span>
           </div>
-        {:else if loading && !hasMetricRows}
+        {:else if page.loading && !hasMetricRows}
           <div class="metrics-page__placeholder metrics-empty">
             Loading metrics…
           </div>
-        {:else if !loading && !hasMetricRows}
+        {:else if !page.loading && !hasMetricRows}
           <div class="metrics-page__placeholder metrics-empty">
             <p class="text-rp-subtle">No metrics in this time range</p>
             <p class="mt-2 text-sm text-rp-muted">
@@ -502,13 +356,13 @@
 
     {#snippet pageFooter()}
       <SignalFooter
-        index={selectedIndex}
-        total={sortedMetrics.length}
+        index={page.selectedIndex}
+        total={page.sortedItems.length}
         label="metric"
-        onFirst={navFirst}
-        onPrev={navPrev}
-        onNext={navNext}
-        onLast={navLast}
+        onFirst={page.selectFirst}
+        onPrev={() => page.selectByOffset(-1)}
+        onNext={() => page.selectByOffset(1)}
+        onLast={page.selectLast}
       />
     {/snippet}
   </PageLayout>

--- a/desktopexporter/internal/frontend/src/pages/TracesPage.svelte
+++ b/desktopexporter/internal/frontend/src/pages/TracesPage.svelte
@@ -55,83 +55,95 @@
 </script>
 
 <script lang="ts">
-  import { onMount } from 'svelte'
   import { telemetryAPI } from '@/services/telemetry-service'
   import {
     getTimeContext,
     selectionToQueryRangeMs,
   } from '@/contexts/time-context.svelte'
+  import { getRouteContext } from '@/contexts/route-context.svelte'
   import {
-    signalIdFromPath,
     navigateToItem,
     getSpanFromQuery,
     setSpanInQuery,
     SPAN_PARAM,
   } from '@/route'
-  import { getRouteContext } from '@/contexts/route-context.svelte'
   import type {
     TraceData,
     SearchResultEvent,
     TraceStats,
   } from '@/types/api-types'
   import type { QueryNode } from '@/components/shared/Search/queryTree'
-  import type { SearchEditorAPI } from '@/components/shared/Search/search-editor-api'
+  import { createSignalListPage } from '@/contexts/signal-list-page.svelte'
   import PageLayout from '@/components/shared/PageLayout.svelte'
   import DrawerSearchPanel from '@/components/shared/Drawer/DrawerSearchPanel.svelte'
+  import SignalDrawerFooter from '@/components/shared/Drawer/SignalDrawerFooter.svelte'
   import TraceCard from '@/components/traces/TraceCard.svelte'
   import DetailView from '@/components/traces/Detail/TraceDetailView.svelte'
   import WaterfallView from '@/components/traces/Waterfall/WaterfallView.svelte'
   import SignalFooter from '@/components/shared/SignalFooter.svelte'
-  import { TrashIcon } from '@/icons'
 
-  // --- context ---
   let timeContext = getTimeContext()
-
-  // --- URL is the source of truth for the selected trace + span ---
-  // `/traces/<traceID>?span=<spanID>`. Every selection change is a navigate (below).
   const routeContext = getRouteContext()
 
-  // --- state: API / list ---
-  let traceSummaries = $state<TraceSummary[]>([])
-  let loading = $state(true)
-  let error = $state<string | null>(null)
-  let mounted = $state(false)
+  let baselineStats = $state<TraceStats | null>(null)
+  let polledStats = $state<TraceStats | null>(null)
+  let actionError = $state<string | null>(null)
 
-  // --- state: sort ---
-  let sortColumn = $state<TraceSummarySortColumn>('startTime')
-  let sortDirection = $state<TraceSummarySortDirection>('desc')
+  const page = createSignalListPage<TraceSummary>({
+    signal: 'traces',
+    getItemId: trace => trace.traceID,
+    initialSort: { column: 'startTime', direction: 'desc' },
+    compare: (a, b, col, dir) =>
+      compareTraceSummaries(
+        a,
+        b,
+        col as TraceSummarySortColumn,
+        dir as TraceSummarySortDirection
+      ),
+    fetchList: async () => {
+      const { start: startTime, end: endTime } = selectionToQueryRangeMs(
+        timeContext.selection,
+        Date.now()
+      )
+      const results = await telemetryAPI.searchTraces(startTime, endTime)
+      const s = await telemetryAPI.getStats()
+      baselineStats = s.traces
+      polledStats = s.traces
+      return results
+    },
+    pollStats: async () => {
+      const s = await telemetryAPI.getStats()
+      polledStats = s.traces
+    },
+    refreshFromStats: () => {
+      if (!baselineStats || !polledStats) {
+        return { pulse: false, tip: '' }
+      }
+      const parts: string[] = []
+      const traceDelta = polledStats.traceCount - baselineStats.traceCount
+      if (traceDelta > 0) {
+        parts.push(
+          `+${traceDelta.toLocaleString()} trace${traceDelta !== 1 ? 's' : ''}`
+        )
+      }
+      const spanDelta = polledStats.spanCount - baselineStats.spanCount
+      if (spanDelta > 0) {
+        parts.push(
+          `+${spanDelta.toLocaleString()} span${spanDelta !== 1 ? 's' : ''}`
+        )
+      }
+      return { pulse: parts.length > 0, tip: parts.join(', ') }
+    },
+  })
 
-  // --- selection + detail (selection derived from URL) ---
-  let selectedTraceId = $derived(signalIdFromPath('traces', routeContext.route.path))
+  // `/traces/<traceID>?span=<spanID>` — span selection lives in the query string.
   let selectedSpanID = $derived(routeContext.route.query[SPAN_PARAM] ?? null)
   let traceData = $state<TraceData | null>(null)
   let detailLoading = $state(false)
-
-  // --- state: active search query (for span highlighting in waterfall) ---
   let activeQueryTree = $state<QueryNode | undefined>(undefined)
 
-  // --- state: polling / refresh ---
-  let searchEditorApi = $state<SearchEditorAPI | null>(null)
-  let baselineStats = $state<TraceStats | null>(null)
-  let polledStats = $state<TraceStats | null>(null)
-  const POLL_INTERVAL_MS = 3000
-
-  // --- derived ---
-  let sortedTraces = $derived.by(() => {
-    const col = sortColumn
-    const dir = sortDirection
-    const rows = [...traceSummaries]
-    rows.sort((a, b) => compareTraceSummaries(a, b, col, dir))
-    return rows
-  })
-
-  let hasTraceRows = $derived(traceSummaries.length > 0)
-
-  let selectedSummary = $derived(
-    selectedTraceId
-      ? sortedTraces.find(t => t.traceID === selectedTraceId)
-      : undefined
-  )
+  let hasTraceRows = $derived(page.items.length > 0)
+  let displayError = $derived(page.error ?? actionError)
 
   let selectedSpan = $derived(
     traceData?.spans.find(n => n.spanData.spanID === selectedSpanID)
@@ -140,59 +152,12 @@
       undefined
   )
 
-  let pendingNewTraceCount = $derived.by(() => {
-    if (!baselineStats || !polledStats) return 0
-    const delta = polledStats.traceCount - baselineStats.traceCount
-    return delta > 0 ? delta : 0
-  })
-
-  let pendingNewSpanCount = $derived.by(() => {
-    if (!baselineStats || !polledStats) return 0
-    const delta = polledStats.spanCount - baselineStats.spanCount
-    return delta > 0 ? delta : 0
-  })
-
-  let refreshPulse = $derived(
-    pendingNewTraceCount > 0 || pendingNewSpanCount > 0
-  )
-
-  let refreshAsideTip = $derived.by(() => {
-    const parts: string[] = []
-    if (pendingNewTraceCount > 0)
-      parts.push(`+${pendingNewTraceCount.toLocaleString()} trace${pendingNewTraceCount !== 1 ? 's' : ''}`)
-    if (pendingNewSpanCount > 0)
-      parts.push(`+${pendingNewSpanCount.toLocaleString()} span${pendingNewSpanCount !== 1 ? 's' : ''}`)
-    return parts.join(', ')
-  })
-
-  // --- effects ---
-
-  let lastValidIndex = $state(0)
-
-  // Auto-select a trace when none (or an out-of-range id) is selected. Guarded
-  // behind mounted + !loading so a URL-provided id is never clobbered before
-  // the list has finished fetching (shared-link load ordering).
   $effect(() => {
-    if (!mounted || loading) return
-    const id = selectedTraceId
-    const idx = id ? sortedTraces.findIndex(t => t.traceID === id) : -1
-    if (idx >= 0) {
-      lastValidIndex = idx
-    } else if (sortedTraces.length > 0) {
-      const fallback =
-        sortedTraces[Math.min(lastValidIndex, sortedTraces.length - 1)]
-      if (fallback) navigateToItem('traces', fallback.traceID, 'replace')
-    } else if (id) {
-      navigateToItem('traces', null, 'replace')
-    }
-  })
-
-  $effect(() => {
-    const summary = selectedSummary
+    const summary = page.selectedSummary
     if (!summary) {
       // Don't tear down the detail view while the list is still loading -- a
       // shared link's trace id may simply not be in the list yet.
-      if (!mounted || loading) return
+      if (!page.mounted || page.loading) return
       traceData = null
       setSpanInQuery(null)
       return
@@ -200,88 +165,18 @@
     fetchTraceDetail(summary.traceID, activeQueryTree)
   })
 
-  $effect(() => {
-    void timeContext.selection
-    if (mounted) {
-      fetchTraces()
-    }
-  })
-
-  $effect(() => {
-    if (!mounted) return
-    const id = setInterval(async () => {
-      try {
-        const s = await telemetryAPI.getStats()
-        polledStats = s.traces
-      } catch {
-        /* polling failures are silent */
-      }
-    }, POLL_INTERVAL_MS)
-    return () => clearInterval(id)
-  })
-
-  // --- handlers ---
-  function handleSortChange(value: string, direction: 'asc' | 'desc') {
-    sortColumn = value as TraceSummarySortColumn
-    sortDirection = direction
-  }
-
   function selectTrace(traceID: string) {
-    // Explicit click is navigational: push so back returns to the prior trace.
-    navigateToItem('traces', traceID)
-  }
-
-  // --- nav: walk sortedTraces ---
-
-  let selectedIndex = $derived(
-    selectedTraceId
-      ? sortedTraces.findIndex(t => t.traceID === selectedTraceId)
-      : -1
-  )
-
-  function selectByOffset(delta: number) {
-    if (selectedIndex < 0 || sortedTraces.length === 0) return
-    const target = Math.max(
-      0,
-      Math.min(sortedTraces.length - 1, selectedIndex + delta)
-    )
-    if (target === selectedIndex) return
-    const next = sortedTraces[target]
-    if (next) navigateToItem('traces', next.traceID, 'replace')
-  }
-
-  function selectFirst() {
-    const first = sortedTraces[0]
-    if (first) navigateToItem('traces', first.traceID, 'replace')
-  }
-
-  function selectLast() {
-    const last = sortedTraces[sortedTraces.length - 1]
-    if (last) navigateToItem('traces', last.traceID, 'replace')
+    page.selectItem(traceID)
   }
 
   function handleSelectSpan(spanID: string) {
-    // Clicking a span is navigational: push so back returns to the prior span.
     setSpanInQuery(spanID, 'push')
   }
 
-  async function fetchTraces() {
-    try {
-      loading = true
-      error = null
-      const { start: startTime, end: endTime } = selectionToQueryRangeMs(
-        timeContext.selection,
-        Date.now()
-      )
-      traceSummaries = await telemetryAPI.searchTraces(startTime, endTime)
-      const s = await telemetryAPI.getStats()
-      baselineStats = s.traces
-      polledStats = s.traces
-    } catch (err) {
-      error = err instanceof Error ? err.message : 'Failed to fetch traces'
-      console.error('Error fetching trace summaries:', err)
-    } finally {
-      loading = false
+  function handleSearchResults(event: SearchResultEvent) {
+    page.handleSearchResults(event)
+    if (event.signal === 'traces') {
+      activeQueryTree = event.queryTree as QueryNode | undefined
     }
   }
 
@@ -297,7 +192,6 @@
         const firstMatch = result.spans.find(n => n.matched)
         desired = firstMatch?.spanData.spanID ?? spanIds[0] ?? null
       } else if (urlSpan && spanIds.includes(urlSpan)) {
-        // Honor a span carried by a shared/deep link.
         desired = urlSpan
       } else {
         desired = spanIds[0] ?? null
@@ -312,71 +206,51 @@
     }
   }
 
-  function handleRefresh() {
-    searchEditorApi?.clear()
-    fetchTraces()
-  }
-
-  function handleSearchResults(event: SearchResultEvent) {
-    if (event.signal === 'traces') {
-      loading = false
-      error = null
-      traceSummaries = event.results
-      activeQueryTree = event.queryTree as QueryNode | undefined
-    }
-  }
-
   async function handleDeleteAllTraces() {
+    actionError = null
     try {
       await telemetryAPI.clearTraces()
       navigateToItem('traces', null, 'replace')
       traceData = null
-      await fetchTraces()
+      await page.runListFetch()
     } catch (err) {
-      error = err instanceof Error ? err.message : 'Failed to delete traces'
+      actionError =
+        err instanceof Error ? err.message : 'Failed to delete traces'
       console.error('Error deleting traces:', err)
     }
   }
 
   async function handleDeleteTrace(traceID: string) {
+    actionError = null
     try {
       await telemetryAPI.deleteTraces([traceID])
-      if (selectedTraceId === traceID) {
+      if (page.selectedId === traceID) {
         navigateToItem('traces', null, 'replace')
         traceData = null
       }
-      await fetchTraces()
+      await page.runListFetch()
     } catch (err) {
-      error = err instanceof Error ? err.message : 'Failed to delete trace'
+      actionError =
+        err instanceof Error ? err.message : 'Failed to delete trace'
       console.error('Error deleting trace:', err)
     }
   }
 
-  // Wrapped form for the footer's onDelete: SignalFooter expects a
-  // 0-arg callback. We bind the currently selected trace ID inside the
-  // function (not at the prop site) so TS's narrowing on the truthy
-  // check holds when the callback eventually fires.
   function deleteSelectedTrace() {
     if (traceData) handleDeleteTrace(traceData.traceID)
   }
-
-  // --- lifecycle ---
-  onMount(async () => {
-    await fetchTraces()
-    mounted = true
-  })
 </script>
 
 <div class="traces-page">
   <PageLayout
-    items={sortedTraces}
-    selectedId={selectedTraceId}
+    items={page.sortedItems}
+    selectedId={page.selectedId}
     drawerId="signal-drawer"
     drawerLabel="Traces"
-    onRefresh={handleRefresh}
-    {refreshPulse}
-    {refreshAsideTip}
-    {loading}
+    onRefresh={page.handleRefresh}
+    refreshPulse={page.refreshPulse}
+    refreshAsideTip={page.refreshAsideTip}
+    loading={page.loading}
     itemKey={t => t.traceID}
     resizableStorageKey="trace-detail-panels"
     minDetailPx={352}
@@ -386,9 +260,9 @@
         segment="toolbar"
         signal="traces"
         sortOptions={SORT_OPTIONS}
-        sortValue={sortColumn}
-        {sortDirection}
-        onSortChange={handleSortChange}
+        sortValue={page.sortColumn}
+        sortDirection={page.sortDirection}
+        onSortChange={page.handleSortChange}
       />
     {/snippet}
 
@@ -397,11 +271,11 @@
         segment="search"
         signal="traces"
         sortOptions={SORT_OPTIONS}
-        sortValue={sortColumn}
-        {sortDirection}
-        onSortChange={handleSortChange}
+        sortValue={page.sortColumn}
+        sortDirection={page.sortDirection}
+        onSortChange={page.handleSortChange}
         onSearchResults={handleSearchResults}
-        onSearchReady={api => (searchEditorApi = api)}
+        onSearchReady={api => (page.searchEditorApi = api)}
       />
     {/snippet}
 
@@ -410,32 +284,23 @@
     {/snippet}
 
     {#snippet drawerFooter()}
-      <div class="flex items-center justify-between">
-        <span class="text-xs tabular-nums text-base-content/50">
-          {sortedTraces.length} trace{sortedTraces.length !== 1 ? 's' : ''}
-        </span>
-        <button
-          type="button"
-          class="btn btn-ghost btn-xs text-error"
-          onclick={handleDeleteAllTraces}
-          aria-label="Delete all traces"
-        >
-          <TrashIcon class="h-3 w-3" aria-hidden="true" />
-          Delete all
-        </button>
-      </div>
+      <SignalDrawerFooter
+        count={page.sortedItems.length}
+        label="trace"
+        onDeleteAll={handleDeleteAllTraces}
+      />
     {/snippet}
 
     {#snippet main()}
-      {#if error}
+      {#if displayError}
         <div class="traces-page__placeholder alert alert-error">
-          <span>Error: {error}</span>
+          <span>Error: {displayError}</span>
         </div>
-      {:else if loading && !hasTraceRows}
+      {:else if page.loading && !hasTraceRows}
         <div class="traces-page__placeholder traces-empty">
           Loading traces…
         </div>
-      {:else if !loading && !hasTraceRows}
+      {:else if !page.loading && !hasTraceRows}
         <div class="traces-page__placeholder traces-empty">
           <p class="text-rp-subtle">No traces in this time range</p>
           <p class="mt-2 text-sm text-rp-muted">
@@ -466,13 +331,13 @@
 
     {#snippet pageFooter()}
       <SignalFooter
-        index={selectedIndex}
-        total={sortedTraces.length}
+        index={page.selectedIndex}
+        total={page.sortedItems.length}
         label="trace"
-        onFirst={selectFirst}
-        onPrev={() => selectByOffset(-1)}
-        onNext={() => selectByOffset(1)}
-        onLast={selectLast}
+        onFirst={page.selectFirst}
+        onPrev={() => page.selectByOffset(-1)}
+        onNext={() => page.selectByOffset(1)}
+        onLast={page.selectLast}
         onDelete={traceData ? deleteSelectedTrace : undefined}
       />
     {/snippet}

--- a/desktopexporter/internal/frontend/src/test/SignalListPageProbe.svelte
+++ b/desktopexporter/internal/frontend/src/test/SignalListPageProbe.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { createSignalListPage } from '@/contexts/signal-list-page.svelte'
+  import type { SignalListPage } from '@/contexts/signal-list-page.svelte'
+
+  type Item = { id: string; name: string }
+
+  interface Props {
+    fetchList: () => Promise<Item[]>
+    onContext?: (ctx: SignalListPage<Item>) => void
+  }
+
+  let { fetchList, onContext }: Props = $props()
+
+  const page = createSignalListPage<Item>({
+    signal: 'logs',
+    getItemId: item => item.id,
+    fetchList: () => fetchList(),
+    compare: (a, b) => a.name.localeCompare(b.name),
+    initialSort: { column: 'name', direction: 'asc' },
+  })
+
+  $effect(() => {
+    onContext?.(page)
+  })
+</script>
+
+<output data-testid="loading">{page.loading}</output>
+<output data-testid="mounted">{page.mounted}</output>
+<output data-testid="selected-id">{page.selectedId ?? ''}</output>
+<output data-testid="selected-index">{page.selectedIndex}</output>
+<output data-testid="item-count">{page.sortedItems.length}</output>
+<output data-testid="item-ids">
+  {page.sortedItems.map(item => item.id).join(',')}
+</output>

--- a/desktopexporter/internal/frontend/src/types/api-types.ts
+++ b/desktopexporter/internal/frontend/src/types/api-types.ts
@@ -314,6 +314,21 @@ export type Stats = {
 // projection. Full LogData for a single row is fetched on demand via
 // the getLog(id) JSON-RPC method.
 export type SearchResultEvent =
-  | { signal: 'traces'; results: TraceSummary[]; queryTree?: unknown; updateSeq: number }
-  | { signal: 'logs'; results: LogSummary[]; queryTree?: unknown; updateSeq: number }
-  | { signal: 'metrics'; results: MetricSummary[]; queryTree?: unknown; updateSeq: number }
+  | {
+      signal: 'traces'
+      results: TraceSummary[]
+      queryTree?: unknown
+      updateSeq: number
+    }
+  | {
+      signal: 'logs'
+      results: LogSummary[]
+      queryTree?: unknown
+      updateSeq: number
+    }
+  | {
+      signal: 'metrics'
+      results: MetricSummary[]
+      queryTree?: unknown
+      updateSeq: number
+    }

--- a/desktopexporter/internal/frontend/src/types/api-types.ts
+++ b/desktopexporter/internal/frontend/src/types/api-types.ts
@@ -314,6 +314,6 @@ export type Stats = {
 // projection. Full LogData for a single row is fetched on demand via
 // the getLog(id) JSON-RPC method.
 export type SearchResultEvent =
-  | { signal: 'traces'; results: TraceSummary[]; queryTree?: unknown }
-  | { signal: 'logs'; results: LogSummary[]; queryTree?: unknown }
-  | { signal: 'metrics'; results: MetricSummary[]; queryTree?: unknown }
+  | { signal: 'traces'; results: TraceSummary[]; queryTree?: unknown; updateSeq: number }
+  | { signal: 'logs'; results: LogSummary[]; queryTree?: unknown; updateSeq: number }
+  | { signal: 'metrics'; results: MetricSummary[]; queryTree?: unknown; updateSeq: number }


### PR DESCRIPTION
- Adds `createSignalListPage()` to centralize duplicated list-page orchestration (mount/fetch, sort, URL selection guard, time-range refetch, stats polling refresh indicator, footer nav, search hooks) across traces, logs, and metrics.
- Adds `SignalDrawerFooter` with unified count styling (`text-base-content/50`) for all three signal drawers.
- Migrates `LogsPage`, `MetricsPage`, and `TracesPage` to the composable; each page keeps signal-specific sort logic, detail fetching, and delete handlers.
- Hardens list update ordering: per-signal `updateSeq` guards (bidirectional fetch vs search), unmount cancellation, single fetch on mount.

Closes #244.