### PR TITLE
Harden store concurrency with scoped RWMutex (closes #238)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -65,6 +65,35 @@ jobs:
     - name: Exporter Go Tests
       run: cd desktopexporter; go test ./...
 
+  # Go source checks that need no CGO and no DuckDB toolchain, so they run once
+  # on Linux rather than across the build matrix (which includes Windows, where
+  # this shell syntax differs).
+  go-checks:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Set up Go
+      uses: actions/setup-go@v7
+      with:
+        go-version: '1.26'
+
+    # The frontend job gates Prettier; this is the Go equivalent.
+    - name: Format check (gofmt)
+      run: make format-go-check
+
+    # Guards the store's concurrency model: production code must reach DuckDB
+    # through Store.WithConn, WithDBRead, or WithDBWrite so access is ordered
+    # against ingest, retention, and Close. A raw *sql.DB handed to a caller
+    # escapes that ordering, which is what issue #238 fixed.
+    - name: No unguarded store access outside tests
+      run: |
+        if grep -rn --include='*.go' '\.DB()' desktopexporter/ | grep -v '_test\.go'; then
+          echo "::error::Production code must use Store.WithDBRead/WithDBWrite, not a raw *sql.DB."
+          exit 1
+        fi
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -142,7 +142,7 @@ What this does **not** guarantee: a query does not see rows that an in-flight in
 
 `EnforceRetention` takes the write lock once per prune round rather than across a whole pass, so queries interleave between rounds instead of blocking for up to three checkpoints.
 
-`Store.DB()` returns the pool without holding the lock across the caller's work. It exists for tests, which drive one store from a single goroutine; production code goes through `WithDBRead` or `WithDBWrite`.
+`Store` exposes no accessor for its `*sql.DB`. Handing out the pool would let a caller query after the lock released, which is the ordering these methods exist to enforce, so every caller — production and test alike — passes a closure to `WithDBRead` or `WithDBWrite`. CI enforces this: a `.DB()` call outside `_test.go` files fails the `go-checks` job.
 
 ### Schema
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -123,7 +123,26 @@ Ingest writes directly from OpenTelemetry pdata into DuckDB appenders. There are
 
 **Engine**: DuckDB via `github.com/duckdb/duckdb-go/v2` (CGO required).
 
-**Connection model**: `store.Store` wraps a mutex-protected `driver.Conn`. All reads and writes go through `WithConn` to serialize access.
+**Connection model**: `store.Store` holds two handles to one DuckDB database, ordered by a single `sync.RWMutex`.
+
+- `conn` — a dedicated `driver.Conn` from `connector.Connect`, used only by ingest. DuckDB appenders are bound to the connection that created them, so ingest cannot run on the pool.
+- `db` — a `*sql.DB` pool from `sql.OpenDB`, used by every query and by the delete/checkpoint paths. The pool is capped via `SetMaxOpenConns`, because each pooled connection is a real DuckDB connection with real memory cost.
+
+Access is chosen by intent, not by handle:
+
+| Method | Lock | Handle | Used by |
+|--------|------|--------|---------|
+| `WithConn` | write | `conn` | ingest (appenders) |
+| `WithDBWrite` | write | `db` | clear, delete, retention prune + checkpoint |
+| `WithDBRead` | read | `db` | all queries |
+
+The write lock is shared across both handles, so appender writes, deletes, and retention checkpoints are mutually exclusive even though they run on different connections. Reads run concurrently with one another and never overlap a write.
+
+What this does **not** guarantee: a query does not see rows that an in-flight ingest has appended but not yet flushed. DuckDB appenders buffer client-side and become visible on flush — automatically at the chunk threshold, or on `Flush`/`Close` at the end of each ingest call. Under load the UI can lag ingest by up to one batch. That is a visibility window, not a lost write.
+
+`EnforceRetention` takes the write lock once per prune round rather than across a whole pass, so queries interleave between rounds instead of blocking for up to three checkpoints.
+
+`Store.DB()` returns the pool without holding the lock across the caller's work. It exists for tests, which drive one store from a single goroutine; production code goes through `WithDBRead` or `WithDBWrite`.
 
 ### Schema
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,17 @@ install-clean:
 build-go:
 	go build -o otel-desktop-viewer
 
+.PHONY: format-go
+format-go:
+	gofmt -w .
+
+.PHONY: format-go-check
+format-go-check:
+	@unformatted=$$(gofmt -l .); \
+	if [ -n "$$unformatted" ]; then \
+		echo "These files need gofmt:"; echo "$$unformatted"; exit 1; \
+	fi
+
 .PHONY: test-go
 test-go:
 	cd desktopexporter && go test ./...
@@ -118,6 +129,8 @@ help:
 	@echo ""
 	@echo "Server:"
 	@echo "  build-go          - Build Go binary"
+	@echo "  format-go         - Format Go code (gofmt)"
+	@echo "  format-go-check   - Fail if any Go file needs gofmt"
 	@echo "  test-go           - Run Go tests"
 	@echo "  run-go            - Run server (in-memory, data lost on exit)"
 	@echo "  run-go-persist    - Run server with persistent DB file (data retained)"

--- a/desktopexporter/exporter.go
+++ b/desktopexporter/exporter.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
-	"go.uber.org/zap"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
 
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/server"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store"

--- a/desktopexporter/internal/server/jsonrpc_handler.go
+++ b/desktopexporter/internal/server/jsonrpc_handler.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -37,6 +38,19 @@ func (h *JSONRPCHandler) handleStoreError(err error) error {
 		h.logger.Error("store error", zap.Error(err))
 	}
 	return mapped
+}
+
+// storeRead runs a query that returns a value, under the store's read lock.
+// Every read path in this file goes through here so no handler reaches the
+// pool unordered against ingest and retention.
+func storeRead[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error) {
+	var out T
+	err := s.WithDBRead(func(db *sql.DB) error {
+		var err error
+		out, err = fn(db)
+		return err
+	})
+	return out, err
 }
 
 func (h *JSONRPCHandler) Handle(ctx context.Context, req *jsonrpc2.Request) (any, error) {
@@ -107,7 +121,9 @@ func (h *JSONRPCHandler) searchTraces(ctx context.Context, req *jsonrpc2.Request
 		query = params[2]
 	}
 
-	summaries, err := spans.SearchTraces(ctx, h.store.DB(), startTime, endTime, query)
+	summaries, err := storeRead(h.store, func(db *sql.DB) (json.RawMessage, error) {
+		return spans.SearchTraces(ctx, db, startTime, endTime, query)
+	})
 	if err != nil {
 		return nil, h.handleStoreError(err)
 	}
@@ -134,7 +150,9 @@ func (h *JSONRPCHandler) searchSpans(ctx context.Context, req *jsonrpc2.Request)
 		query = params[1]
 	}
 
-	result, err := spans.SearchSpans(ctx, h.store.DB(), traceID, query)
+	result, err := storeRead(h.store, func(db *sql.DB) (json.RawMessage, error) {
+		return spans.SearchSpans(ctx, db, traceID, query)
+	})
 	if err != nil {
 		return nil, h.handleStoreError(err)
 	}
