### PR TITLE
Schema version stamping, checked before anything is built on the old shape

### DIFF
--- a/desktopexporter/duckdbextension/extension.go
+++ b/desktopexporter/duckdbextension/extension.go
@@ -74,7 +74,7 @@ func (e *DuckDBExtension) Store() *store.Store {
 }
 
 func (e *DuckDBExtension) Start(ctx context.Context, _ component.Host) error {
-	str, err := store.NewStore(ctx, e.cfg.Db)
+	str, err := store.NewStore(ctx, e.cfg.Db, e.logger)
 	if err != nil {
 		return err
 	}

--- a/desktopexporter/internal/server/jsonrpc_handler_test.go
+++ b/desktopexporter/internal/server/jsonrpc_handler_test.go
@@ -25,7 +25,7 @@ import (
 
 func setupHandler(t *testing.T) (*JSONRPCHandler, func()) {
 	t.Helper()
-	s, err := store.NewStore(context.Background(), "")
+	s, err := store.NewStore(context.Background(), "", zap.NewNop())
 	require.NoError(t, err)
 	handler := NewJSONRPCHandler(s, zap.NewNop())
 	return handler, func() {
@@ -65,7 +65,7 @@ func buildTestLogs() plog.Logs {
 
 func setupHandlerWithData(t *testing.T) (*JSONRPCHandler, func()) {
 	t.Helper()
-	s, err := store.NewStore(context.Background(), "")
+	s, err := store.NewStore(context.Background(), "", zap.NewNop())
 	require.NoError(t, err)
 	handler := NewJSONRPCHandler(s, zap.NewNop())
 	ctx := context.Background()
@@ -812,7 +812,7 @@ func buildTestMetrics() pmetric.Metrics {
 
 func setupHandlerWithMetrics(t *testing.T) (*JSONRPCHandler, func()) {
 	t.Helper()
-	s, err := store.NewStore(context.Background(), "")
+	s, err := store.NewStore(context.Background(), "", zap.NewNop())
 	require.NoError(t, err)
 	handler := NewJSONRPCHandler(s, zap.NewNop())
 	ctx := context.Background()

--- a/desktopexporter/internal/server/server_test.go
+++ b/desktopexporter/internal/server/server_test.go
@@ -21,7 +21,7 @@ import (
 
 func setupServer(t *testing.T) (*httptest.Server, func()) {
 	t.Helper()
-	str, err := store.NewStore(context.Background(), "")
+	str, err := store.NewStore(context.Background(), "", zap.NewNop())
 	require.NoError(t, err)
 	s, err := NewServer("localhost:8000", str, zap.NewNop(), telemetry.Disabled())
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestStartBindConflict(t *testing.T) {
 	addr := ln.Addr().String()
 	defer ln.Close()
 
-	str, err := store.NewStore(context.Background(), "")
+	str, err := store.NewStore(context.Background(), "", zap.NewNop())
 	require.NoError(t, err)
 	defer str.Close()
 

--- a/desktopexporter/internal/store/ingest/appender_test.go
+++ b/desktopexporter/internal/store/ingest/appender_test.go
@@ -1,6 +1,7 @@
 package ingest_test
 
 import (
+	"go.uber.org/zap"
 	"context"
 	"database/sql"
 	"database/sql/driver"
@@ -32,7 +33,7 @@ func readStore[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error)
 func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
 	t.Helper()
 	ctx := context.Background()
-	s, err := store.NewStore(ctx, "")
+	s, err := store.NewStore(ctx, "", zap.NewNop())
 	require.NoError(t, err)
 	return s, ctx, func() { s.Close() }
 }

--- a/desktopexporter/internal/store/ingest/appender_test.go
+++ b/desktopexporter/internal/store/ingest/appender_test.go
@@ -1,7 +1,6 @@
 package ingest_test
 
 import (
-	"go.uber.org/zap"
 	"context"
 	"database/sql"
 	"database/sql/driver"
@@ -15,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
 )
 
 // readStore runs a query under the store's read lock and returns its result.

--- a/desktopexporter/internal/store/logs/logs_test.go
+++ b/desktopexporter/internal/store/logs/logs_test.go
@@ -1,6 +1,7 @@
 package logs_test
 
 import (
+	"go.uber.org/zap"
 	"context"
 	"database/sql"
 	"encoding/hex"
@@ -37,7 +38,7 @@ func readStore[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error)
 func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
 	t.Helper()
 	ctx := context.Background()
-	s, err := store.NewStore(ctx, "")
+	s, err := store.NewStore(ctx, "", zap.NewNop())
 	require.NoError(t, err)
 	return s, ctx, func() { s.Close() }
 }

--- a/desktopexporter/internal/store/logs/logs_test.go
+++ b/desktopexporter/internal/store/logs/logs_test.go
@@ -1,7 +1,6 @@
 package logs_test
 
 import (
-	"go.uber.org/zap"
 	"context"
 	"database/sql"
 	"encoding/hex"
@@ -20,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
 )
 
 // readStore runs a query under the store's read lock and returns its result.

--- a/desktopexporter/internal/store/metrics/metrics_test.go
+++ b/desktopexporter/internal/store/metrics/metrics_test.go
@@ -1,6 +1,7 @@
 package metrics_test
 
 import (
+	"go.uber.org/zap"
 	"context"
 	"database/sql"
 	"database/sql/driver"
@@ -49,7 +50,7 @@ func readStore[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error)
 func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
 	t.Helper()
 	ctx := context.Background()
-	s, err := store.NewStore(ctx, "")
+	s, err := store.NewStore(ctx, "", zap.NewNop())
 	require.NoError(t, err)
 	return s, ctx, func() { s.Close() }
 }

--- a/desktopexporter/internal/store/metrics/metrics_test.go
+++ b/desktopexporter/internal/store/metrics/metrics_test.go
@@ -1,7 +1,6 @@
 package metrics_test
 
 import (
-	"go.uber.org/zap"
 	"context"
 	"database/sql"
 	"database/sql/driver"
@@ -18,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
 )
 
 const maxNano = 1<<63 - 1

--- a/desktopexporter/internal/store/retention_test.go
+++ b/desktopexporter/internal/store/retention_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"go.uber.org/zap"
 	"path/filepath"
 	"testing"
 
@@ -62,7 +63,7 @@ func count(t *testing.T, s *Store, table string) int64 {
 
 func TestSizeBytesInMemory(t *testing.T) {
 	ctx := context.Background()
-	s, err := NewStore(ctx, "")
+	s, err := NewStore(ctx, "", zap.NewNop())
 	require.NoError(t, err)
 	defer s.Close()
 
@@ -78,7 +79,7 @@ func TestSizeBytesInMemory(t *testing.T) {
 
 func TestSizeBytesOnDisk(t *testing.T) {
 	ctx := context.Background()
-	s, err := NewStore(ctx, filepath.Join(t.TempDir(), "retention_test.db"))
+	s, err := NewStore(ctx, filepath.Join(t.TempDir(), "retention_test.db"), zap.NewNop())
 	require.NoError(t, err)
 	defer s.Close()
 
@@ -93,7 +94,7 @@ func TestSizeBytesOnDisk(t *testing.T) {
 
 func TestEnforceRetentionPrunesOldest(t *testing.T) {
 	ctx := context.Background()
-	s, err := NewStore(ctx, "")
+	s, err := NewStore(ctx, "", zap.NewNop())
 	require.NoError(t, err)
 	defer s.Close()
 
@@ -128,7 +129,7 @@ func TestEnforceRetentionPrunesOldest(t *testing.T) {
 
 func TestEnforceRetentionSweepsOrphanedMetricIdentity(t *testing.T) {
 	ctx := context.Background()
-	s, err := NewStore(ctx, "")
+	s, err := NewStore(ctx, "", zap.NewNop())
 	require.NoError(t, err)
 	defer s.Close()
 
@@ -156,7 +157,7 @@ func TestEnforceRetentionSweepsOrphanedMetricIdentity(t *testing.T) {
 
 func TestEnforceRetentionDisabled(t *testing.T) {
 	ctx := context.Background()
-	s, err := NewStore(ctx, "")
+	s, err := NewStore(ctx, "", zap.NewNop())
 	require.NoError(t, err)
 	defer s.Close()
 
@@ -168,7 +169,7 @@ func TestEnforceRetentionDisabled(t *testing.T) {
 
 func TestEnforceRetentionUnderCap(t *testing.T) {
 	ctx := context.Background()
-	s, err := NewStore(ctx, "")
+	s, err := NewStore(ctx, "", zap.NewNop())
 	require.NoError(t, err)
 	defer s.Close()
 

--- a/desktopexporter/internal/store/schema/version.go
+++ b/desktopexporter/internal/store/schema/version.go
@@ -1,0 +1,53 @@
+package schema
+
+// Version is the schema this build writes and expects.
+//
+// Bump it whenever a change makes an existing database file unreadable by this
+// build -- a dropped or renamed column, a changed constraint, a different
+// meaning for existing data. Additive changes that `create table if not exists`
+// and `create index if not exists` apply cleanly to an older file do not need a
+// bump.
+//
+// There is no migration machinery. This exists so an incompatible file is
+// reported clearly instead of failing later with something opaque: without it,
+// `create table if not exists` silently leaves an old table in place and the
+// mismatch first surfaces as a duckdb appender column-count error during ingest,
+// or as an index creation failure against a column that does not exist.
+//
+// Version 1 is the schema as of the attributes-dictionary rewrite. Files written
+// before versioning existed carry no stamp at all and are detected separately.
+const Version = 1
+
+// VersionTableQuery creates the version table.
+//
+// Deliberately not part of TableCreationQueries: the version check has to run
+// *before* those, so that opening an incompatible file reports a version
+// mismatch rather than failing partway through creating tables and indexes
+// against a schema that does not match them.
+const VersionTableQuery = `create table if not exists schema_meta (version integer)`
+
+// ReadVersionQuery returns the stamped version, or NULL for a file that has
+// none -- either brand new, or written before versioning existed. The caller
+// distinguishes those two cases.
+const ReadVersionQuery = `select max(version) from schema_meta`
+
+// StampVersionQuery records the current version. Only ever run against a
+// database with no stamp and no data, so there is nothing to overwrite.
+const StampVersionQuery = `insert into schema_meta (version) values (?)`
+
+// A stamp-less file is either brand new or predates versioning. Telling those
+// apart is a two-step probe: does the spans table exist, and if so does it hold
+// anything.
+//
+// It has to be two queries rather than one guarded by EXISTS, because DuckDB
+// binds the whole statement before executing it -- a subquery naming `spans`
+// fails to bind on a database where that table does not exist yet, which is
+// every brand-new file.
+//
+// The probe asks duckdb_tables() rather than checking for a specific column, so
+// it keeps working across future schema changes: the question is "does this file
+// predate versioning", not "does it match some particular past shape".
+const (
+	SpansTableExistsQuery = `select count(*) from duckdb_tables() where table_name = 'spans'`
+	SpanCountQuery        = `select count(*) from spans`
+)

--- a/desktopexporter/internal/store/spans/ingest_bench_test.go
+++ b/desktopexporter/internal/store/spans/ingest_bench_test.go
@@ -1,7 +1,6 @@
 package spans_test
 
 import (
-	"go.uber.org/zap"
 	"context"
 	"database/sql/driver"
 	"fmt"
@@ -12,6 +11,7 @@ import (
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/spans"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
 )
 
 // benchTraces builds a batch shaped like the reference capture: 17 attribute

--- a/desktopexporter/internal/store/spans/ingest_bench_test.go
+++ b/desktopexporter/internal/store/spans/ingest_bench_test.go
@@ -1,6 +1,7 @@
 package spans_test
 
 import (
+	"go.uber.org/zap"
 	"context"
 	"database/sql/driver"
 	"fmt"
@@ -77,7 +78,7 @@ func BenchmarkIngestBatch(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				s, err := store.NewStore(ctx, "")
+				s, err := store.NewStore(ctx, "", zap.NewNop())
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/desktopexporter/internal/store/spans/spans_test.go
+++ b/desktopexporter/internal/store/spans/spans_test.go
@@ -1,6 +1,7 @@
 package spans_test
 
 import (
+	"go.uber.org/zap"
 	"context"
 	"database/sql"
 	"encoding/hex"
@@ -36,7 +37,7 @@ func readStore[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error)
 func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
 	t.Helper()
 	ctx := context.Background()
-	s, err := store.NewStore(ctx, "")
+	s, err := store.NewStore(ctx, "", zap.NewNop())
 	require.NoError(t, err)
 	return s, ctx, func() { s.Close() }
 }

--- a/desktopexporter/internal/store/spans/spans_test.go
+++ b/desktopexporter/internal/store/spans/spans_test.go
@@ -1,7 +1,6 @@
 package spans_test
 
 import (
-	"go.uber.org/zap"
 	"context"
 	"database/sql"
 	"encoding/hex"
@@ -19,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
 )
 
 // readStore runs a query under the store's read lock and returns its result.

--- a/desktopexporter/internal/store/stats/stats_test.go
+++ b/desktopexporter/internal/store/stats/stats_test.go
@@ -1,7 +1,6 @@
 package stats_test
 
 import (
-	"go.uber.org/zap"
 	"context"
 	"encoding/hex"
 	"encoding/json"
@@ -22,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
 )
 
 // readStore runs a query under the store's read lock and returns its result.

--- a/desktopexporter/internal/store/stats/stats_test.go
+++ b/desktopexporter/internal/store/stats/stats_test.go
@@ -1,6 +1,7 @@
 package stats_test
 
 import (
+	"go.uber.org/zap"
 	"context"
 	"encoding/hex"
 	"encoding/json"
@@ -39,7 +40,7 @@ func readStore[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error)
 func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
 	t.Helper()
 	ctx := context.Background()
-	s, err := store.NewStore(ctx, "")
+	s, err := store.NewStore(ctx, "", zap.NewNop())
 	require.NoError(t, err)
 	return s, ctx, func() { s.Close() }
 }

--- a/desktopexporter/internal/store/store.go
+++ b/desktopexporter/internal/store/store.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/schema"
 	"github.com/duckdb/duckdb-go/v2"
+	"go.uber.org/zap"
 )
 
 // maxPoolConns caps the *sql.DB pool. Reads run concurrently under the store's
@@ -45,6 +46,16 @@ type Store struct {
 	// and reported by getStats. 0 means retention is disabled. Set once via
 	// SetRetentionCap before the store is shared; read without locking.
 	retentionCapBytes int64
+
+	// logger is never nil: NewStore substitutes a no-op when given one, so
+	// call sites need no guard.
+	logger *zap.Logger
+
+	// Result of the schema version check, set once during NewStore and read
+	// without locking. The warning is logged at open; this is kept so callers
+	// (and the enforcement switch, when it lands) can act on the outcome
+	// rather than parse a message.
+	schemaCompat SchemaCompatibility
 }
 
 // SetRetentionCap sets the store size cap in bytes. Call before the store is
@@ -60,7 +71,13 @@ func (s *Store) RetentionCap() int64 {
 
 // NewStore creates a new store for the given database path.
 // An empty dbPath will create a temporary in-memory database.
-func NewStore(ctx context.Context, dbPath string) (*Store, error) {
+//
+// logger may be nil, in which case nothing is logged.
+func NewStore(ctx context.Context, dbPath string, logger *zap.Logger) (*Store, error) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
 	if dbPath != "" {
 		dbPath = filepath.Clean(dbPath)
 	}
@@ -92,21 +109,34 @@ func NewStore(ctx context.Context, dbPath string) (*Store, error) {
 		}
 	}
 
-	// 2) Create the tables for our signals
+	// 2) Check the schema version before creating anything else.
+	//
+	// The ordering is load-bearing, not stylistic. Run after the table and
+	// index loops and an incompatible file fails inside them first --
+	// `create table if not exists` leaves the old table alone, then index
+	// creation dies against a column that does not exist, and the user gets
+	// "failed to create index 4" instead of "this database was written by a
+	// different version".
+	schemaCompat, err := checkSchemaVersion(db, dbPath, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	// 3) Create the tables for our signals
 	for i, query := range schema.TableCreationQueries {
 		if _, err = db.Exec(query); err != nil {
 			return nil, fmt.Errorf("%w while creating table %d: %w", ErrStoreInitFailed, i, err)
 		}
 	}
 
-	// 3) Create indexes - queries use IF NOT EXISTS so reopening is safe
+	// 4) Create indexes - queries use IF NOT EXISTS so reopening is safe
 	for i, query := range schema.IndexCreationQueries {
 		if _, err = db.Exec(query); err != nil {
 			return nil, fmt.Errorf("%w while creating index %d: %w", ErrStoreInitFailed, i, err)
 		}
 	}
 
-	// 4) Create macros - queries use CREATE OR REPLACE so reopening is safe
+	// 5) Create macros - queries use CREATE OR REPLACE so reopening is safe
 	for i, query := range schema.MacroCreationQueries {
 		if _, err = db.Exec(query); err != nil {
 			return nil, fmt.Errorf("%w while creating macro %d: %w", ErrStoreInitFailed, i, err)
@@ -114,9 +144,11 @@ func NewStore(ctx context.Context, dbPath string) (*Store, error) {
 	}
 
 	return &Store{
-		db:     db,
-		conn:   conn,
-		dbPath: dbPath,
+		db:           db,
+		conn:         conn,
+		dbPath:       dbPath,
+		logger:       logger,
+		schemaCompat: schemaCompat,
 	}, nil
 }
 

--- a/desktopexporter/internal/store/store_test.go
+++ b/desktopexporter/internal/store/store_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
+	"go.uber.org/zap"
 	"os"
 	"testing"
 	"time"
@@ -24,7 +25,7 @@ import (
 func setupStore(t *testing.T) (*Store, context.Context, func()) {
 	t.Helper()
 	ctx := context.Background()
-	s, err := NewStore(ctx, "")
+	s, err := NewStore(ctx, "", zap.NewNop())
 	require.NoError(t, err)
 	return s, ctx, func() { s.Close() }
 }
@@ -113,7 +114,7 @@ func runStoreTests(t *testing.T, tests []storeTest) {
 			ctx := context.Background()
 
 			// Test store initialization
-			s, err := NewStore(ctx, tt.dbPath)
+			s, err := NewStore(ctx, tt.dbPath, zap.NewNop())
 			require.NoError(t, err, "store should initialize without error")
 			assert.NotNil(t, s.db, "database connection should not be nil")
 			assert.NotNil(t, s.conn, "duckdb connection should not be nil")
@@ -168,7 +169,7 @@ func runStoreTests(t *testing.T, tests []storeTest) {
 			assert.NoError(t, err, "store should close without error")
 
 			// Test store reopening
-			s, err = NewStore(ctx, tt.dbPath)
+			s, err = NewStore(ctx, tt.dbPath, zap.NewNop())
 			require.NoError(t, err, "store should reopen without error")
 			assert.NotNil(t, s.db, "database connection should be reestablished")
 			assert.NotNil(t, s.conn, "duckdb connection should be reestablished")
@@ -213,7 +214,7 @@ func runStoreTests(t *testing.T, tests []storeTest) {
 // TestStoreIndexesCreated verifies that all IndexCreationQueries are applied on store init.
 func TestStoreIndexesCreated(t *testing.T) {
 	ctx := context.Background()
-	s, err := NewStore(ctx, "")
+	s, err := NewStore(ctx, "", zap.NewNop())
 	require.NoError(t, err)
 	defer s.Close()
 
@@ -228,7 +229,7 @@ func TestStoreIndexesCreated(t *testing.T) {
 // chk_metric_type_valid is rejected.
 func TestStoreConstraintsEnforced(t *testing.T) {
 	ctx := context.Background()
-	s, err := NewStore(ctx, "")
+	s, err := NewStore(ctx, "", zap.NewNop())
 	require.NoError(t, err)
 	defer s.Close()
 
@@ -276,13 +277,13 @@ func TestStorePersistentReopenIdempotent(t *testing.T) {
 
 	ctx := context.Background()
 
-	s, err := NewStore(ctx, dbPath)
+	s, err := NewStore(ctx, dbPath, zap.NewNop())
 	require.NoError(t, err)
 	require.NoError(t, s.Close())
 
 	// Reopening must not panic or fatal - constraints use "already exists" guard,
 	// indexes use IF NOT EXISTS.
-	s2, err := NewStore(ctx, dbPath)
+	s2, err := NewStore(ctx, dbPath, zap.NewNop())
 	require.NoError(t, err)
 
 	var indexCount int
@@ -296,7 +297,7 @@ func TestStorePersistentReopenIdempotent(t *testing.T) {
 // constraint accepts a valid ExponentialHistogram datapoint.
 func TestStoreExponentialHistogramConstraint(t *testing.T) {
 	ctx := context.Background()
-	s, err := NewStore(ctx, "")
+	s, err := NewStore(ctx, "", zap.NewNop())
 	require.NoError(t, err)
 	defer s.Close()
 
@@ -328,7 +329,7 @@ func TestStoreExponentialHistogramConstraint(t *testing.T) {
 
 func TestStoreLifecycleErrors(t *testing.T) {
 	ctx := context.Background()
-	s, err := NewStore(ctx, "")
+	s, err := NewStore(ctx, "", zap.NewNop())
 	require.NoError(t, err)
 
 	// Test using store after close

--- a/desktopexporter/internal/store/version.go
+++ b/desktopexporter/internal/store/version.go
@@ -1,0 +1,114 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/schema"
+	"go.uber.org/zap"
+)
+
+// SchemaCompatibility describes what the version check found when the store was
+// opened.
+type SchemaCompatibility int
+
+const (
+	// SchemaOK means the file carries the version this build writes, or was
+	// brand new and has just been stamped with it.
+	SchemaOK SchemaCompatibility = iota
+
+	// SchemaPreVersioning means the file holds data but carries no version
+	// stamp: it was written before versioning existed, so its shape is unknown.
+	SchemaPreVersioning
+
+	// SchemaMismatch means the file is stamped with a different version.
+	SchemaMismatch
+)
+
+// SchemaCompatibility reports what the version check found. SchemaOK for an
+// in-memory store, which is always created fresh.
+func (s *Store) SchemaCompatibility() SchemaCompatibility {
+	return s.schemaCompat
+}
+
+// checkSchemaVersion inspects the version stamp and decides whether this build
+// can be expected to read the file.
+//
+// Four outcomes:
+//
+//	stamp absent, no data   -> brand new; stamp it and proceed
+//	stamp absent, has data  -> written before versioning; warn
+//	stamp present, matches  -> proceed
+//	stamp present, differs  -> warn
+//
+// A stamp-less file with data is treated as suspect rather than stamped,
+// because stamping it would assert a compatibility nobody has checked and
+// destroy the only evidence that it predates versioning.
+func checkSchemaVersion(db *sql.DB, dbPath string, logger *zap.Logger) (SchemaCompatibility, error) {
+	if _, err := db.Exec(schema.VersionTableQuery); err != nil {
+		return SchemaOK, fmt.Errorf("%w while creating schema_meta: %w", ErrStoreInitFailed, err)
+	}
+
+	// NULL when the table is empty, so scan through a nullable.
+	var stamped sql.NullInt64
+	if err := db.QueryRow(schema.ReadVersionQuery).Scan(&stamped); err != nil {
+		return SchemaOK, fmt.Errorf("%w while reading schema version: %w", ErrStoreInitFailed, err)
+	}
+
+	if stamped.Valid {
+		if stamped.Int64 == schema.Version {
+			return SchemaOK, nil
+		}
+		logger.Warn("database was written by a different schema version; "+
+			"the viewer may fail to read or write it",
+			zap.String("database", describePath(dbPath)),
+			zap.Int64("file_version", stamped.Int64),
+			zap.Int("expected_version", schema.Version),
+			zap.String("remedy", "delete it or pass a different --db path"))
+		return SchemaMismatch, nil
+	}
+
+	hasData, err := hasExistingData(db)
+	if err != nil {
+		return SchemaOK, err
+	}
+	if hasData {
+		logger.Warn("database holds data but carries no schema version, so it predates "+
+			"versioning and its shape cannot be confirmed",
+			zap.String("database", describePath(dbPath)),
+			zap.Int("expected_version", schema.Version),
+			zap.String("remedy", "delete it or pass a different --db path"))
+		return SchemaPreVersioning, nil
+	}
+
+	if _, err := db.Exec(schema.StampVersionQuery, schema.Version); err != nil {
+		return SchemaOK, fmt.Errorf("%w while stamping schema version: %w", ErrStoreInitFailed, err)
+	}
+	return SchemaOK, nil
+}
+
+// hasExistingData reports whether the file already holds telemetry. Two queries
+// rather than one: DuckDB binds a whole statement before running it, so a
+// subquery naming `spans` fails to bind on a database that has never had it.
+func hasExistingData(db *sql.DB) (bool, error) {
+	var tables int
+	if err := db.QueryRow(schema.SpansTableExistsQuery).Scan(&tables); err != nil {
+		return false, fmt.Errorf("%w while probing for existing tables: %w", ErrStoreInitFailed, err)
+	}
+	if tables == 0 {
+		return false, nil
+	}
+
+	var spans int64
+	if err := db.QueryRow(schema.SpanCountQuery).Scan(&spans); err != nil {
+		return false, fmt.Errorf("%w while probing for existing data: %w", ErrStoreInitFailed, err)
+	}
+	return spans > 0, nil
+}
+
+func describePath(dbPath string) string {
+	if dbPath == "" {
+		return "(in-memory)"
+	}
+	return dbPath
+}

--- a/desktopexporter/internal/store/version_test.go
+++ b/desktopexporter/internal/store/version_test.go
@@ -1,0 +1,177 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func newFileStore(t *testing.T, path string) *Store {
+	t.Helper()
+	s, _ := openWithLogs(t, path)
+	return s
+}
+
+// openWithLogs opens a store and captures whatever it logged while doing so, so
+// tests can assert on the message a user would actually see rather than on an
+// accessor that exists only for tests.
+func openWithLogs(t *testing.T, path string) (*Store, *observer.ObservedLogs) {
+	t.Helper()
+	core, logs := observer.New(zap.WarnLevel)
+	s, err := NewStore(context.Background(), path, zap.New(core))
+	require.NoError(t, err)
+	return s, logs
+}
+
+// A brand-new database gets stamped, so the next open recognises it rather than
+// treating it as pre-versioning.
+func TestNewDatabaseIsStampedAndClean(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fresh.db")
+
+	s, logs := openWithLogs(t, path)
+	assert.Equal(t, SchemaOK, s.SchemaCompatibility())
+	assert.Zero(t, logs.Len(), "a fresh database should warn about nothing")
+	require.NoError(t, s.Close())
+
+	reopened, reopenLogs := openWithLogs(t, path)
+	defer reopened.Close()
+	assert.Equal(t, SchemaOK, reopened.SchemaCompatibility())
+	assert.Zero(t, reopenLogs.Len(), "reopening our own database should warn about nothing")
+}
+
+// In-memory stores are created fresh every time, so they are always clean.
+func TestInMemoryStoreIsClean(t *testing.T) {
+	s, logs := openWithLogs(t, "")
+	defer s.Close()
+	assert.Equal(t, SchemaOK, s.SchemaCompatibility())
+	assert.Zero(t, logs.Len())
+}
+
+// A file stamped with a different version must be reported, not silently used.
+// This is the case that becomes a hard failure once enforcement is switched on.
+func TestVersionMismatchIsReported(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "future.db")
+
+	s := newFileStore(t, path)
+	require.NoError(t, s.Close())
+
+	// Rewrite the stamp to a version this build does not know.
+	db, err := sql.Open("duckdb", path)
+	require.NoError(t, err)
+	_, err = db.Exec(`delete from schema_meta`)
+	require.NoError(t, err)
+	_, err = db.Exec(`insert into schema_meta (version) values (?)`, schema.Version+1)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	reopened, logs := openWithLogs(t, path)
+	defer reopened.Close()
+
+	assert.Equal(t, SchemaMismatch, reopened.SchemaCompatibility())
+	require.Equal(t, 1, logs.Len(), "a mismatch must be reported to the user")
+
+	entry := logs.All()[0]
+	fields := entry.ContextMap()
+	assert.Contains(t, fields["database"], "future.db", "name the file")
+	assert.Equal(t, int64(schema.Version+1), fields["file_version"])
+	assert.Contains(t, fields["remedy"], "--db", "say what to do about it")
+}
+
+// A file holding data but carrying no stamp predates versioning. It must not be
+// stamped on sight: doing so would assert a compatibility nobody checked and
+// destroy the only evidence of where the file came from.
+func TestPreVersioningDatabaseIsNotStamped(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.db")
+
+	// Build a database the way a pre-versioning build would leave it: real
+	// tables with a row in spans, and no schema_meta at all.
+	s := newFileStore(t, path)
+	err := s.WithDBWrite(func(db *sql.DB) error {
+		_, err := db.Exec(`insert into spans (trace_id, span_id) values (?::uuid, ?::uuid)`,
+			"11111111-1111-1111-1111-111111111111",
+			"22222222-2222-2222-2222-222222222222")
+		return err
+	})
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+
+	db, err := sql.Open("duckdb", path)
+	require.NoError(t, err)
+	_, err = db.Exec(`drop table schema_meta`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	reopened, logs := openWithLogs(t, path)
+	defer reopened.Close()
+
+	assert.Equal(t, SchemaPreVersioning, reopened.SchemaCompatibility())
+	require.Equal(t, 1, logs.Len())
+	assert.Contains(t, logs.All()[0].ContextMap()["database"], "legacy.db")
+
+	// And it stays unstamped, so reopening reports the same thing rather than
+	// quietly deciding the file is fine the second time.
+	require.NoError(t, reopened.WithDBRead(func(db *sql.DB) error {
+		var stamped sql.NullInt64
+		if err := db.QueryRow(schema.ReadVersionQuery).Scan(&stamped); err != nil {
+			return err
+		}
+		assert.False(t, stamped.Valid, "a pre-versioning file must not be stamped on sight")
+		return nil
+	}))
+}
+
+// The version check has to run before the table and index loops.
+//
+// The scenario that makes this matter: a file whose `spans` table predates a
+// column that a current index needs. `create table if not exists` leaves the old
+// table alone, so index creation then fails against a column that is not there.
+// Check first and the user gets a version message; check afterwards and they get
+// "failed to create index N" with no hint about why.
+//
+// Mutation-checked: moving checkSchemaVersion below the table/index loops in
+// NewStore makes this test fail. An earlier version of this test asserted only
+// the returned compatibility, which survived that mutation and proved nothing.
+func TestVersionCheckRunsBeforeTableCreation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "order.db")
+
+	// A spans table shaped like an older schema: no service_name, which
+	// idx_spans_service needs.
+	db, err := sql.Open("duckdb", path)
+	require.NoError(t, err)
+	_, err = db.Exec(`create table spans (trace_id uuid, span_id uuid primary key)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`insert into spans values (?::uuid, ?::uuid)`,
+		"11111111-1111-1111-1111-111111111111",
+		"22222222-2222-2222-2222-222222222222")
+	require.NoError(t, err)
+	_, err = db.Exec(schema.VersionTableQuery)
+	require.NoError(t, err)
+	_, err = db.Exec(`insert into schema_meta (version) values (?)`, schema.Version+99)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	core, logs := observer.New(zap.WarnLevel)
+	_, err = NewStore(context.Background(), path, zap.New(core))
+
+	// The open still fails: warn-only means the check explains the failure
+	// rather than preventing it. Enforcement (returning this as an error) is
+	// the switch to flip once the schema settles.
+	require.Error(t, err, "an incompatible file cannot be opened by this build")
+
+	// The point of the ordering: the version warning is emitted *before* the
+	// failure, so the opaque index error has an explanation attached. With the
+	// check moved after the table/index loops, this open fails identically but
+	// logs nothing -- which is what the mutation check confirms.
+	require.Equal(t, 1, logs.Len(),
+		"the version warning must be logged before anything builds on the old schema")
+	entry := logs.All()[0].ContextMap()
+	assert.Contains(t, entry["database"], "order.db")
+	assert.Contains(t, entry["remedy"], "--db")
+}


### PR DESCRIPTION
First commit of the attributes/schema rewrite. Adds version stamping so an incompatible database file says so, instead of failing later with something opaque. No schema changes yet — this is the guardrail that goes in before the rewrite starts moving the schema.

- `schema.Version` (currently `1`) is the schema this build writes and expects.
- A `schema_meta` table records the version a file was written with.
- On open, four outcomes:

  | file state | action |
  |---|---|
  | no stamp, no data | brand new → stamp it, proceed |
  | no stamp, has data | predates versioning → warn |
  | stamped, matches | proceed |
  | stamped, differs | warn |

- A stamp-less file holding data is **reported, not stamped**. Stamping it would assert a compatibility nobody checked and destroy the only evidence of where the file came from.

- The check runs before the table and index loops. A file whose `spans` table predates a column a current index needs would otherwise fail inside index creation — `create table if not exists` leaves the old table alone, then `idx_spans_service` dies against a column that isn't there, and the user gets `failed to create index 4`. Checking first means the version warning arrives before that, as its explanation.

- Warn-only explains the failure, it doesn't prevent it.** An incompatible file still can't be opened; `NewStore` still fails in index creation, but gives a warning naming the file, both versions, and the remedy is logged first. Returning the mismatch as an error rather than logging it is a one-line change, deferred until the schema stops moving so that iterating doesn't mean deleting a database every build.

## Incidental

`NewStore` now takes a `*zap.Logger`, matching `server`, the JSON-RPC handler and the extension. It was the one component reporting through return values instead of logging. Nil is accepted and becomes a no-op, so tests need no ceremony.

## Follow-ups

- Bump `Version` and flip warn → error when the rewrite lands.
- The rewrite itself, which this exists to make safe.