@@ -142,7 +160,9 @@ func (h *JSONRPCHandler) searchSpans(ctx context.Context, req *jsonrpc2.Request)
 }
 
 func (h *JSONRPCHandler) clearTraces(ctx context.Context) (any, error) {
-	err := spans.Clear(ctx, h.store.DB())
+	err := h.store.WithDBWrite(func(db *sql.DB) error {
+		return spans.Clear(ctx, db)
+	})
 	if err != nil {
 		return nil, h.handleStoreError(err)
 	}
@@ -169,7 +189,9 @@ func (h *JSONRPCHandler) searchLogs(ctx context.Context, req *jsonrpc2.Request) 
 	if len(params) == 3 {
 		query = params[2]
 	}
-	result, err := logs.Search(ctx, h.store.DB(), startTime, endTime, query)
+	result, err := storeRead(h.store, func(db *sql.DB) (json.RawMessage, error) {
+		return logs.Search(ctx, db, startTime, endTime, query)
+	})
 	if err != nil {
 		return nil, h.handleStoreError(err)
 	}
@@ -177,7 +199,9 @@ func (h *JSONRPCHandler) searchLogs(ctx context.Context, req *jsonrpc2.Request) 
 }
 
 func (h *JSONRPCHandler) clearLogs(ctx context.Context) (any, error) {
-	err := logs.Clear(ctx, h.store.DB())
+	err := h.store.WithDBWrite(func(db *sql.DB) error {
+		return logs.Clear(ctx, db)
+	})
 	if err != nil {
 		return nil, h.handleStoreError(err)
 	}
@@ -198,7 +222,9 @@ func (h *JSONRPCHandler) getLog(ctx context.Context, req *jsonrpc2.Request) (any
 	if err != nil {
 		return nil, err
 	}
-	result, err := logs.Get(ctx, h.store.DB(), logID)
+	result, err := storeRead(h.store, func(db *sql.DB) (json.RawMessage, error) {
+		return logs.Get(ctx, db, logID)
+	})
 	if err != nil {
 		return nil, h.handleStoreError(err)
 	}
@@ -225,7 +251,9 @@ func (h *JSONRPCHandler) searchMetricSummaries(ctx context.Context, req *jsonrpc
 	if len(params) == 3 {
 		query = params[2]
 	}
-	summaries, err := metrics.SearchSummaries(ctx, h.store.DB(), startTime, endTime, query)
+	summaries, err := storeRead(h.store, func(db *sql.DB) (json.RawMessage, error) {
+		return metrics.SearchSummaries(ctx, db, startTime, endTime, query)
+	})
 	if err != nil {
 		return nil, h.handleStoreError(err)
 	}
@@ -252,7 +280,9 @@ func (h *JSONRPCHandler) getMetric(ctx context.Context, req *jsonrpc2.Request) (
 	if err != nil {
 		return nil, err
 	}
-	result, err := metrics.GetMetric(ctx, h.store.DB(), streamID, startTime, endTime)
+	result, err := storeRead(h.store, func(db *sql.DB) (json.RawMessage, error) {
+		return metrics.GetMetric(ctx, db, streamID, startTime, endTime)
+	})
 	if err != nil {
 		return nil, h.handleStoreError(err)
 	}
@@ -260,7 +290,9 @@ func (h *JSONRPCHandler) getMetric(ctx context.Context, req *jsonrpc2.Request) (
 }
 
 func (h *JSONRPCHandler) clearMetrics(ctx context.Context) (any, error) {
-	err := metrics.Clear(ctx, h.store.DB())
+	err := h.store.WithDBWrite(func(db *sql.DB) error {
+		return metrics.Clear(ctx, db)
+	})
 	if err != nil {
 		return nil, h.handleStoreError(err)
 	}
@@ -274,7 +306,9 @@ func (h *JSONRPCHandler) deleteSpansByTraceID(ctx context.Context, req *jsonrpc2
 		return nil, err
 	}
 
-	if err := spans.DeleteSpansByTraceIDs(ctx, h.store.DB(), traceIDs); err != nil {
+	if err := h.store.WithDBWrite(func(db *sql.DB) error {
+		return spans.DeleteSpansByTraceIDs(ctx, db, traceIDs)
+	}); err != nil {
 		return nil, h.handleStoreError(err)
 	}
 
@@ -291,7 +325,9 @@ func (h *JSONRPCHandler) deleteSpanByID(ctx context.Context, req *jsonrpc2.Reque
 		return nil, err
 	}
 
-	if err := spans.DeleteSpansByIDs(ctx, h.store.DB(), spanIDs); err != nil {
+	if err := h.store.WithDBWrite(func(db *sql.DB) error {
+		return spans.DeleteSpansByIDs(ctx, db, spanIDs)
+	}); err != nil {
 		return nil, h.handleStoreError(err)
 	}
 
@@ -308,7 +344,9 @@ func (h *JSONRPCHandler) deleteLogByID(ctx context.Context, req *jsonrpc2.Reques
 		return nil, err
 	}
 
-	if err := logs.DeleteLogsByIDs(ctx, h.store.DB(), logIDs); err != nil {
+	if err := h.store.WithDBWrite(func(db *sql.DB) error {
+		return logs.DeleteLogsByIDs(ctx, db, logIDs)
+	}); err != nil {
 		return nil, h.handleStoreError(err)
 	}
 
@@ -338,7 +376,9 @@ func (h *JSONRPCHandler) getTraceAttributes(ctx context.Context, req *jsonrpc2.R
 		return nil, err
 	}
 
-	attributes, err := spans.GetTraceAttributes(ctx, h.store.DB(), startTime, endTime)
+	attributes, err := storeRead(h.store, func(db *sql.DB) (json.RawMessage, error) {
+		return spans.GetTraceAttributes(ctx, db, startTime, endTime)
+	})
 	if err != nil {
 		return nil, h.handleStoreError(err)
 	}
@@ -366,7 +406,9 @@ func (h *JSONRPCHandler) getLogAttributes(ctx context.Context, req *jsonrpc2.Req
 		return nil, err
 	}
 
-	attributes, err := logs.GetLogAttributes(ctx, h.store.DB(), startTime, endTime)
+	attributes, err := storeRead(h.store, func(db *sql.DB) (json.RawMessage, error) {
+		return logs.GetLogAttributes(ctx, db, startTime, endTime)
+	})
 	if err != nil {
 		return nil, h.handleStoreError(err)
 	}
@@ -394,7 +436,9 @@ func (h *JSONRPCHandler) getMetricAttributes(ctx context.Context, req *jsonrpc2.
 		return nil, err
 	}
 
-	attributes, err := metrics.GetMetricAttributes(ctx, h.store.DB(), startTime, endTime)
+	attributes, err := storeRead(h.store, func(db *sql.DB) (json.RawMessage, error) {
+		return metrics.GetMetricAttributes(ctx, db, startTime, endTime)
+	})
 	if err != nil {
 		return nil, h.handleStoreError(err)
 	}
@@ -417,7 +461,9 @@ func (h *JSONRPCHandler) getAttributesByTraceID(ctx context.Context, req *jsonrp
 		return nil, err
 	}
 
-	attributes, err := spans.GetAttributesByTraceID(ctx, h.store.DB(), traceID)
+	attributes, err := storeRead(h.store, func(db *sql.DB) (json.RawMessage, error) {
+		return spans.GetAttributesByTraceID(ctx, db, traceID)
+	})
 	if err != nil {
 		return nil, h.handleStoreError(err)
 	}
@@ -437,7 +483,9 @@ func (h *JSONRPCHandler) getTraceSpanCount(ctx context.Context, req *jsonrpc2.Re
 	if err != nil {
 		return nil, err
 	}
-	count, err := stats.GetTraceSpanCount(ctx, h.store.DB(), traceID)
+	count, err := storeRead(h.store, func(db *sql.DB) (int64, error) {
+		return stats.GetTraceSpanCount(ctx, db, traceID)
+	})
 	if err != nil {
 		return nil, h.handleStoreError(err)
 	}
@@ -445,12 +493,16 @@ func (h *JSONRPCHandler) getTraceSpanCount(ctx context.Context, req *jsonrpc2.Re
 }
 
 func (h *JSONRPCHandler) getStats(ctx context.Context) (any, error) {
-	sizeBytes, err := h.store.SizeBytes(ctx)
-	if err != nil {
-		return nil, h.handleStoreError(err)
-	}
+	retentionCap := h.store.RetentionCap()
 
-	result, err := stats.GetStats(ctx, h.store.DB(), sizeBytes, h.store.RetentionCap())
+	result, err := storeRead(h.store, func(db *sql.DB) (json.RawMessage, error) {
+		// SizeBytesWithDB, not SizeBytes: we already hold the read lock.
+		sizeBytes, err := h.store.SizeBytesWithDB(ctx, db)
+		if err != nil {
+			return nil, err
+		}
+		return stats.GetStats(ctx, db, sizeBytes, retentionCap)
+	})
 	if err != nil {
 		return nil, h.handleStoreError(err)
 	}

--- a/desktopexporter/internal/store/concurrency_test.go
+++ b/desktopexporter/internal/store/concurrency_test.go
@@ -1,0 +1,169 @@
+package store
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/spans"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// buildUniqueTraces returns a single-span trace whose IDs are derived from seq,
+// so repeated ingest in the stress loop does not collide on primary keys.
+func buildUniqueTraces(seq uint64) ptrace.Traces {
+	tr := ptrace.NewTraces()
+	rs := tr.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "stress")
+	ss := rs.ScopeSpans().AppendEmpty()
+	sp := ss.Spans().AppendEmpty()
+
+	var traceID [16]byte
+	binary.BigEndian.PutUint64(traceID[8:], seq)
+	var spanID [8]byte
+	binary.BigEndian.PutUint64(spanID[:], seq)
+
+	sp.SetTraceID(traceID)
+	sp.SetSpanID(spanID)
+	sp.SetName("stress-span")
+
+	now := time.Now().UnixNano()
+	sp.SetStartTimestamp(pcommon.Timestamp(now))
+	sp.SetEndTimestamp(pcommon.Timestamp(now + 1000))
+	return tr
+}
+
+// TestConcurrentIngestQueryAndRetention drives every path that touches the
+// store at once: appender writes on the dedicated connection, SELECTs on the
+// pool, and DELETE + checkpoint on the pool. Run with -race.
+func TestConcurrentIngestQueryAndRetention(t *testing.T) {
+	s, ctx, teardown := setupStore(t)
+	defer teardown()
+
+	const (
+		ingesters = 4
+		readers   = 8
+		duration  = 3 * time.Second
+	)
+
+	deadline := time.Now().Add(duration)
+	var (
+		wg    sync.WaitGroup
+		seq   atomic.Uint64
+		errCh = make(chan error, 64)
+	)
+
+	fail := func(err error) {
+		select {
+		case errCh <- err:
+		default:
+		}
+	}
+
+	for i := 0; i < ingesters; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for time.Now().Before(deadline) {
+				traces := buildUniqueTraces(seq.Add(1))
+				err := s.WithConn(func(conn driver.Conn) error {
+					return spans.Ingest(ctx, conn, traces)
+				})
+				if err != nil {
+					fail(fmt.Errorf("ingest: %w", err))
+					return
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for time.Now().Before(deadline) {
+				err := s.WithDBRead(func(db *sql.DB) error {
+					_, err := spans.SearchTraces(ctx, db, 0, time.Now().UnixNano(), nil)
+					return err
+				})
+				if err != nil {
+					fail(fmt.Errorf("read: %w", err))
+					return
+				}
+			}
+		}()
+	}
+
+	// Retention: DELETE + checkpoint under the write lock. maxBytes = 1 forces
+	// a prune every pass.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for time.Now().Before(deadline) {
+			if err := s.EnforceRetention(ctx, 1); err != nil {
+				fail(fmt.Errorf("retention: %w", err))
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+	}()
+
+	// Clears: the JSON-RPC mutation path.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for time.Now().Before(deadline) {
+			err := s.WithDBWrite(func(db *sql.DB) error {
+				return spans.Clear(ctx, db)
+			})
+			if err != nil {
+				fail(fmt.Errorf("clear: %w", err))
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+}
+
+// TestConcurrentCloseAndRead closes the store while reads are in flight. Every
+// read must either complete or return ErrStoreConnectionClosed — never panic
+// on a nil *sql.DB, and never trip the race detector on s.db.
+func TestConcurrentCloseAndRead(t *testing.T) {
+	s, ctx, teardown := setupStore(t)
+	defer teardown()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				err := s.WithDBRead(func(db *sql.DB) error {
+					_, err := spans.SearchTraces(ctx, db, 0, time.Now().UnixNano(), nil)
+					return err
+				})
+				if err != nil && !errors.Is(err, ErrStoreConnectionClosed) {
+					t.Errorf("unexpected read error: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	_ = s.Close()
+	wg.Wait()
+}

--- a/desktopexporter/internal/store/ingest/appender_test.go
+++ b/desktopexporter/internal/store/ingest/appender_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/ingest"
-	"github.com/google/uuid"
 	"github.com/duckdb/duckdb-go/v2"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -71,8 +71,8 @@ func TestFlushAppenders_MakesDataVisible(t *testing.T) {
 		if err := appenders["logs"].AppendRow(
 			logID,
 			int64(0), int64(0), // Timestamp, ObservedTimestamp
-			nil, nil,           // TraceID, SpanID
-			"INFO", int32(9),   // SeverityText, SeverityNumber
+			nil, nil, // TraceID, SpanID
+			"INFO", int32(9), // SeverityText, SeverityNumber
 			"flush test", "str", // Body, BodyType
 			uint32(0), "scope", "v1", uint32(0), uint32(0), uint32(0), "",
 			"", // ServiceName VARCHAR (NOT NULL, '' = unknown)

--- a/desktopexporter/internal/store/ingest/appender_test.go
+++ b/desktopexporter/internal/store/ingest/appender_test.go
@@ -2,6 +2,7 @@ package ingest_test
 
 import (
 	"context"
+	"database/sql"
 	"database/sql/driver"
 	"errors"
 	"testing"
@@ -14,6 +15,19 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
+
+// readStore runs a query under the store's read lock and returns its result.
+// Store exposes no raw *sql.DB: every read is ordered against ingest,
+// retention, and Close.
+func readStore[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error) {
+	var out T
+	err := s.WithDBRead(func(db *sql.DB) error {
+		var err error
+		out, err = fn(db)
+		return err
+	})
+	return out, err
+}
 
 func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
 	t.Helper()
@@ -94,19 +108,25 @@ func TestFlushAppenders_MakesDataVisible(t *testing.T) {
 	require.NoError(t, err)
 
 	var logCount int
-	err = s.DB().QueryRowContext(ctx, "select count(*) from logs").Scan(&logCount)
+	err = s.WithDBRead(func(db *sql.DB) error {
+		return db.QueryRowContext(ctx, "select count(*) from logs").Scan(&logCount)
+	})
 	require.NoError(t, err)
 	assert.Equal(t, 1, logCount, "log row must be visible after Flush without Close")
 
 	logIDStr := uuid.UUID(logID).String()
 	var attrCount int
-	require.NoError(t, s.DB().QueryRowContext(ctx, "select count(*) from attributes where log_id = ?", logIDStr).Scan(&attrCount))
+	require.NoError(t, s.WithDBRead(func(db *sql.DB) error {
+		return db.QueryRowContext(ctx, "select count(*) from attributes where log_id = ?", logIDStr).Scan(&attrCount)
+	}))
 	assert.Equal(t, 2, attrCount, "attribute rows must be visible after Flush without Close")
 
 	var key, value, scope string
-	err = s.DB().QueryRowContext(ctx,
-		"select key, value, scope from attributes where log_id = ? and key = ?",
-		logIDStr, "flush_attr").Scan(&key, &value, &scope)
+	err = s.WithDBRead(func(db *sql.DB) error {
+		return db.QueryRowContext(ctx,
+			"select key, value, scope from attributes where log_id = ? and key = ?",
+			logIDStr, "flush_attr").Scan(&key, &value, &scope)
+	})
 	require.NoError(t, err)
 	assert.Equal(t, "flush_attr", key)
 	assert.Equal(t, "ok", value)

--- a/desktopexporter/internal/store/ingest/attributes_test.go
+++ b/desktopexporter/internal/store/ingest/attributes_test.go
@@ -1,6 +1,7 @@
 package ingest_test
 
 import (
+	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
 	"testing"
@@ -42,7 +43,9 @@ func TestIngestAttributes_ResourceScopeSpan(t *testing.T) {
 	assert.NoError(t, err)
 
 	now := time.Now().UnixNano()
-	raw, err := spans.GetTraceAttributes(ctx, s.DB(), now-int64(time.Hour), now+int64(time.Hour))
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return spans.GetTraceAttributes(ctx, db, now-int64(time.Hour), now+int64(time.Hour))
+	})
 	assert.NoError(t, err)
 
 	var attrs []struct {
@@ -106,7 +109,9 @@ func TestIngestAttributes_EventAndLink(t *testing.T) {
 	assert.NoError(t, err)
 
 	now := time.Now().UnixNano()
-	raw, err := spans.GetTraceAttributes(ctx, s.DB(), now-int64(time.Hour), now+int64(time.Hour))
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return spans.GetTraceAttributes(ctx, db, now-int64(time.Hour), now+int64(time.Hour))
+	})
 	assert.NoError(t, err)
 
 	var attrs []struct {
@@ -249,7 +254,9 @@ func TestIngestAttributes_EmptyMaps(t *testing.T) {
 	assert.NoError(t, err)
 
 	now := time.Now().UnixNano()
-	raw, err := spans.GetTraceAttributes(ctx, s.DB(), now-int64(time.Hour), now+int64(time.Hour))
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return spans.GetTraceAttributes(ctx, db, now-int64(time.Hour), now+int64(time.Hour))
+	})
 	assert.NoError(t, err)
 
 	var attrs []struct {

--- a/desktopexporter/internal/store/logs/logs_test.go
+++ b/desktopexporter/internal/store/logs/logs_test.go
@@ -21,6 +21,19 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 )
 
+// readStore runs a query under the store's read lock and returns its result.
+// Store exposes no raw *sql.DB: every read is ordered against ingest,
+// retention, and Close.
+func readStore[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error) {
+	var out T
+	err := s.WithDBRead(func(db *sql.DB) error {
+		var err error
+		out, err = fn(db)
+		return err
+	})
+	return out, err
+}
+
 func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
 	t.Helper()
 	ctx := context.Background()
@@ -29,10 +42,12 @@ func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
 	return s, ctx, func() { s.Close() }
 }
 
-func countRows(t *testing.T, db *sql.DB, ctx context.Context, query string, args ...any) int {
+func countRows(t *testing.T, s *store.Store, ctx context.Context, query string, args ...any) int {
 	t.Helper()
 	var n int
-	require.NoError(t, db.QueryRowContext(ctx, query, args...).Scan(&n))
+	require.NoError(t, s.WithDBRead(func(db *sql.DB) error {
+		return db.QueryRowContext(ctx, query, args...).Scan(&n)
+	}))
 	return n
 }
 
@@ -158,7 +173,9 @@ func createTestLogsPdataN(baseTime int64, n int) plog.Logs {
 func searchLogsAll(t *testing.T, s *store.Store, ctx context.Context) []logSummaryJSON {
 	t.Helper()
 	const maxNano = 1<<63 - 1
-	raw, err := logs.Search(ctx, s.DB(), 0, maxNano, nil)
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return logs.Search(ctx, db, 0, maxNano, nil)
+	})
 	assert.NoError(t, err)
 	var entries []logSummaryJSON
 	assert.NoError(t, json.Unmarshal(raw, &entries))
@@ -170,7 +187,9 @@ func searchLogsAll(t *testing.T, s *store.Store, ctx context.Context) []logSumma
 // shape assertions below.
 func getLogFull(t *testing.T, s *store.Store, ctx context.Context, id string) logEntryJSON {
 	t.Helper()
-	raw, err := logs.Get(ctx, s.DB(), id)
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return logs.Get(ctx, db, id)
+	})
 	assert.NoError(t, err)
 	var entry logEntryJSON
 	assert.NoError(t, json.Unmarshal(raw, &entry))
@@ -296,14 +315,16 @@ func TestClearLogs(t *testing.T) {
 
 	entries := searchLogsAll(t, s, ctx)
 	assert.Len(t, entries, 3)
-	assert.Greater(t, countRows(t, s.DB(), ctx, "select count(*) from attributes where log_id is not null"), 0)
+	assert.Greater(t, countRows(t, s, ctx, "select count(*) from attributes where log_id is not null"), 0)
 
-	err = logs.Clear(ctx, s.DB())
+	err = s.WithDBWrite(func(db *sql.DB) error {
+		return logs.Clear(ctx, db)
+	})
 	assert.NoError(t, err)
 
 	entries = searchLogsAll(t, s, ctx)
 	assert.Empty(t, entries)
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from attributes where log_id is not null"))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from attributes where log_id is not null"))
 }
 
 // TestLogSuite runs a comprehensive suite on the same three-log dataset.
@@ -428,7 +449,9 @@ func TestLogSuite(t *testing.T) {
 	})
 
 	t.Run("LogGetNotFound", func(t *testing.T) {
-		_, err := logs.Get(ctx, s.DB(), "00000000-0000-0000-0000-000000000000")
+		_, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Get(ctx, db, "00000000-0000-0000-0000-000000000000")
+		})
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, logs.ErrLogIDNotFound)
 	})
@@ -447,7 +470,9 @@ func TestGetLogAttributes(t *testing.T) {
 
 	startTime := baseTime - int64(time.Hour)
 	endTime := baseTime + int64(time.Hour)
-	raw, err := logs.GetLogAttributes(ctx, s.DB(), startTime, endTime)
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return logs.GetLogAttributes(ctx, db, startTime, endTime)
+	})
 	assert.NoError(t, err)
 
 	var attributes []struct {
@@ -472,7 +497,9 @@ func TestGetLogAttributes(t *testing.T) {
 	assert.Contains(t, byScope["log"], "log.list")
 
 	// Out-of-range query returns empty
-	rawEmpty, err := logs.GetLogAttributes(ctx, s.DB(), 0, 1)
+	rawEmpty, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return logs.GetLogAttributes(ctx, db, 0, 1)
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, json.RawMessage("[]"), rawEmpty)
 }
@@ -495,10 +522,12 @@ func TestDeleteLogByID(t *testing.T) {
 	targetID := entries[0].ID
 	assert.NotEmpty(t, targetID)
 
-	attrsBefore := countRows(t, s.DB(), ctx, "select count(*) from attributes where log_id = ?", targetID)
+	attrsBefore := countRows(t, s, ctx, "select count(*) from attributes where log_id = ?", targetID)
 	assert.Greater(t, attrsBefore, 0, "target log should have attributes")
 
-	err = logs.DeleteLogByID(ctx, s.DB(), targetID)
+	err = s.WithDBWrite(func(db *sql.DB) error {
+		return logs.DeleteLogByID(ctx, db, targetID)
+	})
 	assert.NoError(t, err)
 
 	entries = searchLogsAll(t, s, ctx)
@@ -507,7 +536,7 @@ func TestDeleteLogByID(t *testing.T) {
 		assert.NotEqual(t, targetID, e.ID)
 	}
 
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from attributes where log_id = ?", targetID))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from attributes where log_id = ?", targetID))
 }
 
 // TestDeleteLogsByIDs verifies that multiple logs can be deleted by their IDs.
@@ -526,7 +555,9 @@ func TestDeleteLogsByIDs(t *testing.T) {
 	assert.Len(t, entries, 3)
 
 	idsToDelete := []any{entries[0].ID, entries[1].ID}
-	err = logs.DeleteLogsByIDs(ctx, s.DB(), idsToDelete)
+	err = s.WithDBWrite(func(db *sql.DB) error {
+		return logs.DeleteLogsByIDs(ctx, db, idsToDelete)
+	})
 	assert.NoError(t, err)
 
 	entries = searchLogsAll(t, s, ctx)
@@ -538,7 +569,9 @@ func TestDeleteLogsByIDs_Empty(t *testing.T) {
 	s, ctx, teardown := setupStore(t)
 	defer teardown()
 
-	err := logs.DeleteLogsByIDs(ctx, s.DB(), []any{})
+	err := s.WithDBWrite(func(db *sql.DB) error {
+		return logs.DeleteLogsByIDs(ctx, db, []any{})
+	})
 	assert.NoError(t, err)
 }
 
@@ -647,7 +680,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "Operation failed",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.Len(t, entries, 1)
@@ -667,7 +702,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "event.a",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.NotEmpty(t, entries)
@@ -685,7 +722,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "00000000000000000000000000000099",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.Len(t, entries, 3, "global search for trace ID hex should match all logs")
@@ -701,7 +740,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "0000000000000002",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.Len(t, entries, 1, "global search for span ID hex should match one log")
@@ -718,7 +759,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "nonexistent-log-text-xyz",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.Empty(t, entries)
@@ -738,7 +781,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "00000000000000000000000000000099",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.Len(t, entries, 3, "wire-form trace ID should match all logs in the trace")
@@ -754,7 +799,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "0000000000000002",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.Len(t, entries, 1, "wire-form span ID should match its log, not a cast error")
@@ -773,7 +820,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "not-a-trace",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err, "garbage trace ID must not surface a cast error")
 		assert.Empty(t, parseSummaries(raw))
 	})
@@ -788,7 +837,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "zz-definitely-not-hex",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err, "garbage span ID must not surface a cast error")
 		assert.Empty(t, parseSummaries(raw))
 	})
@@ -803,7 +854,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "ERROR",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.Len(t, entries, 1)
@@ -824,7 +877,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "0000000000000001",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.Len(t, entries, 1)
@@ -843,7 +898,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "00000000-0000-0000-0000-000000000099",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.Len(t, entries, 3, "all three logs share the same trace")
@@ -859,7 +916,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "17", // plog.SeverityNumberError
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.Len(t, entries, 1)
@@ -881,7 +940,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "Operation warning",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.Len(t, entries, 1)
@@ -899,7 +960,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "event.a",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.Len(t, entries, 1)
@@ -918,7 +981,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "test-scope",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.Len(t, entries, 3)
@@ -937,7 +1002,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "v1.0.0",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.Len(t, entries, 3)
@@ -960,7 +1027,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "log-b",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.Len(t, entries, 1)
@@ -983,7 +1052,9 @@ func TestSearchLogs(t *testing.T) {
 				Value:         "test-service",
 			},
 		}
-		raw, err := logs.Search(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		entries := parseSummaries(raw)
 		assert.NotEmpty(t, entries)
@@ -1010,7 +1081,7 @@ func TestLogs_ServiceNameDenormStaysConsistent(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	mismatches := countRows(t, s.DB(), ctx, `
+	mismatches := countRows(t, s, ctx, `
 		select count(*) from logs l
 		left join attributes a
 		     on a.log_id = l.id

--- a/desktopexporter/internal/store/metrics/metrics_test.go
+++ b/desktopexporter/internal/store/metrics/metrics_test.go
@@ -33,6 +33,19 @@ const (
 	testQuantileWindowPoints  int   = 1_000_000_000
 )
 
+// readStore runs a query under the store's read lock and returns its result.
+// Store exposes no raw *sql.DB: every read is ordered against ingest,
+// retention, and Close.
+func readStore[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error) {
+	var out T
+	err := s.WithDBRead(func(db *sql.DB) error {
+		var err error
+		out, err = fn(db)
+		return err
+	})
+	return out, err
+}
+
 func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
 	t.Helper()
 	ctx := context.Background()
@@ -41,10 +54,12 @@ func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
 	return s, ctx, func() { s.Close() }
 }
 
-func countRows(t *testing.T, db *sql.DB, ctx context.Context, query string, args ...any) int {
+func countRows(t *testing.T, s *store.Store, ctx context.Context, query string, args ...any) int {
 	t.Helper()
 	var n int
-	require.NoError(t, db.QueryRowContext(ctx, query, args...).Scan(&n))
+	require.NoError(t, s.WithDBRead(func(db *sql.DB) error {
+		return db.QueryRowContext(ctx, query, args...).Scan(&n)
+	}))
 	return n
 }
 
@@ -207,7 +222,9 @@ func createTestMetricsPdata() pmetric.Metrics {
 // searchMetricsAll returns metrics.SearchSummaries with wide time range and nil query; parses JSON to slice of maps.
 func searchMetricsAll(t *testing.T, s *store.Store, ctx context.Context) []map[string]any {
 	t.Helper()
-	raw, err := metrics.SearchSummaries(ctx, s.DB(), 0, maxNano, nil)
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return metrics.SearchSummaries(ctx, db, 0, maxNano, nil)
+	})
 	assert.NoError(t, err)
 	var out []map[string]any
 	assert.NoError(t, json.Unmarshal(raw, &out))
@@ -216,7 +233,9 @@ func searchMetricsAll(t *testing.T, s *store.Store, ctx context.Context) []map[s
 
 func searchSummariesAll(t *testing.T, s *store.Store, ctx context.Context) []map[string]any {
 	t.Helper()
-	raw, err := metrics.SearchSummaries(ctx, s.DB(), 0, maxNano, nil)
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return metrics.SearchSummaries(ctx, db, 0, maxNano, nil)
+	})
 	require.NoError(t, err)
 	var out []map[string]any
 	require.NoError(t, json.Unmarshal(raw, &out))
@@ -239,7 +258,9 @@ func findSummary(t *testing.T, summaries []map[string]any, name string) map[stri
 func getMetricFullByName(t *testing.T, s *store.Store, ctx context.Context, name string) map[string]any {
 	t.Helper()
 	id := findMetricID(t, s, ctx, name)
-	raw, err := metrics.GetMetric(ctx, s.DB(), id, 0, maxNano)
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return metrics.GetMetric(ctx, db, id, 0, maxNano)
+	})
 	require.NoError(t, err)
 	var m map[string]any
 	require.NoError(t, json.Unmarshal(raw, &m))
@@ -353,7 +374,7 @@ func TestMetricSuite(t *testing.T) {
 	})
 
 	t.Run("Exemplars", func(t *testing.T) {
-		assert.Greater(t, countRows(t, s.DB(), ctx, "select count(*) from exemplars"), 0, "exemplars should be ingested")
+		assert.Greater(t, countRows(t, s, ctx, "select count(*) from exemplars"), 0, "exemplars should be ingested")
 		gauge := getMetricFullByName(t, s, ctx, "gauge_metric")
 		requireMetric(t, gauge, "gauge_metric")
 		datapoints := metricDatapoints(gauge)
@@ -385,7 +406,9 @@ func TestMetricSuite(t *testing.T) {
 				"value":         "test-service",
 			},
 		}
-		raw, err := metrics.SearchSummaries(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return metrics.SearchSummaries(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		var metrics []map[string]any
 		assert.NoError(t, json.Unmarshal(raw, &metrics))
@@ -410,7 +433,9 @@ func TestMetricSuite(t *testing.T) {
 				"value":         "gauge_metric",
 			},
 		}
-		raw, err := metrics.SearchSummaries(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return metrics.SearchSummaries(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		var metrics []map[string]any
 		assert.NoError(t, json.Unmarshal(raw, &metrics))
@@ -428,7 +453,9 @@ func TestMetricSuite(t *testing.T) {
 				"value":         "memory",
 			},
 		}
-		raw, err := metrics.SearchSummaries(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return metrics.SearchSummaries(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		var metrics []map[string]any
 		assert.NoError(t, json.Unmarshal(raw, &metrics))
@@ -446,7 +473,9 @@ func TestMetricSuite(t *testing.T) {
 				"value":         "bytes",
 			},
 		}
-		raw, err := metrics.SearchSummaries(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return metrics.SearchSummaries(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		var metrics []map[string]any
 		assert.NoError(t, json.Unmarshal(raw, &metrics))
@@ -469,7 +498,9 @@ func TestMetricSuite(t *testing.T) {
 				"value":         "test-scope",
 			},
 		}
-		raw, err := metrics.SearchSummaries(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return metrics.SearchSummaries(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		var metrics []map[string]any
 		assert.NoError(t, json.Unmarshal(raw, &metrics))
@@ -486,7 +517,9 @@ func TestMetricSuite(t *testing.T) {
 				"value":         "test-scope",
 			},
 		}
-		raw, err := metrics.SearchSummaries(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return metrics.SearchSummaries(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		var metrics []map[string]any
 		assert.NoError(t, json.Unmarshal(raw, &metrics))
@@ -503,7 +536,9 @@ func TestMetricSuite(t *testing.T) {
 				"value":         "v1.0.0",
 			},
 		}
-		raw, err := metrics.SearchSummaries(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return metrics.SearchSummaries(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		var metrics []map[string]any
 		assert.NoError(t, json.Unmarshal(raw, &metrics))
@@ -520,7 +555,9 @@ func TestMetricSuite(t *testing.T) {
 				"value":         "v1.0.0",
 			},
 		}
-		raw, err := metrics.SearchSummaries(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return metrics.SearchSummaries(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		var metrics []map[string]any
 		assert.NoError(t, json.Unmarshal(raw, &metrics))
@@ -538,7 +575,9 @@ func TestMetricSuite(t *testing.T) {
 				"value":         "0",
 			},
 		}
-		raw, err := metrics.SearchSummaries(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return metrics.SearchSummaries(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		var metrics []map[string]any
 		assert.NoError(t, json.Unmarshal(raw, &metrics))
@@ -556,7 +595,9 @@ func TestMetricSuite(t *testing.T) {
 				"value":         "memory",
 			},
 		}
-		raw, err := metrics.SearchSummaries(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return metrics.SearchSummaries(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		var metrics []map[string]any
 		assert.NoError(t, json.Unmarshal(raw, &metrics))
@@ -574,7 +615,9 @@ func TestMetricSuite(t *testing.T) {
 				"value":         "test-service",
 			},
 		}
-		raw, err := metrics.SearchSummaries(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return metrics.SearchSummaries(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		var metrics []map[string]any
 		assert.NoError(t, json.Unmarshal(raw, &metrics))
@@ -591,7 +634,9 @@ func TestMetricSuite(t *testing.T) {
 				"value":         "nonexistent-metric-xyz",
 			},
 		}
-		raw, err := metrics.SearchSummaries(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return metrics.SearchSummaries(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		var metrics []map[string]any
 		assert.NoError(t, json.Unmarshal(raw, &metrics))
@@ -635,7 +680,10 @@ func metricDatapoints(m map[string]any) []any {
 // DeleteMetricStream. The production JSON-RPC layer does the same
 // resolve-then-delete pattern; we replicate it here so the existing
 // test cases stay readable without needing to spell out streamIDs.
-func deleteByIdentity(t *testing.T, ctx context.Context, db *sql.DB, name, unit, metricType, aggTemporality, isMonotonic, scopeName, scopeVersion, serviceName string) error {
+// deleteByIdentity resolves an identity tuple to a stream UUID and deletes that
+// stream. Both steps run in one write-lock window so the resolved ID cannot be
+// pruned out from under the delete.
+func deleteByIdentity(t *testing.T, ctx context.Context, s *store.Store, name, unit, metricType, aggTemporality, isMonotonic, scopeName, scopeVersion, serviceName string) error {
 	t.Helper()
 	const q = `
 		select id::varchar from metric_streams
@@ -649,18 +697,20 @@ func deleteByIdentity(t *testing.T, ctx context.Context, db *sql.DB, name, unit,
 		  and service_name = ?
 		limit 1
 	`
-	var streamID string
-	err := db.QueryRowContext(ctx, q,
-		name, unit, metricType, aggTemporality, isMonotonic == "true",
-		scopeName, scopeVersion, serviceName,
-	).Scan(&streamID)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	return metrics.DeleteMetricStream(ctx, db, streamID)
+	return s.WithDBWrite(func(db *sql.DB) error {
+		var streamID string
+		err := db.QueryRowContext(ctx, q,
+			name, unit, metricType, aggTemporality, isMonotonic == "true",
+			scopeName, scopeVersion, serviceName,
+		).Scan(&streamID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		return metrics.DeleteMetricStream(ctx, db, streamID)
+	})
 }
 
 // TestDeleteMetricStream covers the per-stream cascade. Each subtest
@@ -681,7 +731,7 @@ func TestDeleteMetricStream(t *testing.T) {
 		assert.Len(t, before, 5)
 
 		// Gauges have no temporality / monotonic; pass empty strings.
-		err = deleteByIdentity(t, ctx, s.DB(),
+		err = deleteByIdentity(t, ctx, s,
 			"gauge_metric", "bytes", "Gauge",
 			"", "",
 			"test-scope", "v1.0.0", "test-service",
@@ -694,7 +744,7 @@ func TestDeleteMetricStream(t *testing.T) {
 			assert.NotEqual(t, "gauge_metric", m["name"])
 		}
 
-		assert.Equal(t, 0, countRows(t, s.DB(), ctx,
+		assert.Equal(t, 0, countRows(t, s, ctx,
 			`select count(*) from metric_streams where name = ?`, "gauge_metric"))
 	})
 
@@ -714,10 +764,10 @@ func TestDeleteMetricStream(t *testing.T) {
 		// SearchSummaries collapses by identity so we still see 5 rows.
 		assert.Len(t, searchSummariesAll(t, s, ctx), 5)
 		// One stream per logical metric (5), 3 ingests per stream (15).
-		assert.Equal(t, 5, countRows(t, s.DB(), ctx, `select count(*) from metric_streams`))
-		assert.Equal(t, 15, countRows(t, s.DB(), ctx, `select count(*) from metric_ingests`))
+		assert.Equal(t, 5, countRows(t, s, ctx, `select count(*) from metric_streams`))
+		assert.Equal(t, 15, countRows(t, s, ctx, `select count(*) from metric_ingests`))
 
-		err := deleteByIdentity(t, ctx, s.DB(),
+		err := deleteByIdentity(t, ctx, s,
 			"gauge_metric", "bytes", "Gauge",
 			"", "",
 			"test-scope", "v1.0.0", "test-service",
@@ -726,11 +776,11 @@ func TestDeleteMetricStream(t *testing.T) {
 
 		assert.Len(t, searchSummariesAll(t, s, ctx), 4)
 		// One stream + its three ingests should be gone.
-		assert.Equal(t, 4, countRows(t, s.DB(), ctx, `select count(*) from metric_streams`))
-		assert.Equal(t, 12, countRows(t, s.DB(), ctx, `select count(*) from metric_ingests`))
-		assert.Equal(t, 0, countRows(t, s.DB(), ctx,
+		assert.Equal(t, 4, countRows(t, s, ctx, `select count(*) from metric_streams`))
+		assert.Equal(t, 12, countRows(t, s, ctx, `select count(*) from metric_ingests`))
+		assert.Equal(t, 0, countRows(t, s, ctx,
 			`select count(*) from metric_streams where name = ?`, "gauge_metric"))
-		assert.Equal(t, 0, countRows(t, s.DB(), ctx,
+		assert.Equal(t, 0, countRows(t, s, ctx,
 			`select count(*) from datapoints d join metric_streams s on s.id = d.stream_id where s.name = ?`,
 			"gauge_metric"))
 	})
@@ -762,7 +812,7 @@ func TestDeleteMetricStream(t *testing.T) {
 		assert.Len(t, searchMetricsAll(t, s, ctx), 2)
 
 		// Delete the bytes one — count should survive.
-		err = deleteByIdentity(t, ctx, s.DB(),
+		err = deleteByIdentity(t, ctx, s,
 			"requests", "bytes", "Gauge", "", "",
 			"scope", "v1", "svc",
 		)
@@ -798,7 +848,7 @@ func TestDeleteMetricStream(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, searchSummariesAll(t, s, ctx), 2)
 
-		err = deleteByIdentity(t, ctx, s.DB(),
+		err = deleteByIdentity(t, ctx, s,
 			"requests", "count", "Gauge", "", "",
 			"scope", "v1", "svc-a",
 		)
@@ -838,7 +888,7 @@ func TestDeleteMetricStream(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, searchSummariesAll(t, s, ctx), 2)
 
-		err = deleteByIdentity(t, ctx, s.DB(),
+		err = deleteByIdentity(t, ctx, s,
 			"requests", "count", "Sum", "Cumulative", "true",
 			"scope", "v1", "svc",
 		)
@@ -861,7 +911,7 @@ func TestDeleteMetricStream(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, searchMetricsAll(t, s, ctx), 5)
 
-		err = deleteByIdentity(t, ctx, s.DB(),
+		err = deleteByIdentity(t, ctx, s,
 			"nonexistent", "bytes", "Gauge", "", "",
 			"test-scope", "v1.0.0", "test-service",
 		)
@@ -879,38 +929,38 @@ func TestDeleteMetricStream(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Histogram has datapoints with exemplars — pick it.
-		dpBefore := countRows(t, s.DB(), ctx,
+		dpBefore := countRows(t, s, ctx,
 			`select count(*) from datapoints where stream_id in (select id from metric_streams where name = ?)`,
 			"histogram_metric")
-		exBefore := countRows(t, s.DB(), ctx,
+		exBefore := countRows(t, s, ctx,
 			`select count(*) from exemplars where datapoint_id in (select id from datapoints where stream_id in (select id from metric_streams where name = ?))`,
 			"histogram_metric")
-		attrBefore := countRows(t, s.DB(), ctx,
+		attrBefore := countRows(t, s, ctx,
 			`select count(*) from attributes where metric_ingest_id in (select id from metric_ingests where stream_id in (select id from metric_streams where name = ?))`,
 			"histogram_metric")
 		assert.Greater(t, dpBefore, 0)
 		assert.Greater(t, exBefore, 0)
 		assert.Greater(t, attrBefore, 0)
 
-		err = deleteByIdentity(t, ctx, s.DB(),
+		err = deleteByIdentity(t, ctx, s,
 			"histogram_metric", "seconds", "Histogram",
 			"Delta", "",
 			"test-scope", "v1.0.0", "test-service",
 		)
 		assert.NoError(t, err)
 
-		assert.Equal(t, 0, countRows(t, s.DB(), ctx,
+		assert.Equal(t, 0, countRows(t, s, ctx,
 			`select count(*) from metric_streams where name = ?`, "histogram_metric"))
-		assert.Equal(t, 0, countRows(t, s.DB(), ctx,
+		assert.Equal(t, 0, countRows(t, s, ctx,
 			`select count(*) from datapoints where stream_id in (select id from metric_streams where name = ?)`,
 			"histogram_metric"))
-		assert.Equal(t, 0, countRows(t, s.DB(), ctx,
+		assert.Equal(t, 0, countRows(t, s, ctx,
 			`select count(*) from exemplars e where exists (
 				select 1 from datapoints d
 				where d.id = e.datapoint_id
 				  and d.stream_id in (select id from metric_streams where name = ?)
 			)`, "histogram_metric"))
-		assert.Equal(t, 0, countRows(t, s.DB(), ctx,
+		assert.Equal(t, 0, countRows(t, s, ctx,
 			`select count(*) from attributes where metric_ingest_id in (select id from metric_ingests where stream_id in (select id from metric_streams where name = ?))`,
 			"histogram_metric"))
 	})
@@ -940,10 +990,10 @@ func TestMetricStreams_FindOrInsertIdempotent(t *testing.T) {
 
 	// createTestMetricsPdata produces five distinct logical metrics.
 	// Across N batches we should still see exactly five stream rows.
-	assert.Equal(t, 5, countRows(t, s.DB(), ctx,
+	assert.Equal(t, 5, countRows(t, s, ctx,
 		`select count(*) from metric_streams`),
 		"distinct logical metrics should not multiply across batches")
-	assert.Equal(t, 5*batches, countRows(t, s.DB(), ctx,
+	assert.Equal(t, 5*batches, countRows(t, s, ctx,
 		`select count(*) from metric_ingests`),
 		"every batch should add one ingest per metric")
 
@@ -951,7 +1001,7 @@ func TestMetricStreams_FindOrInsertIdempotent(t *testing.T) {
 	// stream_id must match a metric_streams row, and every per-batch
 	// metric_ingests row pointing at the same logical metric must
 	// resolve to the same stream_id.
-	gaugeStreamRows := countRows(t, s.DB(), ctx,
+	gaugeStreamRows := countRows(t, s, ctx,
 		`select count(distinct stream_id) from metric_ingests where stream_id in (
 			select id from metric_streams where name = 'gauge_metric'
 		)`)
@@ -959,7 +1009,7 @@ func TestMetricStreams_FindOrInsertIdempotent(t *testing.T) {
 		"all gauge_metric ingests must share one stream_id")
 
 	// Sanity: cross-table referential integrity holds.
-	orphanDatapoints := countRows(t, s.DB(), ctx,
+	orphanDatapoints := countRows(t, s, ctx,
 		`select count(*) from datapoints d
 		 left join metric_streams s on s.id = d.stream_id
 		 where s.id is null`)
@@ -1026,7 +1076,7 @@ func TestMetricStreams_DistinctIdentitiesStayDistinct(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			assert.Equal(t, 2, countRows(t, s.DB(), ctx,
+			assert.Equal(t, 2, countRows(t, s, ctx,
 				`select count(*) from metric_streams`),
 				"changing %s should produce a distinct stream", tc.name)
 		})
@@ -1054,7 +1104,7 @@ func TestMetricStreams_ServiceNameDenormStaysConsistent(t *testing.T) {
 	// Match the column against the resource attribute by joining
 	// metric_streams -> metric_ingests -> attributes(scope=resource,
 	// key=service.name).
-	mismatches := countRows(t, s.DB(), ctx, `
+	mismatches := countRows(t, s, ctx, `
 		select count(*) from metric_streams s
 		join metric_ingests mi on mi.stream_id = s.id
 		join attributes a
@@ -1093,19 +1143,21 @@ func TestClearMetrics(t *testing.T) {
 
 	metricList := searchMetricsAll(t, s, ctx)
 	assert.Len(t, metricList, 5)
-	assert.Greater(t, countRows(t, s.DB(), ctx, "select count(*) from datapoints"), 0)
-	assert.Greater(t, countRows(t, s.DB(), ctx, "select count(*) from attributes where metric_ingest_id is not null"), 0)
+	assert.Greater(t, countRows(t, s, ctx, "select count(*) from datapoints"), 0)
+	assert.Greater(t, countRows(t, s, ctx, "select count(*) from attributes where metric_ingest_id is not null"), 0)
 
-	err = metrics.Clear(ctx, s.DB())
+	err = s.WithDBWrite(func(db *sql.DB) error {
+		return metrics.Clear(ctx, db)
+	})
 	assert.NoError(t, err)
 
 	metricList = searchMetricsAll(t, s, ctx)
 	assert.Empty(t, metricList)
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from metric_streams"))
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from metric_ingests"))
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from datapoints"))
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from exemplars"))
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from attributes where metric_ingest_id is not null"))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from metric_streams"))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from metric_ingests"))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from datapoints"))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from exemplars"))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from attributes where metric_ingest_id is not null"))
 }
 
 func TestExpHistogramZeroThresholdRoundTrip(t *testing.T) {

--- a/desktopexporter/internal/store/metrics/metrics_test.go
+++ b/desktopexporter/internal/store/metrics/metrics_test.go
@@ -405,7 +405,7 @@ func TestMetricSuite(t *testing.T) {
 			"id":   "f1",
 			"type": "condition",
 			"query": map[string]any{
-				"field":          map[string]any{"name": "name", "searchScope": "field"},
+				"field":         map[string]any{"name": "name", "searchScope": "field"},
 				"fieldOperator": "=",
 				"value":         "gauge_metric",
 			},
@@ -423,7 +423,7 @@ func TestMetricSuite(t *testing.T) {
 			"id":   "f2",
 			"type": "condition",
 			"query": map[string]any{
-				"field":          map[string]any{"name": "description", "searchScope": "field"},
+				"field":         map[string]any{"name": "description", "searchScope": "field"},
 				"fieldOperator": "CONTAINS",
 				"value":         "memory",
 			},
@@ -441,7 +441,7 @@ func TestMetricSuite(t *testing.T) {
 			"id":   "f3",
 			"type": "condition",
 			"query": map[string]any{
-				"field":          map[string]any{"name": "unit", "searchScope": "field"},
+				"field":         map[string]any{"name": "unit", "searchScope": "field"},
 				"fieldOperator": "=",
 				"value":         "bytes",
 			},
@@ -464,7 +464,7 @@ func TestMetricSuite(t *testing.T) {
 			"id":   "f4",
 			"type": "condition",
 			"query": map[string]any{
-				"field":          map[string]any{"name": "scope.name", "searchScope": "field"},
+				"field":         map[string]any{"name": "scope.name", "searchScope": "field"},
 				"fieldOperator": "=",
 				"value":         "test-scope",
 			},
@@ -481,7 +481,7 @@ func TestMetricSuite(t *testing.T) {
 			"id":   "f4b",
 			"type": "condition",
 			"query": map[string]any{
-				"field":          map[string]any{"name": "scopeName", "searchScope": "field"},
+				"field":         map[string]any{"name": "scopeName", "searchScope": "field"},
 				"fieldOperator": "=",
 				"value":         "test-scope",
 			},
@@ -498,7 +498,7 @@ func TestMetricSuite(t *testing.T) {
 			"id":   "f5",
 			"type": "condition",
 			"query": map[string]any{
-				"field":          map[string]any{"name": "scope.version", "searchScope": "field"},
+				"field":         map[string]any{"name": "scope.version", "searchScope": "field"},
 				"fieldOperator": "=",
 				"value":         "v1.0.0",
 			},
@@ -515,7 +515,7 @@ func TestMetricSuite(t *testing.T) {
 			"id":   "f5b",
 			"type": "condition",
 			"query": map[string]any{
-				"field":          map[string]any{"name": "scopeVersion", "searchScope": "field"},
+				"field":         map[string]any{"name": "scopeVersion", "searchScope": "field"},
 				"fieldOperator": "=",
 				"value":         "v1.0.0",
 			},
@@ -533,7 +533,7 @@ func TestMetricSuite(t *testing.T) {
 			"id":   "f6",
 			"type": "condition",
 			"query": map[string]any{
-				"field":          map[string]any{"name": "resourceDroppedAttributesCount", "searchScope": "field"},
+				"field":         map[string]any{"name": "resourceDroppedAttributesCount", "searchScope": "field"},
 				"fieldOperator": "=",
 				"value":         "0",
 			},
@@ -551,7 +551,7 @@ func TestMetricSuite(t *testing.T) {
 			"id":   "g1",
 			"type": "condition",
 			"query": map[string]any{
-				"field":          map[string]any{"searchScope": "global"},
+				"field":         map[string]any{"searchScope": "global"},
 				"fieldOperator": "CONTAINS",
 				"value":         "memory",
 			},
@@ -569,7 +569,7 @@ func TestMetricSuite(t *testing.T) {
 			"id":   "g2",
 			"type": "condition",
 			"query": map[string]any{
-				"field":          map[string]any{"searchScope": "global"},
+				"field":         map[string]any{"searchScope": "global"},
 				"fieldOperator": "CONTAINS",
 				"value":         "test-service",
 			},
@@ -586,7 +586,7 @@ func TestMetricSuite(t *testing.T) {
 			"id":   "g3",
 			"type": "condition",
 			"query": map[string]any{
-				"field":          map[string]any{"searchScope": "global"},
+				"field":         map[string]any{"searchScope": "global"},
 				"fieldOperator": "CONTAINS",
 				"value":         "nonexistent-metric-xyz",
 			},

--- a/desktopexporter/internal/store/retention.go
+++ b/desktopexporter/internal/store/retention.go
@@ -32,9 +32,29 @@ const (
 // it is the total tracked by DuckDB's duckdb_memory() table function, since
 // there is no file to measure.
 func (s *Store) SizeBytes(ctx context.Context) (int64, error) {
+	var size int64
+	err := s.WithDBRead(func(db *sql.DB) error {
+		var err error
+		size, err = s.sizeBytes(ctx, db)
+		return err
+	})
+	return size, err
+}
+
+// SizeBytesWithDB reports store size using a *sql.DB the caller already
+// obtained from WithDBRead or WithDBWrite. Use this instead of SizeBytes when
+// already inside a WithDB* callback: calling SizeBytes there would acquire the
+// read lock a second time, which deadlocks if a writer queues between the two
+// acquisitions.
+func (s *Store) SizeBytesWithDB(ctx context.Context, db *sql.DB) (int64, error) {
+	return s.sizeBytes(ctx, db)
+}
+
+// sizeBytes is the unlocked implementation. Callers must already hold s.mu.
+func (s *Store) sizeBytes(ctx context.Context, db *sql.DB) (int64, error) {
 	if s.dbPath == "" {
 		var size int64
-		err := s.db.QueryRowContext(ctx,
+		err := db.QueryRowContext(ctx,
 			`select coalesce(sum(memory_usage_bytes), 0) from duckdb_memory()`,
 		).Scan(&size)
 		if err != nil {
@@ -62,45 +82,68 @@ func (s *Store) SizeBytes(ctx context.Context) (int64, error) {
 // maxBytes. maxBytes <= 0 disables enforcement. Each round deletes the oldest
 // pruneFraction of every signal (by time percentile) and checkpoints so
 // DuckDB reclaims the space, re-measuring between rounds.
+//
+// The write lock is taken per round, not for the whole pass, so queries can
+// interleave between rounds. A full pass runs up to three checkpoints; holding
+// the lock across all of them would block every reader for the entire pass.
 func (s *Store) EnforceRetention(ctx context.Context, maxBytes int64) error {
 	if maxBytes <= 0 {
 		return nil
 	}
 
 	for round := 0; round < maxPruneRounds; round++ {
-		size, err := s.SizeBytes(ctx)
+		fits, err := s.enforceRound(ctx, maxBytes)
 		if err != nil {
 			return err
 		}
-		if size <= maxBytes {
+		if fits {
 			return nil
-		}
-
-		if err := s.pruneOldestSpans(ctx); err != nil {
-			return err
-		}
-		if err := s.pruneOldestLogs(ctx); err != nil {
-			return err
-		}
-		if err := s.pruneOldestDatapoints(ctx); err != nil {
-			return err
-		}
-
-		// Checkpoint flushes the WAL and lets DuckDB reuse the freed blocks;
-		// without it the file/memory measurement would not move.
-		if _, err := s.db.ExecContext(ctx, `checkpoint`); err != nil {
-			return fmt.Errorf("EnforceRetention: %w: %w", ErrRetentionInternal, err)
 		}
 	}
 	return nil
 }
 
+// enforceRound runs one measure-prune-checkpoint round under the write lock.
+// It reports whether the store already fits within maxBytes, in which case no
+// pruning was done and the caller can stop.
+func (s *Store) enforceRound(ctx context.Context, maxBytes int64) (bool, error) {
+	fits := false
+	err := s.WithDBWrite(func(db *sql.DB) error {
+		size, err := s.sizeBytes(ctx, db)
+		if err != nil {
+			return err
+		}
+		if size <= maxBytes {
+			fits = true
+			return nil
+		}
+
+		if err := s.pruneOldestSpans(ctx, db); err != nil {
+			return err
+		}
+		if err := s.pruneOldestLogs(ctx, db); err != nil {
+			return err
+		}
+		if err := s.pruneOldestDatapoints(ctx, db); err != nil {
+			return err
+		}
+
+		// Checkpoint flushes the WAL and lets DuckDB reuse the freed blocks;
+		// without it the file/memory measurement would not move.
+		if _, err := db.ExecContext(ctx, `checkpoint`); err != nil {
+			return fmt.Errorf("EnforceRetention: %w: %w", ErrRetentionInternal, err)
+		}
+		return nil
+	})
+	return fits, err
+}
+
 // pruneCutoff returns the timestamp below which rows should be deleted,
 // i.e. the pruneFraction percentile of the given time expression. Returns
 // (0, false) when the table is empty.
-func (s *Store) pruneCutoff(ctx context.Context, query string) (int64, bool, error) {
+func (s *Store) pruneCutoff(ctx context.Context, db *sql.DB, query string) (int64, bool, error) {
 	var cutoff sql.NullInt64
-	if err := s.db.QueryRowContext(ctx, query, pruneFraction).Scan(&cutoff); err != nil {
+	if err := db.QueryRowContext(ctx, query, pruneFraction).Scan(&cutoff); err != nil {
 		return 0, false, fmt.Errorf("pruneCutoff: %w: %w", ErrRetentionInternal, err)
 	}
 	return cutoff.Int64, cutoff.Valid, nil
@@ -110,8 +153,8 @@ func (s *Store) pruneCutoff(ctx context.Context, query string) (int64, bool, err
 // events, links, and attributes. Attribute rows for events and links carry
 // the owning span_id (enforced by chk_attributes_one_owner), so a single
 // span_id predicate covers all three owners. Leaves first, spans last.
-func (s *Store) pruneOldestSpans(ctx context.Context) error {
-	cutoff, ok, err := s.pruneCutoff(ctx,
+func (s *Store) pruneOldestSpans(ctx context.Context, db *sql.DB) error {
+	cutoff, ok, err := s.pruneCutoff(ctx, db,
 		`select cast(quantile_cont(start_time, ?) as bigint) from spans`)
 	if err != nil || !ok {
 		return err
@@ -123,7 +166,7 @@ func (s *Store) pruneOldestSpans(ctx context.Context) error {
 		`delete from events where span_id in (select span_id from spans where start_time < ?)`,
 		`delete from spans where start_time < ?`,
 	} {
-		if _, err := s.db.ExecContext(ctx, q, cutoff); err != nil {
+		if _, err := db.ExecContext(ctx, q, cutoff); err != nil {
 			return fmt.Errorf("pruneOldestSpans: %w: %w", ErrRetentionInternal, err)
 		}
 	}
@@ -133,10 +176,10 @@ func (s *Store) pruneOldestSpans(ctx context.Context) error {
 // pruneOldestLogs deletes the oldest fraction of logs and their attributes.
 // Logs may arrive with timestamp = 0 (unset); observed_timestamp is the
 // fallback, mirroring how GetStats computes lastReceived.
-func (s *Store) pruneOldestLogs(ctx context.Context) error {
+func (s *Store) pruneOldestLogs(ctx context.Context, db *sql.DB) error {
 	const logTime = `coalesce(nullif(timestamp, 0), observed_timestamp)`
 
-	cutoff, ok, err := s.pruneCutoff(ctx,
+	cutoff, ok, err := s.pruneCutoff(ctx, db,
 		`select cast(quantile_cont(`+logTime+`, ?) as bigint) from logs`)
 	if err != nil || !ok {
 		return err
@@ -146,7 +189,7 @@ func (s *Store) pruneOldestLogs(ctx context.Context) error {
 		`delete from attributes where log_id in (select id from logs where ` + logTime + ` < ?)`,
 		`delete from logs where ` + logTime + ` < ?`,
 	} {
-		if _, err := s.db.ExecContext(ctx, q, cutoff); err != nil {
+		if _, err := db.ExecContext(ctx, q, cutoff); err != nil {
 			return fmt.Errorf("pruneOldestLogs: %w: %w", ErrRetentionInternal, err)
 		}
 	}
@@ -159,8 +202,8 @@ func (s *Store) pruneOldestLogs(ctx context.Context) error {
 // metric_ingests grows by one row per OTLP batch, so leaving orphans behind
 // would let the store creep back over the cap with rows pruning can't touch.
 // A swept stream that is still live gets recreated by ingest's find-or-insert.
-func (s *Store) pruneOldestDatapoints(ctx context.Context) error {
-	cutoff, ok, err := s.pruneCutoff(ctx,
+func (s *Store) pruneOldestDatapoints(ctx context.Context, db *sql.DB) error {
+	cutoff, ok, err := s.pruneCutoff(ctx, db,
 		`select cast(quantile_cont(timestamp, ?) as bigint) from datapoints`)
 	if err != nil || !ok {
 		return err
@@ -173,7 +216,7 @@ func (s *Store) pruneOldestDatapoints(ctx context.Context) error {
 		`delete from exemplars where datapoint_id in ` + doomed,
 		`delete from datapoints where timestamp < ?`,
 	} {
-		if _, err := s.db.ExecContext(ctx, q, cutoff); err != nil {
+		if _, err := db.ExecContext(ctx, q, cutoff); err != nil {
 			return fmt.Errorf("pruneOldestDatapoints: %w: %w", ErrRetentionInternal, err)
 		}
 	}
@@ -191,7 +234,7 @@ func (s *Store) pruneOldestDatapoints(ctx context.Context) error {
 		`delete from metric_streams ms
 			where not exists (select 1 from metric_ingests mi where mi.stream_id = ms.id)`,
 	} {
-		if _, err := s.db.ExecContext(ctx, q); err != nil {
+		if _, err := db.ExecContext(ctx, q); err != nil {
 			return fmt.Errorf("pruneOldestDatapoints: %w: %w", ErrRetentionInternal, err)
 		}
 	}

--- a/desktopexporter/internal/store/retention_test.go
+++ b/desktopexporter/internal/store/retention_test.go
@@ -13,12 +13,12 @@ import (
 // one fat attribute row so pruning visibly moves the size measurement.
 func seedSpans(t *testing.T, s *Store, n int) {
 	t.Helper()
-	_, err := s.DB().Exec(`
+	_, err := s.db.Exec(`
 		insert into spans (trace_id, span_id, name, start_time, end_time)
 		select uuid(), uuid(), 'span-' || range, range * 1000000, range * 1000000 + 500
 		from range(?)`, n)
 	require.NoError(t, err)
-	_, err = s.DB().Exec(`
+	_, err = s.db.Exec(`
 		insert into attributes (span_id, scope, key, value, type)
 		select span_id, 'span', 'pad', repeat('x', 500), 'string' from spans`)
 	require.NoError(t, err)
@@ -28,7 +28,7 @@ func seedSpans(t *testing.T, s *Store, n int) {
 // observed_timestamp fallback in the prune cutoff.
 func seedLogs(t *testing.T, s *Store, n int) {
 	t.Helper()
-	_, err := s.DB().Exec(`
+	_, err := s.db.Exec(`
 		insert into logs (id, timestamp, observed_timestamp, body)
 		select uuid(),
 			case when range % 2 = 0 then range * 1000000 else 0 end,
@@ -42,11 +42,11 @@ func seedLogs(t *testing.T, s *Store, n int) {
 // timestamp = startTime + i * 1ms.
 func seedDatapoints(t *testing.T, s *Store, streamID, ingestID string, n int, startTime int64) {
 	t.Helper()
-	_, err := s.DB().Exec(`insert into metric_streams (id, name, metric_type) values (?, 'metric-' || ?, 'Gauge') on conflict do nothing`, streamID, streamID)
+	_, err := s.db.Exec(`insert into metric_streams (id, name, metric_type) values (?, 'metric-' || ?, 'Gauge') on conflict do nothing`, streamID, streamID)
 	require.NoError(t, err)
-	_, err = s.DB().Exec(`insert into metric_ingests (id, stream_id) values (?, ?)`, ingestID, streamID)
+	_, err = s.db.Exec(`insert into metric_ingests (id, stream_id) values (?, ?)`, ingestID, streamID)
 	require.NoError(t, err)
-	_, err = s.DB().Exec(`
+	_, err = s.db.Exec(`
 		insert into datapoints (id, stream_id, metric_ingest_id, timestamp, double_value, value_type)
 		select uuid(), ?::uuid, ?::uuid, ? + range * 1000000, range, 'double'
 		from range(?)`, streamID, ingestID, startTime, n)
@@ -56,7 +56,7 @@ func seedDatapoints(t *testing.T, s *Store, streamID, ingestID string, n int, st
 func count(t *testing.T, s *Store, table string) int64 {
 	t.Helper()
 	var n int64
-	require.NoError(t, s.DB().QueryRow(`select count(*) from `+table).Scan(&n))
+	require.NoError(t, s.db.QueryRow(`select count(*) from `+table).Scan(&n))
 	return n
 }
 
@@ -83,7 +83,7 @@ func TestSizeBytesOnDisk(t *testing.T) {
 	defer s.Close()
 
 	seedSpans(t, s, 5000)
-	_, err = s.DB().Exec(`checkpoint`)
+	_, err = s.db.Exec(`checkpoint`)
 	require.NoError(t, err)
 
 	size, err := s.SizeBytes(ctx)
@@ -114,12 +114,12 @@ func TestEnforceRetentionPrunesOldest(t *testing.T) {
 
 	// The survivors must be the newest rows.
 	var minStart int64
-	require.NoError(t, s.DB().QueryRow(`select min(start_time) from spans`).Scan(&minStart))
+	require.NoError(t, s.db.QueryRow(`select min(start_time) from spans`).Scan(&minStart))
 	assert.Positive(t, minStart, "the oldest spans should be gone")
 
 	// No dangling attributes: every attribute's span must still exist.
 	var orphans int64
-	require.NoError(t, s.DB().QueryRow(`
+	require.NoError(t, s.db.QueryRow(`
 		select count(*) from attributes a
 		where a.span_id is not null
 		and not exists (select 1 from spans sp where sp.span_id = a.span_id)`).Scan(&orphans))
@@ -145,9 +145,9 @@ func TestEnforceRetentionSweepsOrphanedMetricIdentity(t *testing.T) {
 	require.NoError(t, s.EnforceRetention(ctx, 1))
 
 	var oldStreams, oldIngests, liveStreams int64
-	require.NoError(t, s.DB().QueryRow(`select count(*) from metric_streams where id = ?::uuid`, oldStream).Scan(&oldStreams))
-	require.NoError(t, s.DB().QueryRow(`select count(*) from metric_ingests where id = ?::uuid`, oldIngest).Scan(&oldIngests))
-	require.NoError(t, s.DB().QueryRow(`select count(*) from metric_streams where id = ?::uuid`, liveStream).Scan(&liveStreams))
+	require.NoError(t, s.db.QueryRow(`select count(*) from metric_streams where id = ?::uuid`, oldStream).Scan(&oldStreams))
+	require.NoError(t, s.db.QueryRow(`select count(*) from metric_ingests where id = ?::uuid`, oldIngest).Scan(&oldIngests))
+	require.NoError(t, s.db.QueryRow(`select count(*) from metric_streams where id = ?::uuid`, liveStream).Scan(&liveStreams))
 
 	assert.Zero(t, oldStreams, "fully-pruned stream should be swept")
 	assert.Zero(t, oldIngests, "ingest with no remaining datapoints should be swept")

--- a/desktopexporter/internal/store/spans/spans_test.go
+++ b/desktopexporter/internal/store/spans/spans_test.go
@@ -20,6 +20,19 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
+// readStore runs a query under the store's read lock and returns its result.
+// Store exposes no raw *sql.DB: every read is ordered against ingest,
+// retention, and Close.
+func readStore[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error) {
+	var out T
+	err := s.WithDBRead(func(db *sql.DB) error {
+		var err error
+		out, err = fn(db)
+		return err
+	})
+	return out, err
+}
+
 func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
 	t.Helper()
 	ctx := context.Background()
@@ -28,10 +41,12 @@ func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
 	return s, ctx, func() { s.Close() }
 }
 
-func countRows(t *testing.T, db *sql.DB, ctx context.Context, query string, args ...any) int {
+func countRows(t *testing.T, s *store.Store, ctx context.Context, query string, args ...any) int {
 	t.Helper()
 	var n int
-	require.NoError(t, db.QueryRowContext(ctx, query, args...).Scan(&n))
+	require.NoError(t, s.WithDBRead(func(db *sql.DB) error {
+		return db.QueryRowContext(ctx, query, args...).Scan(&n)
+	}))
 	return n
 }
 
@@ -101,7 +116,9 @@ func buildTracesForSummaryOrdering(baseTime int64) (ptrace.Traces, string, strin
 func searchTracesAll(t *testing.T, s *store.Store, ctx context.Context) []traceSummaryJSON {
 	t.Helper()
 	const maxNano = 1<<63 - 1
-	raw, err := spans.SearchTraces(ctx, s.DB(), 0, maxNano, nil)
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return spans.SearchTraces(ctx, db, 0, maxNano, nil)
+	})
 	assert.NoError(t, err)
 	var summaries []traceSummaryJSON
 	assert.NoError(t, json.Unmarshal(raw, &summaries))
@@ -161,7 +178,9 @@ func TestTraceNotFound(t *testing.T) {
 	s, ctx, teardown := setupStore(t)
 	defer teardown()
 
-	_, err := spans.SearchSpans(ctx, s.DB(), "00000000-0000-0000-0000-000000000000", nil)
+	_, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return spans.SearchSpans(ctx, db, "00000000-0000-0000-0000-000000000000", nil)
+	})
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, spans.ErrTraceIDNotFound)
 }
@@ -193,18 +212,20 @@ func TestClearTraces(t *testing.T) {
 
 	summaries := searchTracesAll(t, s, ctx)
 	assert.Len(t, summaries, 1)
-	assert.Greater(t, countRows(t, s.DB(), ctx, "select count(*) from events"), 0)
-	assert.Greater(t, countRows(t, s.DB(), ctx, "select count(*) from links"), 0)
-	assert.Greater(t, countRows(t, s.DB(), ctx, "select count(*) from attributes where span_id is not null"), 0)
+	assert.Greater(t, countRows(t, s, ctx, "select count(*) from events"), 0)
+	assert.Greater(t, countRows(t, s, ctx, "select count(*) from links"), 0)
+	assert.Greater(t, countRows(t, s, ctx, "select count(*) from attributes where span_id is not null"), 0)
 
-	err = spans.Clear(ctx, s.DB())
+	err = s.WithDBWrite(func(db *sql.DB) error {
+		return spans.Clear(ctx, db)
+	})
 	assert.NoError(t, err)
 
 	summaries = searchTracesAll(t, s, ctx)
 	assert.Empty(t, summaries)
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from events"))
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from links"))
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from attributes where span_id is not null"))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from events"))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from links"))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from attributes where span_id is not null"))
 }
 
 // getTraceTraceID returns the trace ID from SearchSpans JSON (traceID in response is hex string).
@@ -256,7 +277,9 @@ func TestTraceSuite(t *testing.T) {
 	assert.NoError(t, err, "failed to ingest test trace")
 
 	t.Run("TraceHierarchicalStructure", func(t *testing.T) {
-		raw, err := spans.SearchSpans(ctx, s.DB(), testTraceID, nil)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchSpans(ctx, db, testTraceID, nil)
+		})
 		assert.NoError(t, err, "failed to get trace")
 		assert.NotEmpty(t, raw)
 
@@ -284,13 +307,17 @@ func TestTraceSuite(t *testing.T) {
 	})
 
 	t.Run("TraceNotFound", func(t *testing.T) {
-		_, err := spans.SearchSpans(ctx, s.DB(), "00000000-0000-0000-0000-000000000000", nil)
+		_, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchSpans(ctx, db, "00000000-0000-0000-0000-000000000000", nil)
+		})
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, spans.ErrTraceIDNotFound)
 	})
 
 	t.Run("SearchSpansAcceptsTraceIDWithoutHyphens", func(t *testing.T) {
-		raw, err := spans.SearchSpans(ctx, s.DB(), "00000000000000000000000000000099", nil)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchSpans(ctx, db, "00000000000000000000000000000099", nil)
+		})
 		assert.NoError(t, err, "SearchSpans with 32-char hex trace ID should succeed")
 		assert.Equal(t, testTraceID, getTraceTraceID(t, raw))
 	})
@@ -299,7 +326,9 @@ func TestTraceSuite(t *testing.T) {
 		now := time.Now().UnixNano()
 		start := now - 24*int64(time.Hour)
 		end := now + 24*int64(time.Hour)
-		raw, err := spans.GetTraceAttributes(ctx, s.DB(), start, end)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.GetTraceAttributes(ctx, db, start, end)
+		})
 		assert.NoError(t, err, "failed to get trace attributes")
 
 		var attributes []struct {
@@ -372,7 +401,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "test-service",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -389,7 +420,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "root-value",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -406,7 +439,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "root-event",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -423,7 +458,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "Hello",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -440,7 +477,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "Link1",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -457,7 +496,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "0000000000000001",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries, "global search for span ID hex should match")
@@ -474,7 +515,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "00000000000000000000000000000099",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries, "global search for trace ID hex should match")
@@ -491,7 +534,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "nonexistent-value-12345",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.Empty(t, summaries)
@@ -512,7 +557,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "test-service",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -534,7 +581,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "42",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -556,7 +605,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "3.14",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -578,7 +629,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "true",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -600,7 +653,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "two",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -622,7 +677,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "20",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -644,7 +701,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "2.2",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -666,7 +725,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "true",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -688,7 +749,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "Hello",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -710,7 +773,9 @@ func TestSearchTraces(t *testing.T) {
 				Value:         "Link1",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -732,7 +797,9 @@ func TestSearchTraces(t *testing.T) {
 				"value":         "test-service",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -750,7 +817,9 @@ func TestSearchTraces(t *testing.T) {
 				"value":         "root-operation",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.Len(t, summaries, 1)
@@ -769,7 +838,9 @@ func TestSearchTraces(t *testing.T) {
 				"value":         testTraceID,
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.Len(t, summaries, 1)
@@ -786,7 +857,9 @@ func TestSearchTraces(t *testing.T) {
 				"value":         "test-scope",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -803,7 +876,9 @@ func TestSearchTraces(t *testing.T) {
 				"value":         "v1.0.0",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -820,7 +895,9 @@ func TestSearchTraces(t *testing.T) {
 				"value":         "root-event",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -838,7 +915,9 @@ func TestSearchTraces(t *testing.T) {
 				"value":         "00000000-0000-0000-0000-00000000000a",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -856,7 +935,9 @@ func TestSearchTraces(t *testing.T) {
 				"value":         "0000000000000000000000000000000a",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -878,7 +959,9 @@ func TestSearchTraces(t *testing.T) {
 				"value":         "000000000000000a",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err)
 		summaries := parseSummaries(raw)
 		assert.NotEmpty(t, summaries)
@@ -897,7 +980,9 @@ func TestSearchTraces(t *testing.T) {
 				"value":         "not-a-trace",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err, "garbage trace ID must not surface a cast error")
 		assert.Empty(t, parseSummaries(raw))
 	})
@@ -912,7 +997,9 @@ func TestSearchTraces(t *testing.T) {
 				"value":         "zz-definitely-not-hex",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err, "garbage span ID must not surface a cast error")
 		assert.Empty(t, parseSummaries(raw))
 	})
@@ -927,7 +1014,9 @@ func TestSearchTraces(t *testing.T) {
 				"value":         "not-a-trace",
 			},
 		}
-		raw, err := spans.SearchTraces(ctx, s.DB(), startTime, endTime, query)
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, startTime, endTime, query)
+		})
 		assert.NoError(t, err, "garbage link trace ID must not surface a cast error")
 		assert.Empty(t, parseSummaries(raw))
 	})
@@ -948,7 +1037,9 @@ func TestIngestSpans_FlushInterval(t *testing.T) {
 	assert.NoError(t, err)
 
 	testTraceID := "00000000000000000000000000000099"
-	raw, err := spans.SearchSpans(ctx, s.DB(), testTraceID, nil)
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return spans.SearchSpans(ctx, db, testTraceID, nil)
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, batchSize, getTraceSpansCount(t, raw))
 
@@ -957,13 +1048,13 @@ func TestIngestSpans_FlushInterval(t *testing.T) {
 	for _, spanIndex := range []int{0, 49, 50} {
 		spanIDHex := fmt.Sprintf("%016x", spanIndex+1)
 		spanUUID := "00000000-0000-0000-0000-" + spanIDHex[4:]
-		attrCount := countRows(t, s.DB(), ctx, "select count(*) from attributes where span_id = ? and scope = 'span' and key in ('span.index', 'flush_test')", spanUUID)
+		attrCount := countRows(t, s, ctx, "select count(*) from attributes where span_id = ? and scope = 'span' and key in ('span.index', 'flush_test')", spanUUID)
 		assert.GreaterOrEqual(t, attrCount, 2, "span %d should have span.index and flush_test attributes", spanIndex)
 	}
 	// Resource/scope attributes on first span
 	span1UUID := "00000000-0000-0000-0000-000000000001"
-	resAttr := countRows(t, s.DB(), ctx, "select count(*) from attributes where span_id = ? and scope = 'resource'", span1UUID)
-	scopeAttr := countRows(t, s.DB(), ctx, "select count(*) from attributes where span_id = ? and scope = 'scope'", span1UUID)
+	resAttr := countRows(t, s, ctx, "select count(*) from attributes where span_id = ? and scope = 'resource'", span1UUID)
+	scopeAttr := countRows(t, s, ctx, "select count(*) from attributes where span_id = ? and scope = 'scope'", span1UUID)
 	assert.GreaterOrEqual(t, resAttr, 1)
 	assert.GreaterOrEqual(t, scopeAttr, 1)
 }
@@ -1011,26 +1102,32 @@ func TestDeleteSpanByID(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	raw, err := spans.SearchSpans(ctx, s.DB(), "00000000-0000-0000-0000-000000000099", nil)
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return spans.SearchSpans(ctx, db, "00000000-0000-0000-0000-000000000099", nil)
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, 9, getTraceSpansCount(t, raw))
 
 	spanUUID := "00000000-0000-0000-0000-000000000001"
-	eventsBefore := countRows(t, s.DB(), ctx, "select count(*) from events where span_id = ?", spanUUID)
-	linksBefore := countRows(t, s.DB(), ctx, "select count(*) from links where span_id = ?", spanUUID)
-	attrsBefore := countRows(t, s.DB(), ctx, "select count(*) from attributes where span_id = ?", spanUUID)
+	eventsBefore := countRows(t, s, ctx, "select count(*) from events where span_id = ?", spanUUID)
+	linksBefore := countRows(t, s, ctx, "select count(*) from links where span_id = ?", spanUUID)
+	attrsBefore := countRows(t, s, ctx, "select count(*) from attributes where span_id = ?", spanUUID)
 	assert.Greater(t, eventsBefore+linksBefore+attrsBefore, 0, "root span should have child rows")
 
-	err = spans.DeleteSpanByID(ctx, s.DB(), spanUUID)
+	err = s.WithDBWrite(func(db *sql.DB) error {
+		return spans.DeleteSpanByID(ctx, db, spanUUID)
+	})
 	assert.NoError(t, err)
 
-	raw, err = spans.SearchSpans(ctx, s.DB(), "00000000-0000-0000-0000-000000000099", nil)
+	raw, err = readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return spans.SearchSpans(ctx, db, "00000000-0000-0000-0000-000000000099", nil)
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, 8, getTraceSpansCount(t, raw))
 
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from events where span_id = ?", spanUUID))
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from links where span_id = ?", spanUUID))
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from attributes where span_id = ?", spanUUID))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from events where span_id = ?", spanUUID))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from links where span_id = ?", spanUUID))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from attributes where span_id = ?", spanUUID))
 }
 
 // TestDeleteSpansByIDs verifies that multiple spans can be deleted by their SpanIDs, including child rows.
@@ -1044,7 +1141,9 @@ func TestDeleteSpansByIDs(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	raw, err := spans.SearchSpans(ctx, s.DB(), "00000000-0000-0000-0000-000000000099", nil)
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return spans.SearchSpans(ctx, db, "00000000-0000-0000-0000-000000000099", nil)
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, 9, getTraceSpansCount(t, raw))
 
@@ -1053,19 +1152,23 @@ func TestDeleteSpansByIDs(t *testing.T) {
 		"00000000-0000-0000-0000-000000000002",
 		"00000000-0000-0000-0000-000000000003",
 	}
-	attrsBefore := countRows(t, s.DB(), ctx, "select count(*) from attributes where span_id in (?, ?, ?)", deletedIDs...)
+	attrsBefore := countRows(t, s, ctx, "select count(*) from attributes where span_id in (?, ?, ?)", deletedIDs...)
 	assert.Greater(t, attrsBefore, 0, "deleted spans should have attributes")
 
-	err = spans.DeleteSpansByIDs(ctx, s.DB(), deletedIDs)
+	err = s.WithDBWrite(func(db *sql.DB) error {
+		return spans.DeleteSpansByIDs(ctx, db, deletedIDs)
+	})
 	assert.NoError(t, err)
 
-	raw, err = spans.SearchSpans(ctx, s.DB(), "00000000-0000-0000-0000-000000000099", nil)
+	raw, err = readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return spans.SearchSpans(ctx, db, "00000000-0000-0000-0000-000000000099", nil)
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, 6, getTraceSpansCount(t, raw))
 
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from events where span_id in (?, ?, ?)", deletedIDs...))
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from links where span_id in (?, ?, ?)", deletedIDs...))
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from attributes where span_id in (?, ?, ?)", deletedIDs...))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from events where span_id in (?, ?, ?)", deletedIDs...))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from links where span_id in (?, ?, ?)", deletedIDs...))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from attributes where span_id in (?, ?, ?)", deletedIDs...))
 }
 
 // TestDeleteSpansByIDs_Empty verifies that deleting with an empty list is a no-op.
@@ -1073,7 +1176,9 @@ func TestDeleteSpansByIDs_Empty(t *testing.T) {
 	s, ctx, teardown := setupStore(t)
 	defer teardown()
 
-	err := spans.DeleteSpansByIDs(ctx, s.DB(), []any{})
+	err := s.WithDBWrite(func(db *sql.DB) error {
+		return spans.DeleteSpansByIDs(ctx, db, []any{})
+	})
 	assert.NoError(t, err)
 }
 
@@ -1091,18 +1196,20 @@ func TestDeleteSpansByTraceID(t *testing.T) {
 
 	summaries := searchTracesAll(t, s, ctx)
 	assert.Len(t, summaries, 1)
-	assert.Greater(t, countRows(t, s.DB(), ctx, "select count(*) from events"), 0)
-	assert.Greater(t, countRows(t, s.DB(), ctx, "select count(*) from links"), 0)
-	assert.Greater(t, countRows(t, s.DB(), ctx, "select count(*) from attributes where span_id is not null"), 0)
+	assert.Greater(t, countRows(t, s, ctx, "select count(*) from events"), 0)
+	assert.Greater(t, countRows(t, s, ctx, "select count(*) from links"), 0)
+	assert.Greater(t, countRows(t, s, ctx, "select count(*) from attributes where span_id is not null"), 0)
 
-	err = spans.DeleteSpansByTraceID(ctx, s.DB(), testTraceID)
+	err = s.WithDBWrite(func(db *sql.DB) error {
+		return spans.DeleteSpansByTraceID(ctx, db, testTraceID)
+	})
 	assert.NoError(t, err)
 
 	summaries = searchTracesAll(t, s, ctx)
 	assert.Empty(t, summaries)
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from events"))
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from links"))
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from attributes where span_id is not null"))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from events"))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from links"))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from attributes where span_id is not null"))
 }
 
 // TestSearchSpansWith32CharHexTraceID verifies that SearchSpans finds a trace when given the 32-char hex form (no hyphens).
@@ -1116,7 +1223,9 @@ func TestSearchSpansWith32CharHexTraceID(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	raw, err := spans.SearchSpans(ctx, s.DB(), "00000000000000000000000000000099", nil)
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return spans.SearchSpans(ctx, db, "00000000000000000000000000000099", nil)
+	})
 	assert.NoError(t, err, "SearchSpans with 32-char hex trace ID should succeed")
 	assert.NotEmpty(t, raw)
 	assert.Equal(t, "00000000000000000000000000000099", getTraceTraceID(t, raw))
@@ -1136,18 +1245,20 @@ func TestDeleteSpansByTraceIDs(t *testing.T) {
 
 	summaries := searchTracesAll(t, s, ctx)
 	assert.Len(t, summaries, 1)
-	assert.Greater(t, countRows(t, s.DB(), ctx, "select count(*) from events"), 0)
-	assert.Greater(t, countRows(t, s.DB(), ctx, "select count(*) from links"), 0)
-	assert.Greater(t, countRows(t, s.DB(), ctx, "select count(*) from attributes where span_id is not null"), 0)
+	assert.Greater(t, countRows(t, s, ctx, "select count(*) from events"), 0)
+	assert.Greater(t, countRows(t, s, ctx, "select count(*) from links"), 0)
+	assert.Greater(t, countRows(t, s, ctx, "select count(*) from attributes where span_id is not null"), 0)
 
-	err = spans.DeleteSpansByTraceIDs(ctx, s.DB(), []any{testTraceID})
+	err = s.WithDBWrite(func(db *sql.DB) error {
+		return spans.DeleteSpansByTraceIDs(ctx, db, []any{testTraceID})
+	})
 	assert.NoError(t, err)
 
 	summaries = searchTracesAll(t, s, ctx)
 	assert.Empty(t, summaries)
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from events"))
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from links"))
-	assert.Equal(t, 0, countRows(t, s.DB(), ctx, "select count(*) from attributes where span_id is not null"))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from events"))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from links"))
+	assert.Equal(t, 0, countRows(t, s, ctx, "select count(*) from attributes where span_id is not null"))
 }
 
 // TestDeleteSpansByTraceIDs_Empty verifies that deleting with an empty list is a no-op.
@@ -1155,7 +1266,9 @@ func TestDeleteSpansByTraceIDs_Empty(t *testing.T) {
 	s, ctx, teardown := setupStore(t)
 	defer teardown()
 
-	err := spans.DeleteSpansByTraceIDs(ctx, s.DB(), []any{})
+	err := s.WithDBWrite(func(db *sql.DB) error {
+		return spans.DeleteSpansByTraceIDs(ctx, db, []any{})
+	})
 	assert.NoError(t, err)
 }
 
@@ -1432,14 +1545,16 @@ func TestSpans_ServiceNameDenormStaysConsistent(t *testing.T) {
 	// (We use coalesce(a.value, '') because spans without the resource
 	// attribute have a column value of '' and no matching attribute.)
 	var mismatches int
-	require.NoError(t, s.DB().QueryRowContext(ctx, `
-		select count(*) from spans s
-		left join attributes a
-		     on a.span_id = s.span_id
-		    and a.scope = 'resource'
-		    and a.key = 'service.name'
-		where s.service_name <> coalesce(a.value, '')
-	`).Scan(&mismatches))
+	require.NoError(t, s.WithDBRead(func(db *sql.DB) error {
+		return db.QueryRowContext(ctx, `
+			select count(*) from spans s
+			left join attributes a
+			     on a.span_id = s.span_id
+			    and a.scope = 'resource'
+			    and a.key = 'service.name'
+			where s.service_name <> coalesce(a.value, '')
+		`).Scan(&mismatches)
+	}))
 	assert.Equal(t, 0, mismatches,
 		"spans.service_name must equal the source resource attribute (or '' when absent)")
 }

--- a/desktopexporter/internal/store/stats/stats_test.go
+++ b/desktopexporter/internal/store/stats/stats_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"database/sql"
 	"database/sql/driver"
 
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store"
@@ -21,6 +22,19 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
+
+// readStore runs a query under the store's read lock and returns its result.
+// Store exposes no raw *sql.DB: every read is ordered against ingest,
+// retention, and Close.
+func readStore[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error) {
+	var out T
+	err := s.WithDBRead(func(db *sql.DB) error {
+		var err error
+		out, err = fn(db)
+		return err
+	})
+	return out, err
+}
 
 func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
 	t.Helper()
@@ -86,7 +100,9 @@ func getStats(t *testing.T, s *store.Store, ctx context.Context) statsJSON {
 	t.Helper()
 	sizeBytes, err := s.SizeBytes(ctx)
 	require.NoError(t, err)
-	raw, err := stats.GetStats(ctx, s.DB(), sizeBytes, s.RetentionCap())
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return stats.GetStats(ctx, db, sizeBytes, s.RetentionCap())
+	})
 	require.NoError(t, err)
 	var result statsJSON
 	require.NoError(t, json.Unmarshal(raw, &result))

--- a/desktopexporter/internal/store/store.go
+++ b/desktopexporter/internal/store/store.go
@@ -185,14 +185,7 @@ func (s *Store) WithDBWrite(fn func(db *sql.DB) error) error {
 	return fn(s.db)
 }
 
-// DB returns the underlying *sql.DB without holding the lock across the
-// caller's work.
-//
-// Test-only. Production code must use WithDBRead or WithDBWrite so access is
-// ordered against ingest, retention, and Close. Tests use one store per test
-// and drive it from a single goroutine, where that ordering is not needed.
-func (s *Store) DB() *sql.DB {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.db
-}
+// Store deliberately exposes no accessor for its *sql.DB. Handing out the pool
+// would let a caller query after the lock released, which is the ordering bug
+// WithDBRead and WithDBWrite exist to prevent. Callers that need the pool pass
+// a closure to one of those instead.

--- a/desktopexporter/internal/store/store.go
+++ b/desktopexporter/internal/store/store.go
@@ -9,10 +9,17 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/schema"
 	"github.com/duckdb/duckdb-go/v2"
 )
+
+// maxPoolConns caps the *sql.DB pool. Reads run concurrently under the store's
+// read lock, so several DuckDB connections can be live at once; without a cap
+// a burst of JSON-RPC calls opens one per in-flight request, and each is a real
+// DuckDB connection with real memory cost.
+const maxPoolConns = 4
 
 // Sentinel errors for use with errors.Is.
 var (
@@ -24,7 +31,15 @@ type Store struct {
 	db     *sql.DB
 	conn   driver.Conn
 	dbPath string // empty means in-memory mode
-	mu     sync.Mutex
+
+	// mu orders access to both handles. The write lock is shared by appender
+	// writes (WithConn), pool mutations (WithDBWrite), and Close, so those are
+	// mutually exclusive even though they run on different connections. Reads
+	// (WithDBRead) run concurrently with each other and never overlap a write.
+	//
+	// Not reentrant: never call a locking Store method from inside a WithConn,
+	// WithDBRead, or WithDBWrite callback.
+	mu sync.RWMutex
 
 	// retentionCapBytes is the store size cap enforced by EnforceRetention
 	// and reported by getStats. 0 means retention is disabled. Set once via
@@ -60,6 +75,13 @@ func NewStore(ctx context.Context, dbPath string) (*Store, error) {
 	}
 
 	db := sql.OpenDB(connector)
+
+	// Idle connections are kept rather than dropped: we hold no connection-local
+	// temporary state, so reusing them is safe, and steady-state UI polling would
+	// otherwise reopen DuckDB connections on every request.
+	db.SetMaxOpenConns(maxPoolConns)
+	db.SetMaxIdleConns(maxPoolConns)
+	db.SetConnMaxIdleTime(5 * time.Minute)
 
 	// 1) Create types - ignore "already exists" errors
 	for i, query := range schema.TypeCreationQueries {
@@ -121,8 +143,9 @@ func (s *Store) Close() error {
 	return errors.Join(connErr, dbErr)
 }
 
-// WithConn locks the store, verifies the connection is alive,
-// and passes it to fn. The lock is released when fn returns.
+// WithConn runs fn against the store's dedicated appender connection under the
+// write lock. Ingest uses this: DuckDB appenders are bound to the connection
+// that created them, so ingest cannot run on the pool.
 func (s *Store) WithConn(fn func(conn driver.Conn) error) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -134,7 +157,42 @@ func (s *Store) WithConn(fn func(conn driver.Conn) error) error {
 	return fn(s.conn)
 }
 
-// DB returns the underlying *sql.DB. Used by subpackages and tests.
+// WithDBRead runs fn against the connection pool under the read lock. Use it
+// for SELECTs. Concurrent readers run in parallel and never overlap a writer.
+func (s *Store) WithDBRead(fn func(db *sql.DB) error) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.db == nil {
+		return ErrStoreConnectionClosed
+	}
+
+	return fn(s.db)
+}
+
+// WithDBWrite runs fn against the connection pool under the write lock. Use it
+// for DELETE, checkpoint, and anything else that mutates. Sharing the write
+// lock with WithConn is the point: it keeps pool mutations from racing the
+// appender writes that ingest performs on a different connection.
+func (s *Store) WithDBWrite(fn func(db *sql.DB) error) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return ErrStoreConnectionClosed
+	}
+
+	return fn(s.db)
+}
+
+// DB returns the underlying *sql.DB without holding the lock across the
+// caller's work.
+//
+// Test-only. Production code must use WithDBRead or WithDBWrite so access is
+// ordered against ingest, retention, and Close. Tests use one store per test
+// and drive it from a single goroutine, where that ordering is not needed.
 func (s *Store) DB() *sql.DB {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.db
 }

--- a/desktopexporter/internal/store/store_test.go
+++ b/desktopexporter/internal/store/store_test.go
@@ -145,19 +145,19 @@ func runStoreTests(t *testing.T, tests []storeTest) {
 			assert.NoError(t, err, "metrics table should exist and accept data")
 
 			// Verify data was inserted correctly
-			summariesRaw, err := spans.SearchTraces(ctx, s.DB(), 0, 1<<63-1, nil)
+			summariesRaw, err := spans.SearchTraces(ctx, s.db, 0, 1<<63-1, nil)
 			assert.NoError(t, err, "should be able to retrieve trace summaries")
 			var summaries []map[string]any
 			assert.NoError(t, json.Unmarshal(summariesRaw, &summaries))
 			assert.Len(t, summaries, 2, "should have two traces")
 
-			logsRaw, err := logs.Search(ctx, s.DB(), 0, 1<<63-1, nil)
+			logsRaw, err := logs.Search(ctx, s.db, 0, 1<<63-1, nil)
 			assert.NoError(t, err, "should be able to retrieve logs")
 			var logEntries []any
 			assert.NoError(t, json.Unmarshal(logsRaw, &logEntries))
 			assert.Len(t, logEntries, 3, "should have three logs")
 
-			metricsRaw, err := metrics.SearchSummaries(ctx, s.DB(), 0, 1<<63-1, nil)
+			metricsRaw, err := metrics.SearchSummaries(ctx, s.db, 0, 1<<63-1, nil)
 			assert.NoError(t, err, "should be able to retrieve metrics")
 			var metricEntries []any
 			assert.NoError(t, json.Unmarshal(metricsRaw, &metricEntries))
@@ -174,15 +174,15 @@ func runStoreTests(t *testing.T, tests []storeTest) {
 			assert.NotNil(t, s.conn, "duckdb connection should be reestablished")
 
 			// Verify data after reopening
-			summariesRaw, err = spans.SearchTraces(ctx, s.DB(), 0, 1<<63-1, nil)
+			summariesRaw, err = spans.SearchTraces(ctx, s.db, 0, 1<<63-1, nil)
 			assert.NoError(t, err, "should be able to retrieve trace summaries after reopening")
 			assert.NoError(t, json.Unmarshal(summariesRaw, &summaries))
 
-			logsRaw, err = logs.Search(ctx, s.DB(), 0, 1<<63-1, nil)
+			logsRaw, err = logs.Search(ctx, s.db, 0, 1<<63-1, nil)
 			assert.NoError(t, err, "should be able to retrieve logs after reopening")
 			assert.NoError(t, json.Unmarshal(logsRaw, &logEntries))
 
-			metricsRaw, err = metrics.SearchSummaries(ctx, s.DB(), 0, 1<<63-1, nil)
+			metricsRaw, err = metrics.SearchSummaries(ctx, s.db, 0, 1<<63-1, nil)
 			assert.NoError(t, err, "should be able to retrieve metrics after reopening")
 			assert.NoError(t, json.Unmarshal(metricsRaw, &metricEntries))
 
@@ -218,7 +218,7 @@ func TestStoreIndexesCreated(t *testing.T) {
 	defer s.Close()
 
 	var count int
-	err = s.DB().QueryRowContext(ctx, "SELECT count(*) FROM duckdb_indexes() WHERE schema_name = 'main'").Scan(&count)
+	err = s.db.QueryRowContext(ctx, "SELECT count(*) FROM duckdb_indexes() WHERE schema_name = 'main'").Scan(&count)
 	require.NoError(t, err)
 	assert.Equal(t, len(schema.IndexCreationQueries), count, "index count should match IndexCreationQueries")
 }
@@ -236,7 +236,7 @@ func TestStoreConstraintsEnforced(t *testing.T) {
 	// FK chain is now stream -> ingest -> datapoint; we have to seed
 	// both parent rows before the chk_metric_type_valid violation will
 	// fire on the datapoint insert.
-	_, err = s.DB().ExecContext(ctx, `
+	_, err = s.db.ExecContext(ctx, `
 		insert into metric_streams
 			(id, name, unit, metric_type, aggregation_temporality,
 			 is_monotonic, scope_name, scope_version, service_name)
@@ -245,10 +245,10 @@ func TestStoreConstraintsEnforced(t *testing.T) {
 	require.NoError(t, err, "inserting a metric_streams row should succeed")
 
 	var streamID string
-	require.NoError(t, s.DB().QueryRowContext(ctx,
+	require.NoError(t, s.db.QueryRowContext(ctx,
 		"select id::varchar from metric_streams where name = 'test'").Scan(&streamID))
 
-	_, err = s.DB().ExecContext(ctx, `
+	_, err = s.db.ExecContext(ctx, `
 		insert into metric_ingests
 			(id, stream_id, description,
 			 resource_dropped_attributes_count, scope_dropped_attributes_count)
@@ -257,10 +257,10 @@ func TestStoreConstraintsEnforced(t *testing.T) {
 	require.NoError(t, err, "inserting a metric_ingests row should succeed")
 
 	var ingestID string
-	require.NoError(t, s.DB().QueryRowContext(ctx,
+	require.NoError(t, s.db.QueryRowContext(ctx,
 		"select id::varchar from metric_ingests where stream_id = ?::uuid", streamID).Scan(&ingestID))
 
-	_, err = s.DB().ExecContext(ctx, `
+	_, err = s.db.ExecContext(ctx, `
 		insert into datapoints
 			(id, stream_id, metric_ingest_id, metric_type, timestamp, start_time, flags)
 		values (gen_random_uuid(), ?::uuid, ?::uuid, 'InvalidType', 0, 0, 0)
@@ -286,7 +286,7 @@ func TestStorePersistentReopenIdempotent(t *testing.T) {
 	require.NoError(t, err)
 
 	var indexCount int
-	err = s2.DB().QueryRowContext(ctx, "SELECT count(*) FROM duckdb_indexes() WHERE schema_name = 'main'").Scan(&indexCount)
+	err = s2.db.QueryRowContext(ctx, "SELECT count(*) FROM duckdb_indexes() WHERE schema_name = 'main'").Scan(&indexCount)
 	require.NoError(t, err)
 	assert.Equal(t, len(schema.IndexCreationQueries), indexCount)
 	require.NoError(t, s2.Close())
@@ -353,5 +353,5 @@ func TestStoreLifecycleErrors(t *testing.T) {
 	assert.Error(t, err, "should get error when reading from closed store")
 	assert.True(t, errors.Is(err, ErrStoreConnectionClosed), "error should be ErrStoreConnectionClosed")
 
-	assert.Nil(t, s.DB(), "DB() should be nil after close")
+	assert.Nil(t, s.db, "db should be nil after close")
 }

--- a/desktopexporter/internal/store/store_test.go
+++ b/desktopexporter/internal/store/store_test.go
@@ -21,6 +21,14 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
+func setupStore(t *testing.T) (*Store, context.Context, func()) {
+	t.Helper()
+	ctx := context.Background()
+	s, err := NewStore(ctx, "")
+	require.NoError(t, err)
+	return s, ctx, func() { s.Close() }
+}
+
 type storeTest struct {
 	name    string
 	dbPath  string


### PR DESCRIPTION
- Switch `store.Store` from a single `Mutex` on ingest-only `WithConn` to a scoped `RWMutex` with `WithDBRead`, `WithDBWrite`, and shared write locking across both DuckDB handles (`conn` for appenders, `db` pool for queries/mutations).
- Cap the connection pool at 4; route all JSON-RPC reads/writes through locked accessors; restructure retention to take the write lock per prune round.
- Remove `Store.DB()` entirely so the unguarded path is unrepresentable, and add a CI job that keeps it that way.
- Add `-race` concurrency stress tests and rewrite the `ARCHITECTURE.md` connection model to match the code.

Fixes the races where pool mutations (clear, delete, retention checkpoint) and bare `DB()` reads could overlap appender ingest or `Close()` setting `s.db = nil`.

## Removing `Store.DB()`

The locking change alone left `DB()` in place as a documented "test-only" accessor. A doc comment is a suggestion, so the accessor is gone and all 199 call sites are converted:

| Category | Count | Treatment |
|---|---|---|
| In-package tests (`package store`) | 27 | Use the unexported `s.db` directly |
| `countRows` / `deleteByIdentity` helpers | 81 | Helpers now take `*store.Store` and wrap internally |
| Reads and mutations in external test packages | 97 | Per-package `readStore[T]` generic, and `s.WithDBWrite` |
| Raw SQL | 4 | Hand-wrapped, scan inside the lock window |

Helpers stay duplicated per test package, matching how this repo already duplicates `setupStore` and `countRows`, rather than introducing a `storetest` package.

`deleteByIdentity` gets slightly more correct as a side effect: it resolved an identity tuple to a stream UUID and then deleted it in two separate trips, and now does both in one `WithDBWrite` window, so a concurrent retention pass can't prune the stream in between.

## Go format tooling

The frontend has Prettier wired through `npm run format:check`, a `format-ts` Make target, and a CI gate. Go had none of the three, which is why `desktopexporter/exporter.go` sat unformatted on `main` with nothing to catch it.

- `make format-go` / `make format-go-check` mirror `format-ts`.
- New `go-checks` CI job (Ubuntu-only — no CGO needed, and the build matrix runs Windows under PowerShell) runs the gofmt check and the store-access guard.
- `exporter.go` formatted: one import reordered. Pre-existing on `main`, unrelated to the locking change.

## Test plan

- [x] `make format-go-check`
- [x] `go build ./... && go vet ./...`
- [x] `go test -race ./desktopexporter/...`
- [x] `go test -race -count=5 -run 'TestConcurrent' ./desktopexporter/internal/store/`
- [x] No `.DB()` call sites remain anywhere, production or test
- [x] Both CI guards verified against planted violations (a misformatted file and a production `.DB()` call), confirming they fail rather than silently passing
- [x] CI `Build and Test` (PR workflow)

## Follow-up, not in this PR

`metrics.DeleteMetricStream` has no JSON-RPC caller — the handler exposes `clearMetrics` but no per-stream delete, so that function is currently reachable only from tests. The UI component was removed at some point; restoring it is a separate PR.
