### PR TITLE
Resource identity by OTel triplet, and a dictionary cache that survives a restart

### DIFF
--- a/desktopexporter/internal/store/dictionary_integrity_test.go
+++ b/desktopexporter/internal/store/dictionary_integrity_test.go
@@ -294,6 +294,13 @@ func TestDictionaryIntegrityAfterRetention(t *testing.T) {
 // content adds no new ids, so its dictionary flush issues no SQL at all. That is
 // what removes the ~2.3ms fixed per-batch cost, and it is why small batches went
 // from 2.7x slower than the pre-dictionary schema to 2.1x faster.
+//
+// The final stretch pins the sweep's precise invalidation, not just that it
+// invalidates something: clearing traces orphans the span/event/link
+// attributes, but the resource, scope, and the log/metric attributes stay
+// referenced, so those ids must survive in the cache. A sweep that fell back
+// to forgetting everything would also make `after` smaller than `first` --
+// only the `Positive` assertion on `after` tells the two apart.
 func TestFlushedIDsPopulatesAndClears(t *testing.T) {
 	ctx := context.Background()
 	s, err := NewStore(ctx, "", zap.NewNop())
@@ -310,9 +317,18 @@ func TestFlushedIDsPopulatesAndClears(t *testing.T) {
 	assert.Equal(t, first, s.FlushedIDs().Len(),
 		"identical content adds no new ids -- this is the skip that makes it fast")
 
+	// Clear traces only: span/event/link attributes lose their only owner and
+	// become orphans, but the resource and scope are still referenced by logs
+	// and metrics, and log/metric attributes are untouched.
+	require.NoError(t, s.WithDBWrite(func(db *sql.DB) error {
+		return spans.Clear(ctx, db)
+	}))
 	sweep(t, s)
-	assert.Zero(t, s.FlushedIDs().Len(),
-		"the sweep deletes dictionary rows, so it must forget them too")
+
+	after := s.FlushedIDs().Len()
+	assert.Less(t, after, first, "the sweep must forget the ids it actually deleted")
+	assert.Positive(t, after,
+		"ids the sweep did not delete -- the shared resource, scope, and log/metric attributes -- must stay marked")
 }
 
 // A store must never consult another store's set. Two stores are two databases;

--- a/desktopexporter/internal/store/ingest/appender_test.go
+++ b/desktopexporter/internal/store/ingest/appender_test.go
@@ -141,6 +141,7 @@ func TestFlushAppenders_MakesDataVisible(t *testing.T) {
 			ingest.NonNil(logAttrIDs), // AttributeIDs UUID[]
 			uint32(0), uint32(0), "",  // DroppedAttributesCount, Flags, EventName
 			"flush-test", // ServiceName VARCHAR (NOT NULL, '' = unknown)
+			"", "",       // ResourceSchemaURL, ScopeSchemaURL (batch-level, optional)
 		); err != nil {
 			return err
 		}

--- a/desktopexporter/internal/store/ingest/dictionary.go
+++ b/desktopexporter/internal/store/ingest/dictionary.go
@@ -98,18 +98,71 @@ func ResourceID(attributeIDs []duckdb.UUID, dropped uint32) duckdb.UUID {
 	return hashID(uuidsKey(attributeIDs), strconv.FormatUint(uint64(dropped), 10))
 }
 
-// SeriesID derives a timeseries' identity: the stream it belongs to, the
-// resource that emitted it, and its label set.
+// SeriesID derives a timeseries' identity: the stream it belongs to, which
+// instance emitted it, and its label set.
 //
 // Content-derived like the rest, which is what makes it usable in a URL --
 // the same series gets the same id across restarts and re-ingests, so a link
 // survives in a way one built on a minted datapoint id cannot.
 //
-// resource_id is in the key and that is the whole point: metric_streams
-// identifies a stream by service_name so a counter survives a pod restart,
-// which means two replicas share a stream. The series is where they separate.
-func SeriesID(streamID, resourceID duckdb.UUID, attributeIDs []duckdb.UUID) duckdb.UUID {
-	return hashID(formatUUID(streamID), formatUUID(resourceID), uuidsKey(attributeIDs))
+// The instance key is in there because metric_streams identifies a stream by
+// service_name so a counter survives a pod restart, which means two replicas
+// share a stream. The series is where they separate.
+//
+// It is deliberately NOT the resource row id, which this used to take. A
+// resource id is a hash of the resource's whole attribute set, so anything
+// enriching a resource mid-stream -- a processor that starts resolving k8s
+// metadata, an SDK that adds telemetry.sdk.* partway through -- mints a new
+// resource, and used to mint a new series with it. One instrument from one
+// instance then drew two chart lines, split at the moment those attributes
+// appeared, and a ?series= link addressed only one half of it. Measured in the
+// reference capture: 48 resource rows for 35 distinct service.instance.id,
+// with telemetry.sdk.* on 35 of them and absent from the other 13.
+//
+// See InstanceKey for the identity used instead.
+func SeriesID(streamID duckdb.UUID, instanceKey string, attributeIDs []duckdb.UUID) duckdb.UUID {
+	return hashID(formatUUID(streamID), instanceKey, uuidsKey(attributeIDs))
+}
+
+// instanceKeys are the resource attributes that identify *which instance* a
+// resource describes, rather than merely describing it, most specific first.
+//
+// service.instance.id is the one OTel actually sanctions for this. host.name
+// and k8s.pod.name are the usual stand-ins when an SDK omits it, and are what
+// the original split-by-resource was reaching for.
+var instanceKeys = []string{
+	"service.instance.id",
+	"host.name",
+	"k8s.pod.name",
+}
+
+// InstanceKey returns a stable identity for the instance a resource describes,
+// for use as part of a series id. Empty when the resource does not say.
+//
+// The attribute name is included in the result, so a host.name of "web-1"
+// cannot collide with a k8s.pod.name of "web-1".
+//
+// Absent means absent. When none of these attributes are present the key is
+// empty and every such resource lands on one series -- the same default a
+// datapoint with no labels gets, for the same reason: the telemetry expressed
+// no distinction, so we do not invent one.
+//
+// Falling back to the resource id here would be inventing one. A resource id is
+// a hash of the whole attribute set, so it splits on enrichment rather than on
+// instance, which means it answers a question nobody asked and answers it
+// wrongly -- and it would do so precisely in the cases where we know least
+// about the instance. Two replicas sharing a line because neither identified
+// itself is a true statement about the data. Two lines because a processor
+// added an attribute is not.
+func InstanceKey(attrs pcommon.Map) string {
+	for _, k := range instanceKeys {
+		if v, ok := attrs.Get(k); ok {
+			if s := v.AsString(); s != "" {
+				return k + "=" + s
+			}
+		}
+	}
+	return ""
 }
 
 // ScopeID derives a scope's identity. Name and version participate because two

--- a/desktopexporter/internal/store/ingest/dictionary.go
+++ b/desktopexporter/internal/store/ingest/dictionary.go
@@ -40,6 +40,14 @@ type Attribute struct {
 }
 
 // Resource is one deduped resource: an attribute set plus its dropped count.
+//
+// Deduping is by ResourceID, which no longer depends on this attribute set --
+// see ResourceID. So two AddResource calls that resolve to the same id can
+// carry different AttributeIDs (an enriched resource, say); the map in
+// Dictionary keeps whichever this batch saw last, and Flush's `on conflict do
+// nothing` then keeps whichever batch reached the database first. Either way
+// attribute_ids is a representative sample of the resource's payload, not
+// part of what makes the row that resource.
 type Resource struct {
 	ID           duckdb.UUID
 	AttributeIDs []duckdb.UUID
@@ -92,77 +100,78 @@ func AttributeID(key, value, typ, scope string) duckdb.UUID {
 	return hashID(key, value, typ, scope)
 }
 
-// ResourceID derives a resource's identity from its attribute ids and dropped
-// count. The ids are already sorted and deduped by the caller.
-func ResourceID(attributeIDs []duckdb.UUID, dropped uint32) duckdb.UUID {
-	return hashID(uuidsKey(attributeIDs), strconv.FormatUint(uint64(dropped), 10))
+// ResourceID derives a resource's identity from the OTel-mandated
+// identifying triplet, read straight out of its attributes -- NOT from the
+// resource's whole attribute set.
+//
+// The Resource SDK spec is explicit about what identity means here: the id
+// "MUST be unique for each instance of the same service.namespace,service.name
+// pair (in other words service.namespace,service.name,service.instance.id
+// triplet MUST be globally unique)." All three are Required-level. Nothing
+// else a resource carries -- host.name, k8s.pod.name, telemetry.sdk.*, cloud
+// metadata -- is part of that contract, however much it looks like it should
+// be.
+//
+// A missing attribute contributes an empty string to the hash, not a
+// substitute for one. If a service omits service.instance.id, every instance
+// of that service legitimately shares one resource row, because the telemetry
+// expressed no distinction -- the same collapse a datapoint with no labels
+// gets onto one default series. Falling back to hashing the whole attribute
+// set instead would answer a question the telemetry never asked, and would do
+// so precisely when we know least about the resource: two replicas that both
+// omit service.instance.id sharing one row is a true statement about what was
+// sent; two rows because a processor added telemetry.sdk.* partway through is
+// not.
+//
+// Content-derived like the rest, so ingest never needs a read-back or a wide
+// natural-key index to resolve one, and ids are stable across restarts and
+// re-ingests. Measured in the reference capture: hashing the whole attribute
+// set produced 48 resource rows for 35 distinct service.instance.id values,
+// with telemetry.sdk.* present on 35 of them and absent from the other 13 --
+// the same running process minting a new row the moment it got enriched.
+func ResourceID(attrs pcommon.Map) duckdb.UUID {
+	return hashID(
+		resourceAttrString(attrs, "service.namespace"),
+		resourceAttrString(attrs, "service.name"),
+		resourceAttrString(attrs, "service.instance.id"),
+	)
 }
 
-// SeriesID derives a timeseries' identity: the stream it belongs to, which
-// instance emitted it, and its label set.
+// resourceAttrString reads one resource identity field, or "" if the
+// resource does not set it. Absent means absent -- see ResourceID.
+func resourceAttrString(attrs pcommon.Map, key string) string {
+	if v, ok := attrs.Get(key); ok {
+		return v.AsString()
+	}
+	return ""
+}
+
+// SeriesID derives a timeseries' identity: the stream it belongs to, the
+// resource that emitted it, and its label set.
 //
 // Content-derived like the rest, which is what makes it usable in a URL --
 // the same series gets the same id across restarts and re-ingests, so a link
 // survives in a way one built on a minted datapoint id cannot.
 //
-// The instance key is in there because metric_streams identifies a stream by
+// The resource id is in there because metric_streams identifies a stream by
 // service_name so a counter survives a pod restart, which means two replicas
-// share a stream. The series is where they separate.
+// of one service share a stream. The series is where they separate: two
+// replicas with identical labels still carry distinct resource ids (or, if
+// neither identifies itself, legitimately collapse to one series -- see
+// ResourceID), so keying on it is what keeps their datapoints from
+// interleaving into one line.
 //
-// It is deliberately NOT the resource row id, which this used to take. A
-// resource id is a hash of the resource's whole attribute set, so anything
-// enriching a resource mid-stream -- a processor that starts resolving k8s
-// metadata, an SDK that adds telemetry.sdk.* partway through -- mints a new
-// resource, and used to mint a new series with it. One instrument from one
-// instance then drew two chart lines, split at the moment those attributes
-// appeared, and a ?series= link addressed only one half of it. Measured in the
-// reference capture: 48 resource rows for 35 distinct service.instance.id,
-// with telemetry.sdk.* on 35 of them and absent from the other 13.
-//
-// See InstanceKey for the identity used instead.
-func SeriesID(streamID duckdb.UUID, instanceKey string, attributeIDs []duckdb.UUID) duckdb.UUID {
-	return hashID(formatUUID(streamID), instanceKey, uuidsKey(attributeIDs))
-}
-
-// instanceKeys are the resource attributes that identify *which instance* a
-// resource describes, rather than merely describing it, most specific first.
-//
-// service.instance.id is the one OTel actually sanctions for this. host.name
-// and k8s.pod.name are the usual stand-ins when an SDK omits it, and are what
-// the original split-by-resource was reaching for.
-var instanceKeys = []string{
-	"service.instance.id",
-	"host.name",
-	"k8s.pod.name",
-}
-
-// InstanceKey returns a stable identity for the instance a resource describes,
-// for use as part of a series id. Empty when the resource does not say.
-//
-// The attribute name is included in the result, so a host.name of "web-1"
-// cannot collide with a k8s.pod.name of "web-1".
-//
-// Absent means absent. When none of these attributes are present the key is
-// empty and every such resource lands on one series -- the same default a
-// datapoint with no labels gets, for the same reason: the telemetry expressed
-// no distinction, so we do not invent one.
-//
-// Falling back to the resource id here would be inventing one. A resource id is
-// a hash of the whole attribute set, so it splits on enrichment rather than on
-// instance, which means it answers a question nobody asked and answers it
-// wrongly -- and it would do so precisely in the cases where we know least
-// about the instance. Two replicas sharing a line because neither identified
-// itself is a true statement about the data. Two lines because a processor
-// added an attribute is not.
-func InstanceKey(attrs pcommon.Map) string {
-	for _, k := range instanceKeys {
-		if v, ok := attrs.Get(k); ok {
-			if s := v.AsString(); s != "" {
-				return k + "=" + s
-			}
-		}
-	}
-	return ""
+// This only works because resource identity is the OTel triplet
+// (service.namespace, service.name, service.instance.id), not a hash of the
+// resource's whole attribute set. A whole-attribute-set hash changes the
+// moment anything enriches the resource mid-stream -- a processor resolving
+// k8s metadata, an SDK adding telemetry.sdk.* partway through -- and putting
+// that unstable value in a series key used to mint a second series for the
+// same instance: one instrument drew two chart lines, split at the moment
+// those attributes appeared, and a ?series= link addressed only one half of
+// it.
+func SeriesID(streamID, resourceID duckdb.UUID, attributeIDs []duckdb.UUID) duckdb.UUID {
+	return hashID(formatUUID(streamID), formatUUID(resourceID), uuidsKey(attributeIDs))
 }
 
 // ScopeID derives a scope's identity. Name and version participate because two
@@ -202,7 +211,8 @@ func uuidString(id duckdb.UUID) string {
 // reaches the wire, because the read path orders by key in SQL.
 //
 // Deduping is a guard that should never fire; if it ever did, [A,A,B] and [A,B]
-// would hash to different resources.
+// would hash to different scopes -- scopes still key off this array, though
+// resources no longer do; see ResourceID.
 func AttributeSet(attrs pcommon.Map, scope string) ([]Attribute, []duckdb.UUID) {
 	if attrs.Len() == 0 {
 		return nil, nil
@@ -289,7 +299,7 @@ func (d *Dictionary) AddAttributes(attrs pcommon.Map, scope string) []duckdb.UUI
 // AddResource records a resource and returns its id.
 func (d *Dictionary) AddResource(res pcommon.Resource) duckdb.UUID {
 	ids := d.AddAttributes(res.Attributes(), ScopeResource)
-	id := ResourceID(ids, res.DroppedAttributesCount())
+	id := ResourceID(res.Attributes())
 	d.resources[id] = Resource{ID: id, AttributeIDs: ids, Dropped: res.DroppedAttributesCount()}
 	return id
 }

--- a/desktopexporter/internal/store/ingest/dictionary.go
+++ b/desktopexporter/internal/store/ingest/dictionary.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/util"
 	"github.com/duckdb/duckdb-go/v2"
+	"github.com/google/uuid"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
@@ -282,64 +283,120 @@ func (d *Dictionary) Flush(ctx context.Context, conn driver.Conn) error {
 	return d.flushScopes(ctx, conn)
 }
 
-func (d *Dictionary) flushAttributes(ctx context.Context, conn driver.Conn) error {
-	d.attributes = unseen(d.flushed, d.attributes)
-	if len(d.attributes) == 0 {
+// flushRows is the sequence every dictionary flush shares: filter down to
+// rows the cache has not seen, bail out if nothing is left, execute, and mark
+// only once that execution has actually succeeded.
+//
+// That ordering is the one thing that matters here and it used to be retyped
+// three times, once per table. Marking before a successful exec -- or
+// unconditionally -- would tell the cache a row exists that was never
+// written, which is exactly the undetectable failure FlushedIDs documents:
+// nothing catches it until an owner's array points at a row that silently
+// never made it in.
+//
+// query must be `unnest`-shaped over the parallel arrays buildArgs returns,
+// the same idiom metrics.go uses for the metric_streams upsert: one bound
+// argument per column, so the statement text is fixed regardless of how many
+// rows are in m.
+func flushRows[T any](
+	ctx context.Context,
+	conn driver.Conn,
+	flushed *FlushedIDs,
+	m map[duckdb.UUID]T,
+	query string,
+	what string,
+	buildArgs func(map[duckdb.UUID]T) []any,
+) error {
+	m = unseen(flushed, m)
+	if len(m) == 0 {
 		return nil
 	}
-	rows := make([]string, 0, len(d.attributes))
-	args := make([]any, 0, len(d.attributes)*5)
-	for _, a := range d.attributes {
-		rows = append(rows, "(?::uuid, ?, ?, ?::attr_type, ?)")
-		args = append(args, formatUUID(a.ID), a.Key, a.Value, a.Type, a.Scope)
-	}
-	q := `insert into attributes (id, key, value, type, scope) values ` +
-		strings.Join(rows, ", ") + ` on conflict (id) do nothing`
-	if err := execArgs(ctx, conn, q, args, "attributes"); err != nil {
+	if err := execArgs(ctx, conn, query, buildArgs(m), what); err != nil {
 		return err
 	}
-	mark(d.flushed, d.attributes)
+	mark(flushed, m)
 	return nil
 }
+
+// attributesUpsert is static, unlike the per-batch `values (...), (...), ...`
+// text it replaced: the arrays vary, the query never does, so DuckDB can
+// actually prepare it once instead of replanning on every distinct row count.
+const attributesUpsert = `insert into attributes (id, key, value, type, scope)
+	select unnest(?::varchar[])::uuid, unnest(?::varchar[]), unnest(?::varchar[]), unnest(?::varchar[])::attr_type, unnest(?::varchar[])
+	on conflict (id) do nothing`
+
+func (d *Dictionary) flushAttributes(ctx context.Context, conn driver.Conn) error {
+	return flushRows(ctx, conn, d.flushed, d.attributes, attributesUpsert, "attributes",
+		func(rows map[duckdb.UUID]Attribute) []any {
+			ids := make([]string, 0, len(rows))
+			keys := make([]string, 0, len(rows))
+			values := make([]string, 0, len(rows))
+			types := make([]string, 0, len(rows))
+			scopes := make([]string, 0, len(rows))
+			for _, a := range rows {
+				ids = append(ids, formatUUID(a.ID))
+				keys = append(keys, a.Key)
+				values = append(values, a.Value)
+				types = append(types, a.Type)
+				scopes = append(scopes, a.Scope)
+			}
+			return []any{ids, keys, values, types, scopes}
+		})
+}
+
+const resourcesUpsert = `insert into resources (id, attribute_ids, dropped_attributes_count)
+	select unnest(?::varchar[])::uuid, unnest(?::varchar[][])::uuid[], unnest(?::uinteger[])
+	on conflict (id) do nothing`
 
 func (d *Dictionary) flushResources(ctx context.Context, conn driver.Conn) error {
-	d.resources = unseen(d.flushed, d.resources)
-	if len(d.resources) == 0 {
-		return nil
-	}
-	rows := make([]string, 0, len(d.resources))
-	args := make([]any, 0, len(d.resources)*3)
-	for _, r := range d.resources {
-		rows = append(rows, "(?::uuid, ?::uuid[], ?)")
-		args = append(args, formatUUID(r.ID), uuidList(r.AttributeIDs), r.Dropped)
-	}
-	q := `insert into resources (id, attribute_ids, dropped_attributes_count) values ` +
-		strings.Join(rows, ", ") + ` on conflict (id) do nothing`
-	if err := execArgs(ctx, conn, q, args, "resources"); err != nil {
-		return err
-	}
-	mark(d.flushed, d.resources)
-	return nil
+	return flushRows(ctx, conn, d.flushed, d.resources, resourcesUpsert, "resources",
+		func(rows map[duckdb.UUID]Resource) []any {
+			ids := make([]string, 0, len(rows))
+			attributeIDs := make([][]string, 0, len(rows))
+			dropped := make([]uint32, 0, len(rows))
+			for _, r := range rows {
+				ids = append(ids, formatUUID(r.ID))
+				attributeIDs = append(attributeIDs, formatUUIDs(r.AttributeIDs))
+				dropped = append(dropped, r.Dropped)
+			}
+			return []any{ids, attributeIDs, dropped}
+		})
 }
 
+const scopesUpsert = `insert into scopes (id, name, version, attribute_ids, dropped_attributes_count)
+	select unnest(?::varchar[])::uuid, unnest(?::varchar[]), unnest(?::varchar[]), unnest(?::varchar[][])::uuid[], unnest(?::uinteger[])
+	on conflict (id) do nothing`
+
 func (d *Dictionary) flushScopes(ctx context.Context, conn driver.Conn) error {
-	d.scopes = unseen(d.flushed, d.scopes)
-	if len(d.scopes) == 0 {
-		return nil
+	return flushRows(ctx, conn, d.flushed, d.scopes, scopesUpsert, "scopes",
+		func(rows map[duckdb.UUID]Scope) []any {
+			ids := make([]string, 0, len(rows))
+			names := make([]string, 0, len(rows))
+			versions := make([]string, 0, len(rows))
+			attributeIDs := make([][]string, 0, len(rows))
+			dropped := make([]uint32, 0, len(rows))
+			for _, sc := range rows {
+				ids = append(ids, formatUUID(sc.ID))
+				names = append(names, sc.Name)
+				versions = append(versions, sc.Version)
+				attributeIDs = append(attributeIDs, formatUUIDs(sc.AttributeIDs))
+				dropped = append(dropped, sc.Dropped)
+			}
+			return []any{ids, names, versions, attributeIDs, dropped}
+		})
+}
+
+// formatUUIDs renders each id in its canonical text form, for binding as a
+// `varchar[]` element of the `varchar[][]` parameter an attribute_ids column
+// unnests and casts back to uuid[]. A nil ids (an owner with no attributes)
+// renders as an empty, non-nil []string, which the driver round-trips as SQL
+// `[]` rather than NULL -- see NonNil below for why that distinction matters.
+func formatUUIDs(ids []duckdb.UUID) []string {
+	out := make([]string, len(ids))
+	for i, id := range ids {
+		out[i] = formatUUID(id)
 	}
-	rows := make([]string, 0, len(d.scopes))
-	args := make([]any, 0, len(d.scopes)*5)
-	for _, sc := range d.scopes {
-		rows = append(rows, "(?::uuid, ?, ?, ?::uuid[], ?)")
-		args = append(args, formatUUID(sc.ID), sc.Name, sc.Version, uuidList(sc.AttributeIDs), sc.Dropped)
-	}
-	q := `insert into scopes (id, name, version, attribute_ids, dropped_attributes_count) values ` +
-		strings.Join(rows, ", ") + ` on conflict (id) do nothing`
-	if err := execArgs(ctx, conn, q, args, "scopes"); err != nil {
-		return err
-	}
-	mark(d.flushed, d.scopes)
-	return nil
+	return out
 }
 
 // NonNil normalises a nil id slice to an empty one.
@@ -386,6 +443,22 @@ func UUIDListLiteral(ids []duckdb.UUID) string { return uuidList(ids) }
 func formatUUID(id duckdb.UUID) string {
 	h := uuidString(id)
 	return h[0:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
+}
+
+// parseUUID is the inverse of formatUUID, for ids read back from the database
+// rather than computed here: LoadFlushedIDs warming the cache from what is
+// already on disk, and SweepOrphans reading back exactly which ids a delete
+// removed.
+//
+// duckdb.UUID and uuid.UUID are both plain [16]byte, so the conversion is
+// direct -- same idiom metrics.go's decodeStreamID uses for a uuid column
+// scanned as text.
+func parseUUID(s string) (duckdb.UUID, error) {
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return duckdb.UUID{}, err
+	}
+	return duckdb.UUID(id), nil
 }
 
 func execArgs(ctx context.Context, conn driver.Conn, query string, args []any, what string) error {

--- a/desktopexporter/internal/store/ingest/dictionary_test.go
+++ b/desktopexporter/internal/store/ingest/dictionary_test.go
@@ -53,7 +53,8 @@ func TestHashFramingIsUnambiguous(t *testing.T) {
 
 // Arrays are sorted by id and deduped, so two maps with the same content
 // produce byte-identical arrays regardless of insertion order -- which is what
-// makes resource dedupe work at all.
+// makes scope dedupe work at all (ScopeID still hashes this array; resources
+// no longer do, see the ResourceID tests below).
 func TestAttributeSetIsOrderIndependent(t *testing.T) {
 	one := pcommon.NewMap()
 	one.PutStr("b", "2")
@@ -65,22 +66,67 @@ func TestAttributeSetIsOrderIndependent(t *testing.T) {
 	two.PutStr("a", "1")
 	two.PutStr("b", "2")
 
-	_, idsOne := ingest.AttributeSet(one, ingest.ScopeResource)
-	_, idsTwo := ingest.AttributeSet(two, ingest.ScopeResource)
+	_, idsOne := ingest.AttributeSet(one, ingest.ScopeScope)
+	_, idsTwo := ingest.AttributeSet(two, ingest.ScopeScope)
 
 	require.Equal(t, idsOne, idsTwo, "insertion order must not change the array")
 	assert.Equal(t,
-		ingest.ResourceID(idsOne, 0),
-		ingest.ResourceID(idsTwo, 0),
-		"so the same resource in a different order is still one resource")
+		ingest.ScopeID("otelhttp", "1.0.0", idsOne, 0),
+		ingest.ScopeID("otelhttp", "1.0.0", idsTwo, 0),
+		"so the same scope in a different order is still one scope")
 }
 
-// Dropped counts participate in resource identity, so a resource whose dropped
-// count changes is a genuinely different row. Worth pinning: it means a flaky
-// exporter that varies the count fragments the dedupe.
-func TestResourceIdentityIncludesDroppedCount(t *testing.T) {
-	_, ids := ingest.AttributeSet(attrMap(map[string]string{"service.name": "checkout"}), ingest.ScopeResource)
-	assert.NotEqual(t, ingest.ResourceID(ids, 0), ingest.ResourceID(ids, 3))
+// ResourceID reads the OTel identifying triplet straight out of the
+// resource's attributes -- see the doc comment on ResourceID for the spec
+// citation. These pin the properties that matter: each of the three fields is
+// part of identity, everything else is not, and a field's absence is not a
+// license to fall back to hashing the whole attribute set.
+
+// Two instances of the same service, distinguished only by
+// service.instance.id, must land on different resource ids -- otherwise two
+// running processes collapse into one resource.
+func TestResourceIdentityIncludesInstanceID(t *testing.T) {
+	a := attrMap(map[string]string{"service.name": "checkout", "service.instance.id": "i-1"})
+	b := attrMap(map[string]string{"service.name": "checkout", "service.instance.id": "i-2"})
+	assert.NotEqual(t, ingest.ResourceID(a), ingest.ResourceID(b),
+		"two instances of the same service must get different resource ids")
+}
+
+// service.namespace scopes service.name, per the spec's own pairing, so it
+// has to participate too.
+func TestResourceIdentityIncludesNamespace(t *testing.T) {
+	a := attrMap(map[string]string{"service.namespace": "ns-a", "service.name": "checkout", "service.instance.id": "i-1"})
+	b := attrMap(map[string]string{"service.namespace": "ns-b", "service.name": "checkout", "service.instance.id": "i-1"})
+	assert.NotEqual(t, ingest.ResourceID(a), ingest.ResourceID(b))
+}
+
+// Enriching a resource -- adding attributes that are not part of the
+// identifying triplet -- must not change its id. This is the property that
+// used to fail: telemetry.sdk.* arriving mid-stream minted a new resource for
+// the same running process.
+func TestResourceIdentityIgnoresNonIdentifyingAttributes(t *testing.T) {
+	a := attrMap(map[string]string{"service.name": "checkout", "service.instance.id": "i-1", "region": "us-east-1"})
+	b := attrMap(map[string]string{
+		"service.name": "checkout", "service.instance.id": "i-1",
+		"telemetry.sdk.name": "opentelemetry", "telemetry.sdk.version": "1.28.0",
+	})
+	assert.Equal(t, ingest.ResourceID(a), ingest.ResourceID(b),
+		"enrichment must not mint a new resource id for the same instance")
+}
+
+// Absent means absent: when service.instance.id (and namespace) are missing,
+// every resource for that service.name collapses onto one row, no matter what
+// else the resource carries. This is the property a whole-attribute-set
+// fallback would violate -- these two resources share nothing else, and would
+// hash differently under a fallback that used the rest of the attribute set
+// to compensate for the missing field.
+func TestResourceIdentityAbsentInstanceIDCollapses(t *testing.T) {
+	a := attrMap(map[string]string{"service.name": "checkout", "region": "us-east-1"})
+	b := attrMap(map[string]string{
+		"service.name": "checkout", "pod": "checkout-7f9c", "telemetry.sdk.name": "opentelemetry",
+	})
+	assert.Equal(t, ingest.ResourceID(a), ingest.ResourceID(b),
+		"without service.instance.id, same service.name must collapse to one resource regardless of what else differs")
 }
 
 // Two scopes with identical (empty) attributes are still different scopes.

--- a/desktopexporter/internal/store/ingest/dictionary_test.go
+++ b/desktopexporter/internal/store/ingest/dictionary_test.go
@@ -149,6 +149,33 @@ func TestFlushIsIdempotent(t *testing.T) {
 	}))
 }
 
+// A failed exec must never mark ids as flushed. Marking before -- or
+// regardless of -- a successful exec would tell the cache a row exists that
+// was never written, which is the one failure mode FlushedIDs' doc comment
+// calls out as undetectable: a later batch would trust the cache, skip the
+// insert, and leave an owner's array pointing at a row that was never there.
+func TestFailedFlushDoesNotMarkAsFlushed(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	// Force the attributes insert to fail without touching FlushedIDs itself:
+	// drop the table the statement targets.
+	require.NoError(t, s.WithDBWrite(func(db *sql.DB) error {
+		_, err := db.Exec(`drop table attributes`)
+		return err
+	}))
+
+	d := ingest.NewDictionary(s.FlushedIDs())
+	d.AddAttributes(attrMap(map[string]string{"http.method": "GET"}), ingest.ScopeSpan)
+
+	err := s.WithConn(func(conn driver.Conn) error {
+		return d.Flush(ctx, conn)
+	})
+	require.Error(t, err, "the insert must fail with its table gone")
+	assert.Zero(t, s.FlushedIDs().Len(),
+		"a failed exec must leave nothing marked -- marking beforehand would convince the cache this row exists")
+}
+
 // Every id an owner array references must exist in the dictionary. Nothing
 // enforces this -- DuckDB cannot FK into a LIST -- so it is checked rather than
 // assumed.

--- a/desktopexporter/internal/store/ingest/flushed.go
+++ b/desktopexporter/internal/store/ingest/flushed.go
@@ -1,6 +1,9 @@
 package ingest
 
 import (
+	"context"
+	"database/sql"
+	"fmt"
 	"sync"
 
 	"github.com/duckdb/duckdb-go/v2"
@@ -32,6 +35,14 @@ import (
 // Small batches are the normal case for a desktop viewer watching one local
 // service, where the batch processor flushes on its timeout rather than on size.
 //
+// That table was measured replaying a fixed capture, which is this cache's
+// best case: a finite capture has a finite attribute set, so the hit rate
+// climbs toward 100% and stays there. Live traffic keeps minting new triples
+// -- a fresh url.path, a new db.statement, a stack trace that has never
+// appeared before -- so a running collector's hit rate, and the speedup that
+// comes with it, is lower than the table above and does not generalise from
+// it.
+//
 // # Why a cache is safe here specifically
 //
 // A cache of "rows that exist" is only wrong when something deletes one. Every
@@ -40,8 +51,11 @@ import (
 // cache over those would have four chances to drift.
 //
 // Dictionary rows have exactly one deleter: SweepOrphans. So invalidation lives
-// inside that function rather than at its call sites, and there is no way to
-// remove a row without clearing the set in the same breath.
+// inside that function rather than at its call sites. It can afford to be
+// precise -- forgetting exactly the ids a sweep actually removed, via
+// forgetIDs -- because there is still only one place that ever has to get it
+// right; see SweepOrphans and Forget for the coarse fallback it keeps for when
+// precision cannot be trusted.
 //
 // # Failure mode, and why it is contained
 //
@@ -69,6 +83,72 @@ type FlushedIDs struct {
 
 func NewFlushedIDs() *FlushedIDs {
 	return &FlushedIDs{ids: make(map[duckdb.UUID]struct{})}
+}
+
+// idQueryer is the read access LoadFlushedIDs needs. *sql.DB satisfies it, so
+// callers pass the store's pool directly.
+type idQueryer interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// LoadFlushedIDs builds a FlushedIDs warmed from every id already on disk.
+//
+// Without this, opening a persistent --db that already holds the whole
+// dictionary would still re-insert everything until repeated flushes refilled
+// an empty in-process cache -- the fixed per-batch cost FlushedIDs exists to
+// remove, paid all over again on every restart. This loads every id ever
+// stored across the three dictionary tables, which sounds unbounded but is
+// not: it is bounded the same way the on-disk dictionary itself is, by
+// retention.
+//
+// A fresh or in-memory store has nothing to load, so this just runs three
+// queries against empty tables and returns an empty cache -- equivalent to
+// NewFlushedIDs.
+func LoadFlushedIDs(ctx context.Context, db idQueryer) (*FlushedIDs, error) {
+	f := NewFlushedIDs()
+	for _, table := range [...]string{"attributes", "resources", "scopes"} {
+		if err := warmFlushedFrom(ctx, db, table, f); err != nil {
+			return nil, fmt.Errorf("LoadFlushedIDs: %w: %w", ErrIngestInternal, err)
+		}
+	}
+	return f, nil
+}
+
+// warmFlushedFrom reads every id out of one dictionary table and records it.
+//
+// Cast to varchar in the query rather than scanning the uuid column directly:
+// scanning a uuid straight into a Go string via database/sql yields the raw
+// 16 bytes, not hex text, because the driver's text formatting only happens
+// when DuckDB is asked to produce text. The cast asks for exactly that.
+func warmFlushedFrom(ctx context.Context, db idQueryer, table string, f *FlushedIDs) error {
+	rows, err := db.QueryContext(ctx, fmt.Sprintf(`select id::varchar from %s`, table))
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var ids []duckdb.UUID
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return err
+		}
+		id, err := parseUUID(s)
+		if err != nil {
+			return err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, id := range ids {
+		f.ids[id] = struct{}{}
+	}
+	return nil
 }
 
 // unseen returns the subset of m whose keys are not already recorded.
@@ -106,10 +186,16 @@ func mark[T any](f *FlushedIDs, m map[duckdb.UUID]T) {
 
 // Forget drops everything, so the next flush rewrites whatever it needs.
 //
-// Called by SweepOrphans, which is the only thing that deletes dictionary rows.
-// Deliberately coarse: the sweep does not report which ids it removed, and
-// re-establishing the whole set costs one flush per sender rather than risking a
-// partial invalidation that misses one.
+// Called by SweepOrphans, which is the only thing that deletes dictionary
+// rows -- but only as its fallback, when it could not safely determine
+// exactly which ids a delete removed (a query or scan failure partway through
+// the three sweep statements). Deliberately coarse for that case:
+// re-establishing the whole set costs one flush per sender, which is cheap
+// next to the alternative. A precise invalidation that misses even one id
+// leaves a stale "this row exists" entry, and nothing catches that -- no FK,
+// no error, just an attribute that silently stops appearing in the UI. Being
+// coarse is always safe; being precise-but-incomplete is not. See forgetIDs
+// for the precise path SweepOrphans uses when it can trust what it read back.
 func (f *FlushedIDs) Forget() {
 	if f == nil {
 		return
@@ -117,6 +203,22 @@ func (f *FlushedIDs) Forget() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	clear(f.ids)
+}
+
+// forgetIDs drops exactly the given ids. Unexported: it is only safe when the
+// caller actually knows what got deleted, which today only SweepOrphans can
+// determine (via `delete ... returning id`), and only on the path where every
+// sweep statement's returned rows were read successfully. Any doubt about
+// that belongs on Forget's coarse path instead, never here.
+func (f *FlushedIDs) forgetIDs(ids []duckdb.UUID) {
+	if f == nil || len(ids) == 0 {
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, id := range ids {
+		delete(f.ids, id)
+	}
 }
 
 // Len reports how many ids are remembered. For tests and diagnostics.

--- a/desktopexporter/internal/store/ingest/sweep.go
+++ b/desktopexporter/internal/store/ingest/sweep.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
+	"github.com/duckdb/duckdb-go/v2"
 )
 
 // ExecContext is the slice of *sql.DB and *sql.Tx that SweepOrphans needs.
@@ -11,8 +13,13 @@ import (
 // Taken as an interface so both the per-signal Clear paths (which hold a
 // *sql.DB) and retention (package store, same) can call it without either
 // importing the other.
+//
+// QueryContext rather than plain Exec: every sweep statement carries
+// `returning id`, which SweepOrphans reads back so it can tell FlushedIDs
+// exactly which ids it removed instead of forgetting the whole cache on every
+// call. *sql.DB and *sql.Tx both already satisfy this.
 type ExecContext interface {
-	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
 }
 
 // liveAttributeIDs is every attribute id currently referenced by anything.
@@ -48,6 +55,11 @@ const liveAttributeIDs = `
 // dangling reference. That is the same direction ingest chose (attributes
 // written before the owners that reference them), for the same reason: nothing
 // enforces this, since DuckDB cannot put a foreign key into a LIST.
+//
+// Each carries `returning id::varchar` so SweepOrphans can tell FlushedIDs
+// exactly which ids it deleted. The cast matters: scanning a uuid column
+// straight into a Go string via database/sql yields the raw 16 bytes, not hex
+// text -- DuckDB only formats it as text when asked to, which the cast does.
 var sweepQueries = []string{
 	// A resource or scope is live if any signal still points at it. All three
 	// references are NOT NULL, so no null-safety dance is needed.
@@ -56,14 +68,14 @@ var sweepQueries = []string{
 		union select resource_id from logs
 		union select resource_id from metric_ingests
 		union select resource_id from metric_series
-	)`,
+	) returning id::varchar`,
 	`delete from scopes where id not in (
 		select scope_id from spans
 		union select scope_id from logs
 		union select scope_id from metric_ingests
-	)`,
+	) returning id::varchar`,
 
-	`delete from attributes where id not in (` + liveAttributeIDs + `)`,
+	`delete from attributes where id not in (` + liveAttributeIDs + `) returning id::varchar`,
 }
 
 // SweepOrphans deletes dictionary, resource and scope rows nothing references.
@@ -79,23 +91,64 @@ var sweepQueries = []string{
 // check (so pre-existing garbage can never be what pushes the store over the
 // cap) and once at the end of every round (the prunes are what create the
 // orphans).
+//
 // flushed may be nil when no store-level cache is in play.
+//
+// This is the only function that deletes dictionary rows, which is what makes
+// a "these ids exist" cache safe at all -- so invalidation belongs here rather
+// than at the call sites, where it would be four places to get it right
+// instead of one. Each statement's `returning id` means this can invalidate
+// precisely: only the ids a delete actually removed come out of FlushedIDs,
+// so a resource still referenced by logs after traces are cleared stays
+// marked, and the next batch that repeats it skips the insert exactly as
+// before the sweep ran.
+//
+// That precision is deliberately not trusted blindly. If collecting the
+// returned ids fails partway -- a query error, a scan error -- this falls
+// back to flushed.Forget(), which drops the whole cache rather than a partial
+// one. The asymmetry is intentional: being coarse is always safe, since a
+// forgotten-but-still-live row just gets re-inserted and conflicts for free.
+// Being precise but incomplete is not safe -- it leaves a stale "this row
+// exists" entry for an id whose row is actually gone, an owner ends up
+// referencing a deleted row, no FK can catch it, attrs_json silently joins
+// nothing, and the attribute vanishes from the UI with no error anywhere.
 func SweepOrphans(ctx context.Context, exec ExecContext, flushed *FlushedIDs) error {
-	// Forget first, and unconditionally.
-	//
-	// This is the only function that deletes dictionary rows, which is what
-	// makes a "these ids exist" cache safe at all -- so invalidation belongs
-	// here rather than at the call sites, where it would be four places to
-	// forget. Doing it before the deletes rather than after means a sweep that
-	// fails partway still leaves the cache empty: the next batch re-inserts
-	// rows that may already be present (free, they conflict) instead of
-	// skipping rows that are already gone (silent dangling references).
-	flushed.Forget()
-
+	var removed []duckdb.UUID
 	for _, q := range sweepQueries {
-		if _, err := exec.ExecContext(ctx, q); err != nil {
+		ids, err := collectDeletedIDs(ctx, exec, q)
+		if err != nil {
+			flushed.Forget()
 			return fmt.Errorf("SweepOrphans: %w: %w", ErrIngestInternal, err)
 		}
+		removed = append(removed, ids...)
 	}
+	flushed.forgetIDs(removed)
 	return nil
+}
+
+// collectDeletedIDs runs one `delete ... returning id::varchar` statement and
+// parses back exactly which ids it removed.
+func collectDeletedIDs(ctx context.Context, exec ExecContext, query string) ([]duckdb.UUID, error) {
+	rows, err := exec.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ids []duckdb.UUID
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, err
+		}
+		id, err := parseUUID(s)
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ids, nil
 }

--- a/desktopexporter/internal/store/logs/logs.go
+++ b/desktopexporter/internal/store/logs/logs.go
@@ -159,6 +159,8 @@ func Ingest(ctx context.Context, conn driver.Conn, logs plog.Logs, flushed *inge
 					uint32(log.Flags()),            // Flags UINTEGER
 					log.EventName(),                // EventName VARCHAR
 					serviceName,                    // ServiceName VARCHAR (NOT NULL, '' = unknown)
+					resourceLogs.SchemaUrl(),       // ResourceSchemaURL VARCHAR (batch-level)
+					scopeLogs.SchemaUrl(),          // ScopeSchemaURL VARCHAR (batch-level)
 				)
 				if err != nil {
 					return fmt.Errorf("Ingest: %w: %w", ErrLogsStoreInternal, err)

--- a/desktopexporter/internal/store/metrics/metrics.go
+++ b/desktopexporter/internal/store/metrics/metrics.go
@@ -77,6 +77,9 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 	resourceIDs := map[int]duckdb.UUID{}
 	scopeIDs := map[scopeKey]duckdb.UUID{}
 
+	// One id array per datapoint, in walk order, handed to collectSeries below.
+	var dpAttrIDs [][]duckdb.UUID
+
 	for ri, resourceMetric := range m.ResourceMetrics().All() {
 		resource := resourceMetric.Resource()
 		serviceName := serviceNameFromAttrs(resource.Attributes())
@@ -91,7 +94,7 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 				identity := streamIdentityFromMetric(metric, scope.Name(), scope.Version(), serviceName)
 				identitySet[identity] = struct{}{}
 				coords = append(coords, identityWithCoord{identity: identity, coord: metricCoord{ri, si, mi}})
-				addMetricAttributes(dict, metric)
+				dpAttrIDs = addMetricAttributes(dict, metric, dpAttrIDs)
 			}
 		}
 	}
@@ -251,10 +254,11 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 	// is a foreign key, so the rows must be committed before the appender
 	// flushes. Between the two is the only place it fits.
 	//
-	// The walk also carries each datapoint's attribute ids forward, so pass 2
-	// reads them by position instead of hashing every label set a second time
-	// -- datapoints are the highest-volume path in the store.
-	dpIdents, seriesRows, err := collectSeries(ctx, m, streamIDs, resourceIDs)
+	// The walk consumes the ids the dictionary walk already derived, and carries
+	// them forward again so pass 2 reads them by position too. Neither this walk
+	// nor pass 2 hashes a label set: datapoints are the highest-volume path in
+	// the store, and one derivation each is all they get.
+	dpIdents, seriesRows, err := collectSeries(ctx, m, streamIDs, resourceIDs, dpAttrIDs)
 	if err != nil {
 		return err
 	}
@@ -343,46 +347,26 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 // addMetricAttributes records every datapoint and exemplar attribute set on a
 // metric into the dictionary. Kept separate from the append pass so pass 1 can
 // hash everything before any row references it.
-func addMetricAttributes(dict *ingest.Dictionary, metric pmetric.Metric) {
-	addNumber := func(dps pmetric.NumberDataPointSlice) {
-		for _, dp := range dps.All() {
-			dict.AddAttributes(dp.Attributes(), ingest.ScopeDatapoint)
-			addExemplarAttributes(dict, dp.Exemplars())
-		}
-	}
-	switch metric.Type() {
-	case pmetric.MetricTypeGauge:
-		addNumber(metric.Gauge().DataPoints())
-	case pmetric.MetricTypeSum:
-		addNumber(metric.Sum().DataPoints())
-	case pmetric.MetricTypeHistogram:
-		for _, dp := range metric.Histogram().DataPoints().All() {
-			dict.AddAttributes(dp.Attributes(), ingest.ScopeDatapoint)
-			addExemplarAttributes(dict, dp.Exemplars())
-		}
-	case pmetric.MetricTypeExponentialHistogram:
-		for _, dp := range metric.ExponentialHistogram().DataPoints().All() {
-			dict.AddAttributes(dp.Attributes(), ingest.ScopeDatapoint)
-			addExemplarAttributes(dict, dp.Exemplars())
-		}
-	}
+//
+// Appends each datapoint's id array to out, in walk order, and returns the
+// extended slice. Those ids are the expensive part -- deriving one costs a
+// sha256 per label plus a sort, and datapoints are the highest-volume path in
+// the store -- so collectSeries reads them by position rather than hashing
+// every label set a second time. It cannot register them itself: the dictionary
+// is flushed before collectSeries runs, because series rows reference these ids
+// and no foreign key can enforce that ordering into a uuid[].
+func addMetricAttributes(dict *ingest.Dictionary, metric pmetric.Metric, out [][]duckdb.UUID) [][]duckdb.UUID {
+	eachDatapoint(metric, func(attrs pcommon.Map, exemplars pmetric.ExemplarSlice) {
+		out = append(out, ingest.NonNil(dict.AddAttributes(attrs, ingest.ScopeDatapoint)))
+		addExemplarAttributes(dict, exemplars)
+	})
+	return out
 }
 
 func addExemplarAttributes(dict *ingest.Dictionary, exemplars pmetric.ExemplarSlice) {
 	for _, ex := range exemplars.All() {
 		dict.AddAttributes(ex.FilteredAttributes(), ingest.ScopeExemplar)
 	}
-}
-
-// datapointAttrIDs returns the id array for a datapoint's labels.
-//
-// Replaces nullableCanonical, which materialised the same set as a
-// "key=value|..." string for grouping. The array is the identity itself rather
-// than a rendering of it, and NOT NULL rather than nullable: an unlabelled
-// datapoint stores an empty array, so grouping needs no null coalesce.
-func datapointAttrIDs(attrs pcommon.Map) []duckdb.UUID {
-	_, ids := ingest.AttributeSet(attrs, ingest.ScopeDatapoint)
-	return ingest.NonNil(ids)
 }
 
 // dpIdentity is what pass 1 works out for one datapoint and pass 2 writes.
@@ -412,9 +396,11 @@ func collectSeries(
 	m pmetric.Metrics,
 	streamIDs map[streamIdentity]duckdb.UUID,
 	resourceIDs map[int]duckdb.UUID,
+	dpAttrIDs [][]duckdb.UUID,
 ) ([]dpIdentity, map[duckdb.UUID]seriesRow, error) {
-	var idents []dpIdentity
+	idents := make([]dpIdentity, 0, len(dpAttrIDs))
 	rows := map[duckdb.UUID]seriesRow{}
+	cur := 0
 
 	for ri, resourceMetric := range m.ResourceMetrics().All() {
 		resource := resourceMetric.Resource()
@@ -432,38 +418,53 @@ func collectSeries(
 					return nil, nil, fmt.Errorf("collectSeries: %w: stream id missing for identity %+v",
 						ErrMetricsStoreInternal, identity)
 				}
-				eachDatapointAttrs(metric, func(attrs pcommon.Map) {
-					_, ids := ingest.AttributeSet(attrs, ingest.ScopeDatapoint)
-					ids = ingest.NonNil(ids)
+				var overrun bool
+				eachDatapoint(metric, func(_ pcommon.Map, _ pmetric.ExemplarSlice) {
+					if cur >= len(dpAttrIDs) {
+						overrun = true
+						return
+					}
+					ids := dpAttrIDs[cur]
+					cur++
 					sid := ingest.SeriesID(streamID, resourceID, ids)
 					idents = append(idents, dpIdentity{series: sid, attrs: ids})
 					rows[sid] = seriesRow{id: sid, stream: streamID, resource: resourceID, attrs: ids}
 				})
+				if overrun {
+					return nil, nil, fmt.Errorf("collectSeries: %w: more datapoints than the dictionary walk saw (%d)",
+						ErrMetricsStoreInternal, len(dpAttrIDs))
+				}
 			}
 		}
+	}
+	if cur != len(dpAttrIDs) {
+		return nil, nil, fmt.Errorf("collectSeries: %w: dictionary walk mismatch (%d/%d)",
+			ErrMetricsStoreInternal, cur, len(dpAttrIDs))
 	}
 	return idents, rows, nil
 }
 
-// eachDatapointAttrs visits a metric's datapoints in the order the ingest*
-// helpers write them. Both walks go through this, so they cannot drift apart.
-func eachDatapointAttrs(metric pmetric.Metric, fn func(attrs pcommon.Map)) {
+// eachDatapoint visits a metric's datapoints in the order the ingest* helpers
+// write them. Every walk goes through this, so they cannot drift apart -- which
+// matters because the dictionary walk and collectSeries pair up by position,
+// and a divergence would file every datapoint past it under another series.
+func eachDatapoint(metric pmetric.Metric, fn func(attrs pcommon.Map, exemplars pmetric.ExemplarSlice)) {
 	switch metric.Type() {
 	case pmetric.MetricTypeGauge:
 		for _, dp := range metric.Gauge().DataPoints().All() {
-			fn(dp.Attributes())
+			fn(dp.Attributes(), dp.Exemplars())
 		}
 	case pmetric.MetricTypeSum:
 		for _, dp := range metric.Sum().DataPoints().All() {
-			fn(dp.Attributes())
+			fn(dp.Attributes(), dp.Exemplars())
 		}
 	case pmetric.MetricTypeHistogram:
 		for _, dp := range metric.Histogram().DataPoints().All() {
-			fn(dp.Attributes())
+			fn(dp.Attributes(), dp.Exemplars())
 		}
 	case pmetric.MetricTypeExponentialHistogram:
 		for _, dp := range metric.ExponentialHistogram().DataPoints().All() {
-			fn(dp.Attributes())
+			fn(dp.Attributes(), dp.Exemplars())
 		}
 	}
 }

--- a/desktopexporter/internal/store/metrics/metrics.go
+++ b/desktopexporter/internal/store/metrics/metrics.go
@@ -411,9 +411,6 @@ func collectSeries(
 		resource := resourceMetric.Resource()
 		serviceName := serviceNameFromAttrs(resource.Attributes())
 		resourceID := resourceIDs[ri]
-		// Once per resource, not per datapoint: it is a fixed property of the
-		// resource, and there are ~10^5 datapoints behind each one.
-		instanceKey := ingest.InstanceKey(resource.Attributes())
 		for _, scopeMetric := range resourceMetric.ScopeMetrics().All() {
 			scope := scopeMetric.Scope()
 			for _, metric := range scopeMetric.Metrics().All() {
@@ -434,7 +431,7 @@ func collectSeries(
 					}
 					ids := dpAttrIDs[cur]
 					cur++
-					sid := ingest.SeriesID(streamID, instanceKey, ids)
+					sid := ingest.SeriesID(streamID, resourceID, ids)
 					idents = append(idents, dpIdentity{series: sid, attrs: ids})
 					// resource_id is the resource this series was *first* seen
 					// with, since the insert is on-conflict-do-nothing. When a

--- a/desktopexporter/internal/store/metrics/metrics.go
+++ b/desktopexporter/internal/store/metrics/metrics.go
@@ -301,6 +301,11 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 					metric.Description(), // Description VARCHAR
 					resourceID,           // ResourceID UUID
 					scopeID,              // ScopeID UUID
+					// Batch-level, from the OTLP wrappers rather than the
+					// Resource / InstrumentationScope messages, neither of
+					// which carries the field.
+					resourceMetric.SchemaUrl(), // ResourceSchemaURL VARCHAR
+					scopeMetric.SchemaUrl(),    // ScopeSchemaURL VARCHAR
 				); err != nil {
 					return fmt.Errorf("Ingest: %w: %w", ErrMetricsStoreInternal, err)
 				}
@@ -406,6 +411,9 @@ func collectSeries(
 		resource := resourceMetric.Resource()
 		serviceName := serviceNameFromAttrs(resource.Attributes())
 		resourceID := resourceIDs[ri]
+		// Once per resource, not per datapoint: it is a fixed property of the
+		// resource, and there are ~10^5 datapoints behind each one.
+		instanceKey := ingest.InstanceKey(resource.Attributes())
 		for _, scopeMetric := range resourceMetric.ScopeMetrics().All() {
 			scope := scopeMetric.Scope()
 			for _, metric := range scopeMetric.Metrics().All() {
@@ -426,8 +434,13 @@ func collectSeries(
 					}
 					ids := dpAttrIDs[cur]
 					cur++
-					sid := ingest.SeriesID(streamID, resourceID, ids)
+					sid := ingest.SeriesID(streamID, instanceKey, ids)
 					idents = append(idents, dpIdentity{series: sid, attrs: ids})
+					// resource_id is the resource this series was *first* seen
+					// with, since the insert is on-conflict-do-nothing. When a
+					// resource is enriched mid-stream the series now survives
+					// intact, which is the point, but its stored resource stays
+					// the earlier one. It is a representative, not an identity.
 					rows[sid] = seriesRow{id: sid, stream: streamID, resource: resourceID, attrs: ids}
 				})
 				if overrun {

--- a/desktopexporter/internal/store/metrics/metrics_test.go
+++ b/desktopexporter/internal/store/metrics/metrics_test.go
@@ -1834,3 +1834,96 @@ func TestMetricSeries_IDsAreStableAcrossReingest(t *testing.T) {
 	assert.Equal(t, first, served,
 		"the key on the wire must be the series id, so a link resolves back to a row")
 }
+
+// buildInstanceMetrics emits one gauge from one instance, optionally with extra
+// resource attributes bolted on -- the shape a collector processor produces
+// when it starts resolving metadata partway through a stream.
+func buildInstanceMetrics(t *testing.T, extra map[string]string, base int64) pmetric.Metrics {
+	t.Helper()
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "checkout")
+	rm.Resource().Attributes().PutStr("service.instance.id", "checkout-7f9c")
+	for k, v := range extra {
+		rm.Resource().Attributes().PutStr(k, v)
+	}
+
+	sm := rm.ScopeMetrics().AppendEmpty()
+	sm.Scope().SetName("otelhttp")
+	sm.Scope().SetVersion("1.2.0")
+
+	m := sm.Metrics().AppendEmpty()
+	m.SetName("http.server.duration")
+	m.SetUnit("ms")
+	g := m.SetEmptyGauge()
+	for j := 0; j < 3; j++ {
+		dp := g.DataPoints().AppendEmpty()
+		dp.SetTimestamp(pcommon.Timestamp(base + int64(j)*1_000_000))
+		dp.SetDoubleValue(float64(j))
+		dp.Attributes().PutStr("http.route", "/checkout")
+	}
+	return md
+}
+
+// TestMetricSeries_SurvivesResourceEnrichment is the regression test for a
+// series splitting when nothing about the series changed.
+//
+// A resource id is a hash of the resource's whole attribute set, so when
+// something enriches a resource mid-stream the resource id changes. While the
+// series id was derived from that, one instrument from one instance drew two
+// chart lines, split at the moment the extra attributes appeared, and a
+// ?series= link addressed only half of it. Observed in the reference capture:
+// 48 resource rows for 35 distinct service.instance.id, telemetry.sdk.* present
+// on 35 and absent from 13.
+//
+// Two resource rows is the correct outcome and is asserted deliberately: the
+// payloads really did differ, and being able to see that is information. What
+// must not change is the series.
+func TestMetricSeries_SurvivesResourceEnrichment(t *testing.T) {
+	s, ctx, teardown := setupStore(t)
+	defer teardown()
+
+	base := time.Now().UnixNano()
+	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
+		return metrics.Ingest(ctx, conn, buildInstanceMetrics(t, nil, base), s.FlushedIDs())
+	}))
+	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
+		return metrics.Ingest(ctx, conn, buildInstanceMetrics(t, map[string]string{
+			"telemetry.sdk.name":     "opentelemetry",
+			"telemetry.sdk.language": "go",
+			"telemetry.sdk.version":  "1.28.0",
+		}, base+10_000_000), s.FlushedIDs())
+	}))
+
+	countRows := func(table string) int {
+		var n int
+		require.NoError(t, s.WithDBRead(func(db *sql.DB) error {
+			return db.QueryRow(`select count(*) from ` + table).Scan(&n)
+		}))
+		return n
+	}
+
+	assert.Equal(t, 2, countRows("resources"),
+		"the two payloads genuinely differed, so two resource rows is correct")
+	assert.Equal(t, 1, countRows("metric_series"),
+		"enriching a resource must not mint a second series for the same instance")
+
+	summaries := searchMetricsAll(t, s, ctx)
+	require.Len(t, summaries, 1)
+	assert.Equal(t, float64(1), summaries[0]["seriesCount"],
+		"the summary must agree that this is one series")
+
+	streamID, ok := summaries[0]["id"].(string)
+	require.True(t, ok)
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return metrics.GetMetric(ctx, db, streamID, 0, time.Now().UnixNano()+int64(time.Hour), 0)
+	})
+	require.NoError(t, err)
+	var metric map[string]any
+	require.NoError(t, json.Unmarshal(raw, &metric))
+
+	ts, _ := metric["timeseries"].([]any)
+	require.Len(t, ts, 1, "one line on the chart, not two")
+	dps, _ := ts[0].(map[string]any)["datapoints"].([]any)
+	assert.Len(t, dps, 6, "both batches land on the same line")
+}

--- a/desktopexporter/internal/store/metrics/metrics_test.go
+++ b/desktopexporter/internal/store/metrics/metrics_test.go
@@ -1693,16 +1693,25 @@ func TestMetricSearch_DatapointAndExemplarLabels(t *testing.T) {
 // host.name and k8s.pod.name on the *resource*, which made this the common
 // shape in any replicated deployment rather than an exotic one. Prometheus
 // would show two series here; we showed one, silently averaging two machines.
+//
+// What tells the replicas apart is service.instance.id -- the only field the
+// OTel spec actually commits to as resource identity (see ingest.ResourceID).
+// host.name differing too is realistic flavor, not what does the work here;
+// TestMetricSeries_ResourceOnlyDiffersByHostNameCollapses below pins that
+// host.name alone, without service.instance.id, would NOT split these into
+// two series.
 func buildTwoReplicaMetrics(t *testing.T) pmetric.Metrics {
 	t.Helper()
 	md := pmetric.NewMetrics()
 	base := time.Now().UnixNano()
 
-	// Same service, same scope, same metric, same datapoint labels. The only
-	// difference is host.name on the resource.
+	// Same service, same scope, same metric, same datapoint labels. The
+	// resources differ by service.instance.id -- the identifying field -- and,
+	// incidentally, by host.name too.
 	for i, host := range []string{"pod-a", "pod-b"} {
 		rm := md.ResourceMetrics().AppendEmpty()
 		rm.Resource().Attributes().PutStr("service.name", "checkout")
+		rm.Resource().Attributes().PutStr("service.instance.id", "checkout-"+host)
 		rm.Resource().Attributes().PutStr("host.name", host)
 
 		sm := rm.ScopeMetrics().AppendEmpty()
@@ -1723,6 +1732,11 @@ func buildTwoReplicaMetrics(t *testing.T) pmetric.Metrics {
 	return md
 }
 
+// TestMetricSeries_SplitByResource is also the regression test for the
+// property Change A must not break: two genuinely different instances --
+// same service.name, distinct service.instance.id -- still get two resource
+// rows and two series. Collapsing replicas that actually identified
+// themselves would be a worse bug than the one this whole change fixes.
 func TestMetricSeries_SplitByResource(t *testing.T) {
 	s, ctx, teardown := setupStore(t)
 	defer teardown()
@@ -1730,6 +1744,16 @@ func TestMetricSeries_SplitByResource(t *testing.T) {
 	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
 		return metrics.Ingest(ctx, conn, buildTwoReplicaMetrics(t), s.FlushedIDs())
 	}))
+
+	countRows := func(table string) int {
+		var n int
+		require.NoError(t, s.WithDBRead(func(db *sql.DB) error {
+			return db.QueryRow(`select count(*) from ` + table).Scan(&n)
+		}))
+		return n
+	}
+	assert.Equal(t, 2, countRows("resources"),
+		"distinct service.instance.id must produce distinct resource rows")
 
 	// One logical stream: that part is correct and must stay correct, or a pod
 	// restart would fragment the timeseries.
@@ -1767,6 +1791,61 @@ func TestMetricSeries_SplitByResource(t *testing.T) {
 	// single merged line it replaced.
 	assert.Len(t, keys, 2,
 		"series keys must differ, or the split produces two identical legend entries")
+}
+
+// TestMetricSeries_ResourceOnlyDiffersByHostNameCollapses is the inverse of
+// TestMetricSeries_SplitByResource: two resources that differ only by
+// host.name, with no service.instance.id at all, must collapse onto one
+// series. host.name (and k8s.pod.name) used to be a fallback identity --
+// InstanceKey walked a list of stand-ins when service.instance.id was absent
+// -- but the OTel spec sanctions only service.instance.id for this, so that
+// fallback is gone. Absent means absent: the telemetry never claimed these
+// were different instances, so we do not either.
+func TestMetricSeries_ResourceOnlyDiffersByHostNameCollapses(t *testing.T) {
+	s, ctx, teardown := setupStore(t)
+	defer teardown()
+
+	md := pmetric.NewMetrics()
+	base := time.Now().UnixNano()
+	for i, host := range []string{"pod-a", "pod-b"} {
+		rm := md.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("service.name", "checkout")
+		rm.Resource().Attributes().PutStr("host.name", host)
+
+		sm := rm.ScopeMetrics().AppendEmpty()
+		sm.Scope().SetName("otelhttp")
+		sm.Scope().SetVersion("1.2.0")
+
+		m := sm.Metrics().AppendEmpty()
+		m.SetName("http.server.duration")
+		m.SetUnit("ms")
+		g := m.SetEmptyGauge()
+		for j := 0; j < 3; j++ {
+			dp := g.DataPoints().AppendEmpty()
+			dp.SetTimestamp(pcommon.Timestamp(base + int64(j)*1_000_000))
+			dp.SetDoubleValue(float64(10*(i+1) + j))
+			dp.Attributes().PutStr("http.route", "/checkout")
+		}
+	}
+
+	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
+		return metrics.Ingest(ctx, conn, md, s.FlushedIDs())
+	}))
+
+	countRows := func(table string) int {
+		var n int
+		require.NoError(t, s.WithDBRead(func(db *sql.DB) error {
+			return db.QueryRow(`select count(*) from ` + table).Scan(&n)
+		}))
+		return n
+	}
+	assert.Equal(t, 1, countRows("resources"),
+		"host.name alone, without service.instance.id, must not fragment the resource")
+
+	summaries := searchMetricsAll(t, s, ctx)
+	require.Len(t, summaries, 1)
+	assert.Equal(t, float64(1), summaries[0]["seriesCount"],
+		"neither replica identified itself, so they legitimately collapse to one series")
 }
 
 // A series id has to survive re-ingest, restarts and retention, because it is
@@ -1866,19 +1945,26 @@ func buildInstanceMetrics(t *testing.T, extra map[string]string, base int64) pme
 }
 
 // TestMetricSeries_SurvivesResourceEnrichment is the regression test for a
-// series splitting when nothing about the series changed.
+// series -- and, as of Change A, a resource -- splitting when nothing about
+// the instance changed.
 //
-// A resource id is a hash of the resource's whole attribute set, so when
-// something enriches a resource mid-stream the resource id changes. While the
-// series id was derived from that, one instrument from one instance drew two
-// chart lines, split at the moment the extra attributes appeared, and a
-// ?series= link addressed only half of it. Observed in the reference capture:
-// 48 resource rows for 35 distinct service.instance.id, telemetry.sdk.* present
-// on 35 and absent from 13.
+// A resource id used to be a hash of the resource's whole attribute set, so
+// enriching a resource mid-stream (an SDK adding telemetry.sdk.* partway
+// through, say) minted a second resource row for the same running process,
+// and because the series id was derived from that resource row, a second
+// series too: one instrument from one instance drew two chart lines, split at
+// the moment the extra attributes appeared, and a ?series= link addressed
+// only half of it. Observed in the reference capture: 48 resource rows for 35
+// distinct service.instance.id, telemetry.sdk.* present on 35 and absent from
+// 13.
 //
-// Two resource rows is the correct outcome and is asserted deliberately: the
-// payloads really did differ, and being able to see that is information. What
-// must not change is the series.
+// Resource identity is now the OTel triplet read from attributes (see
+// ingest.ResourceID), and both payloads here share the same
+// service.instance.id -- so enrichment no longer mints a resource either: one
+// row, one series. That is the whole point of Change A, and is why this test
+// now asserts ONE resources row rather than two: the earlier version of this
+// test asserted two as the "correct" half of the split, back when a resource
+// id still carried the attribute set as identity. It no longer does.
 func TestMetricSeries_SurvivesResourceEnrichment(t *testing.T) {
 	s, ctx, teardown := setupStore(t)
 	defer teardown()
@@ -1903,8 +1989,8 @@ func TestMetricSeries_SurvivesResourceEnrichment(t *testing.T) {
 		return n
 	}
 
-	assert.Equal(t, 2, countRows("resources"),
-		"the two payloads genuinely differed, so two resource rows is correct")
+	assert.Equal(t, 1, countRows("resources"),
+		"same service.instance.id: enrichment must not mint a second resource row")
 	assert.Equal(t, 1, countRows("metric_series"),
 		"enriching a resource must not mint a second series for the same instance")
 

--- a/desktopexporter/internal/store/queries/ddl/tables/logs.sql
+++ b/desktopexporter/internal/store/queries/ddl/tables/logs.sql
@@ -16,6 +16,23 @@ create table if not exists logs (
 		event_name varchar,
 		-- See the matching service_name column on spans for rationale.
 		service_name varchar not null default '',
+		-- OTLP carries a schema_url on the *batch* wrapper (ResourceSpans /
+		-- ScopeSpans and their metric and log twins), not on the Resource or
+		-- InstrumentationScope messages -- neither of which has the field at
+		-- all. It names the semantic-convention version the batch's attributes
+		-- follow, e.g. https://opentelemetry.io/schemas/1.27.0.
+		--
+		-- Stored per row rather than on resources/scopes precisely because it
+		-- is batch-level: the same scope emitted through two pipelines that
+		-- stamp different schema urls is still one scope, so putting it in
+		-- scope identity would split it. Repeated varchars are what DuckDB's
+		-- dictionary encoding handles well, so the duplication is close to
+		-- free.
+		--
+		-- NOT NULL with empty-string default: the field is optional in OTLP,
+		-- and the appender takes a plain string more happily than a nullable.
+		resource_schema_url varchar not null default '',
+		scope_schema_url varchar not null default '',
 		foreign key (resource_id) references resources(id),
 		foreign key (scope_id) references scopes(id)
 	)

--- a/desktopexporter/internal/store/queries/ddl/tables/metric_ingests.sql
+++ b/desktopexporter/internal/store/queries/ddl/tables/metric_ingests.sql
@@ -10,6 +10,23 @@ create table if not exists metric_ingests (
 		description varchar,
 		resource_id uuid not null,
 		scope_id uuid not null,
+		-- OTLP carries a schema_url on the *batch* wrapper (ResourceSpans /
+		-- ScopeSpans and their metric and log twins), not on the Resource or
+		-- InstrumentationScope messages -- neither of which has the field at
+		-- all. It names the semantic-convention version the batch's attributes
+		-- follow, e.g. https://opentelemetry.io/schemas/1.27.0.
+		--
+		-- Stored per row rather than on resources/scopes precisely because it
+		-- is batch-level: the same scope emitted through two pipelines that
+		-- stamp different schema urls is still one scope, so putting it in
+		-- scope identity would split it. Repeated varchars are what DuckDB's
+		-- dictionary encoding handles well, so the duplication is close to
+		-- free.
+		--
+		-- NOT NULL with empty-string default: the field is optional in OTLP,
+		-- and the appender takes a plain string more happily than a nullable.
+		resource_schema_url varchar not null default '',
+		scope_schema_url varchar not null default '',
 		foreign key (stream_id) references metric_streams(id),
 		foreign key (resource_id) references resources(id),
 		foreign key (scope_id) references scopes(id)

--- a/desktopexporter/internal/store/queries/ddl/tables/resources.sql
+++ b/desktopexporter/internal/store/queries/ddl/tables/resources.sql
@@ -1,8 +1,15 @@
--- id = sha256(attribute_ids, dropped_attributes_count).
+-- id = sha256(service.namespace, service.name, service.instance.id), read
+-- from the resource's own attributes -- the identifying triplet the OTel
+-- Resource SDK spec commits to, not this row's attribute_ids. A missing
+-- attribute contributes an empty string rather than a substitute: a resource
+-- that omits service.instance.id shares this row with every other instance
+-- of the same service, because nothing in the telemetry distinguished them.
 --
--- dropped_attributes_count is part of identity, so a resource with the same
--- attributes but a different dropped count is a separate row. Correct, but
--- note an exporter that varies its dropped count fragments the dedupe.
+-- attribute_ids and dropped_attributes_count are stored but carry no
+-- identity weight: `insert ... on conflict (id) do nothing` means this row
+-- keeps whichever attribute set and dropped count this resource id was first
+-- seen with, even though later batches for the same instance may enrich it
+-- further.
 create table if not exists resources (
 		id uuid primary key,
 		seq integer not null default nextval('resource_seq'),

--- a/desktopexporter/internal/store/queries/ddl/tables/spans.sql
+++ b/desktopexporter/internal/store/queries/ddl/tables/spans.sql
@@ -30,6 +30,23 @@ create table if not exists spans (
 		-- happier with a plain string column than with nullable typed
 		-- pointers, which it doesn't accept directly.
 		service_name varchar not null default '',
+		-- OTLP carries a schema_url on the *batch* wrapper (ResourceSpans /
+		-- ScopeSpans and their metric and log twins), not on the Resource or
+		-- InstrumentationScope messages -- neither of which has the field at
+		-- all. It names the semantic-convention version the batch's attributes
+		-- follow, e.g. https://opentelemetry.io/schemas/1.27.0.
+		--
+		-- Stored per row rather than on resources/scopes precisely because it
+		-- is batch-level: the same scope emitted through two pipelines that
+		-- stamp different schema urls is still one scope, so putting it in
+		-- scope identity would split it. Repeated varchars are what DuckDB's
+		-- dictionary encoding handles well, so the duplication is close to
+		-- free.
+		--
+		-- NOT NULL with empty-string default: the field is optional in OTLP,
+		-- and the appender takes a plain string more happily than a nullable.
+		resource_schema_url varchar not null default '',
+		scope_schema_url varchar not null default '',
 		foreign key (resource_id) references resources(id),
 		foreign key (scope_id) references scopes(id)
 	)

--- a/desktopexporter/internal/store/queries/metrics/get_metric.sql
+++ b/desktopexporter/internal/store/queries/metrics/get_metric.sql
@@ -21,18 +21,18 @@
 		-- Datapoints inherit aggregation_temporality / is_monotonic from
 		-- the stream so the per-type JSON projection below doesn't need
 		-- a per-row join.
-		-- resource_id joins in so a series can be split by the resource that
-		-- emitted it. A join rather than a denormalized column on datapoints:
-		-- it is a primary-key lookup from metric_ingest_id, and datapoints is
-		-- the largest table in the store.
+		-- resource_id rides along for the per-batch resource of each datapoint.
+		-- It is NOT what groups a series: `resources` is content-addressed, so
+		-- one instance that gets enriched mid-stream owns several rows there,
+		-- and grouping on it split a single series across them. A join rather
+		-- than a denormalized column on datapoints: it is a primary-key lookup
+		-- from metric_ingest_id, and datapoints is the largest table here.
 		filtered_dps as (
 			select d.*,
-				mi.resource_id as resource_id,
 				s.metric_type as metric_type,
 				s.aggregation_temporality as aggregation_temporality,
 				s.is_monotonic as is_monotonic
 			from datapoints d, input, stream s
-			join metric_ingests mi on mi.id = d.metric_ingest_id
 			where d.stream_id = input.stream_id
 			  and d.timestamp >= input.time_start and d.timestamp <= input.time_end
 		),
@@ -99,7 +99,7 @@
 		-- attributes_sample picks any one datapoint's attributes from
 		-- this timeseries. Within a timeseries they're identical by
 		-- construction -- series_id is content-derived from (stream,
-		-- resource, attribute_ids), so the array cannot vary inside a group.
+		-- instance, attribute_ids), so the array cannot vary inside a group.
 		--
 		-- any_value wraps the *array*, not the resolved JSON. Written the
 		-- other way round the macro sits inside the aggregate, so it runs once
@@ -264,7 +264,6 @@
 		hist_merged as (
 			select
 				p.series_id,
-				p.resource_id,
 				p.bucket_start,
 				-- A real datapoint id, not a synthetic one: the last of the
 				-- bucket. Keeps ?dp= links and datapoint selection working
@@ -331,7 +330,7 @@
 					)
 				end as negative_bucket_counts
 			from hist_padded p
-			group by p.series_id, p.resource_id, p.bucket_start
+			group by p.series_id, p.bucket_start
 		),
 
 		-- What the projection reads. Merging replaces a bucket's datapoints
@@ -346,7 +345,7 @@
 			where (select kind from reduction_kind) <> 'merge'
 			union all by name
 			select
-				m.id, m.series_id, m.resource_id, m.timestamp, m.start_time,
+				m.id, m.series_id, m.timestamp, m.start_time,
 				m.metric_type, m.aggregation_temporality, m.flags,
 				m.count, m.sum,
 				-- Bucket-derived, because a merge cannot carry min and max
@@ -381,12 +380,19 @@
 		ts_dps_agg as (
 			select
 				d.series_id,
-				d.resource_id,
-				-- The series id is the key. It is content-derived from
-				-- (stream, resource, labels), so it distinguishes replicas
-				-- whose labels are identical, and it is stable across restarts
-				-- -- which is what makes it safe in a URL, unlike a datapoint
-				-- id that retention eventually deletes.
+				-- The series id is the key, and the only key. It is
+				-- content-derived from (stream, instance, labels), so it
+				-- distinguishes replicas whose labels are identical, and it is
+				-- stable across restarts -- which is what makes it safe in a
+				-- URL, unlike a datapoint id that retention eventually deletes.
+				--
+				-- Deliberately NOT grouped alongside the ingest's resource_id,
+				-- as it once was. A resource is content-addressed, so enriching
+				-- one mid-stream mints a second resources row for the same
+				-- instance, and grouping by it split one series into two chart
+				-- lines even after the series id itself stopped splitting. The
+				-- resource shown comes from metric_series, which holds exactly
+				-- one per series.
 				d.series_id::varchar as attrs_key,
 				attrs_json(any_value(d.attribute_ids)) as attributes_sample,
 				max(d.timestamp) as latest_ts,
@@ -466,7 +472,7 @@
 		-- by the array against 0.9ms by a single uuid.
 		from projected_dps d
 			left join retained_ids r on r.id = d.id
-			group by d.series_id, d.resource_id
+			group by d.series_id
 		),
 		-- Pack each timeseries into the wire shape and order them so
 		-- the most recently active timeseries sorts first -- mirrors
@@ -512,7 +518,8 @@
 			-- order is now total and deterministic.
 			) order by t.latest_ts desc, t.attrs_key)) as timeseries
 			from ts_dps_agg t
-			join resources r on r.id = t.resource_id
+			join metric_series ms on ms.id = t.series_id
+			join resources r on r.id = ms.resource_id
 		)
 		-- Left join: a stream with no datapoints in the window still
 		-- produces a row (empty timeseries, blank representative fields).

--- a/desktopexporter/internal/store/retention.go
+++ b/desktopexporter/internal/store/retention.go
@@ -93,14 +93,22 @@ func (s *Store) EnforceRetention(ctx context.Context, maxBytes int64) error {
 		return nil
 	}
 
-	// Sweep before the first measurement. Orphaned dictionary rows count
-	// toward the size the cap is compared against, so garbage left by a Clear
-	// or a delete-by-id must never be what tips the store over and triggers
-	// pruning of real telemetry.
-	if err := s.WithDBWrite(func(db *sql.DB) error {
-		return ingest.SweepOrphans(ctx, db, s.flushed)
-	}); err != nil {
+	// Orphaned dictionary rows count toward the size the cap is compared
+	// against, so garbage left by a Clear or a delete-by-id must never be what
+	// tips the store over and triggers pruning of real telemetry. That requires
+	// sweeping before any prune -- but not before the measurement that decides
+	// whether to prune at all.
+	//
+	// This used to sweep unconditionally, which meant a store sitting at 1% of
+	// its cap still ran three anti-joins and dropped the dictionary cache every
+	// 30 seconds, under the write lock, to protect against a prune that was
+	// never going to happen.
+	fits, err := s.sweepIfOverCap(ctx, maxBytes)
+	if err != nil {
 		return err
+	}
+	if fits {
+		return nil
 	}
 
 	for round := 0; round < maxPruneRounds; round++ {
@@ -113,6 +121,45 @@ func (s *Store) EnforceRetention(ctx context.Context, maxBytes int64) error {
 		}
 	}
 	return nil
+}
+
+// sweepIfOverCap measures the store and, only if it exceeds maxBytes, collects
+// orphans and measures again. It reports whether the store fits, in which case
+// no pruning is needed.
+//
+// The re-measurement is what preserves the guarantee: if the excess was garbage
+// all along, the sweep alone brings the store back under and this returns true,
+// so no telemetry is pruned. Sweeping and re-measuring costs a checkpoint, but
+// only on the path where something is actually over the cap.
+func (s *Store) sweepIfOverCap(ctx context.Context, maxBytes int64) (bool, error) {
+	fits := false
+	err := s.WithDBWrite(func(db *sql.DB) error {
+		size, err := s.sizeBytes(ctx, db)
+		if err != nil {
+			return err
+		}
+		if size <= maxBytes {
+			fits = true
+			return nil
+		}
+
+		if err := ingest.SweepOrphans(ctx, db, s.flushed); err != nil {
+			return err
+		}
+		// Without a checkpoint the deletes do not move the measurement, so the
+		// re-measure below would report the pre-sweep size and prune anyway.
+		if _, err := db.ExecContext(ctx, `checkpoint`); err != nil {
+			return fmt.Errorf("EnforceRetention: %w: %w", ErrRetentionInternal, err)
+		}
+
+		size, err = s.sizeBytes(ctx, db)
+		if err != nil {
+			return err
+		}
+		fits = size <= maxBytes
+		return nil
+	})
+	return fits, err
 }
 
 // enforceRound runs one measure-prune-checkpoint round under the write lock.

--- a/desktopexporter/internal/store/retention_test.go
+++ b/desktopexporter/internal/store/retention_test.go
@@ -240,3 +240,59 @@ func TestEnforceRetentionUnderCap(t *testing.T) {
 	require.NoError(t, s.EnforceRetention(ctx, 1<<40 /* 1 TB */))
 	assert.Equal(t, int64(1000), count(t, s, "spans"), "store under the cap must not be pruned")
 }
+
+// TestSweepIfOverCapCollectsGarbage pins the guarantee sweepIfOverCap exists
+// for: orphaned dictionary rows count toward the size the cap is compared
+// against, so when the store is over, the orphans are collected *before* any
+// prune decision is taken. Otherwise retention deletes real telemetry to make
+// room for rows nothing references -- the garbage survives and the data does
+// not.
+//
+// Asserting on the resulting size would not catch a regression here, because
+// pruning also shrinks the store. Asserting that the live spans survived does.
+func TestSweepIfOverCapCollectsGarbage(t *testing.T) {
+	ctx := context.Background()
+	s, err := NewStore(ctx, "", zap.NewNop())
+	require.NoError(t, err)
+	defer s.Close()
+
+	const total, keep = 4000, 200
+	seedSpans(t, s, total)
+	_, err = s.db.Exec(`delete from spans where start_time >= ?`, int64(keep)*1000000)
+	require.NoError(t, err)
+	require.Equal(t, int64(total), count(t, s, "attributes"),
+		"the orphans must still be present, or this test proves nothing")
+
+	size, err := s.SizeBytes(ctx)
+	require.NoError(t, err)
+
+	_, err = s.sweepIfOverCap(ctx, size-1)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(keep), count(t, s, "attributes"),
+		"orphaned dictionary rows should have been collected before any prune")
+	assert.Equal(t, int64(keep), count(t, s, "spans"),
+		"sweeping must not touch live telemetry")
+}
+
+// TestSweepIfOverCapSkipsSweepUnderCap is the other half, and the behaviour
+// change: a store comfortably inside its cap does no work at all. It used to
+// sweep unconditionally on every retention tick, which also dropped the
+// dictionary cache every 30 seconds for no reason.
+func TestSweepIfOverCapSkipsSweepUnderCap(t *testing.T) {
+	ctx := context.Background()
+	s, err := NewStore(ctx, "", zap.NewNop())
+	require.NoError(t, err)
+	defer s.Close()
+
+	const total, keep = 1000, 100
+	seedSpans(t, s, total)
+	_, err = s.db.Exec(`delete from spans where start_time >= ?`, int64(keep)*1000000)
+	require.NoError(t, err)
+
+	fits, err := s.sweepIfOverCap(ctx, 1<<40 /* 1 TB */)
+	require.NoError(t, err)
+	assert.True(t, fits, "a store far under its cap must report that it fits")
+	assert.Equal(t, int64(total), count(t, s, "attributes"),
+		"under the cap there is nothing to protect against, so the sweep must not run")
+}

--- a/desktopexporter/internal/store/schema/version.go
+++ b/desktopexporter/internal/store/schema/version.go
@@ -33,9 +33,23 @@ package schema
 // exists to turn into a clear message, so a new column on an existing table
 // bumps it even though a new table or a new index does not.
 //
+// Version 4 changes what a resource id means, not the resources table's
+// columns. It used to be sha256(attribute_ids, dropped_attributes_count) --
+// the resource's whole attribute set -- which meant anything that enriched a
+// resource mid-stream (a processor resolving k8s metadata, an SDK adding
+// telemetry.sdk.* partway through) minted a new row for the same running
+// process; metrics.SeriesID then worked around the resulting instability by
+// keying series on InstanceKey instead of the resource id. It is now
+// sha256(service.namespace, service.name, service.instance.id) -- the OTel
+// triplet the spec actually commits to as identity -- so InstanceKey is gone
+// and SeriesID takes the resource id again. Existing resource rows, and every
+// metric_series row hashed from them, were keyed by the old function: this
+// build would compute different ids for the same resources, so a version 3
+// file's rows are unreadable under the new identity, not merely stale.
+//
 // Files written before versioning existed carry no stamp at all and are
 // detected separately.
-const Version = 3
+const Version = 4
 
 // VersionTableQuery creates the version table.
 //

--- a/desktopexporter/internal/store/schema/version.go
+++ b/desktopexporter/internal/store/schema/version.go
@@ -25,9 +25,17 @@ package schema
 // exist -- so the bump is what stops that being discovered as an appender
 // column-count error midway through an ingest.
 //
+// Version 3 adds resource_schema_url and scope_schema_url to spans, logs and
+// metric_ingests. Additive in the loose sense, but `create table if not exists`
+// does not alter a table that already exists: a version 2 file keeps its
+// narrower spans table and the first ingest fails with "invalid column count:
+// expected 16, got 18". That is precisely the opaque failure this constant
+// exists to turn into a clear message, so a new column on an existing table
+// bumps it even though a new table or a new index does not.
+//
 // Files written before versioning existed carry no stamp at all and are
 // detected separately.
-const Version = 2
+const Version = 3
 
 // VersionTableQuery creates the version table.
 //

--- a/desktopexporter/internal/store/spans/spans.go
+++ b/desktopexporter/internal/store/spans/spans.go
@@ -186,6 +186,8 @@ func Ingest(ctx context.Context, conn driver.Conn, traces ptrace.Traces, flushed
 					span.Status().Code().String(), // StatusCode VARCHAR
 					span.Status().Message(),       // StatusMessage VARCHAR
 					serviceName,                   // ServiceName VARCHAR (NOT NULL, '' = unknown)
+					resourceSpan.SchemaUrl(),      // ResourceSchemaURL VARCHAR (batch-level)
+					scopeSpan.SchemaUrl(),         // ScopeSchemaURL VARCHAR (batch-level)
 				)
 				if err != nil {
 					return fmt.Errorf("Ingest: %w: %w", ErrSpansStoreInternal, err)

--- a/desktopexporter/internal/store/spans/spans_test.go
+++ b/desktopexporter/internal/store/spans/spans_test.go
@@ -1670,3 +1670,43 @@ func TestSpans_ServiceNameDenormStaysConsistent(t *testing.T) {
 		"every span must resolve to a resource row, or the check above passes vacuously")
 	assert.Greater(t, joined, 0)
 }
+
+// TestSchemaURLsAreStored pins that the batch-level schema urls survive ingest.
+//
+// They live on the OTLP wrappers -- ResourceSpans.SchemaUrl and
+// ScopeSpans.SchemaUrl -- and NOT on the Resource or InstrumentationScope
+// messages, neither of which has the field. That is why they are columns on
+// spans rather than part of resource or scope identity: the same scope emitted
+// through two pipelines stamping different urls is still one scope.
+func TestSchemaURLsAreStored(t *testing.T) {
+	s, ctx, teardown := setupStore(t)
+	defer teardown()
+
+	const resURL = "https://opentelemetry.io/schemas/1.27.0"
+	const scopeURL = "https://opentelemetry.io/schemas/1.24.0"
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.SetSchemaUrl(resURL)
+	rs.Resource().Attributes().PutStr("service.name", "checkout")
+	ss := rs.ScopeSpans().AppendEmpty()
+	ss.SetSchemaUrl(scopeURL)
+	ss.Scope().SetName("otelhttp")
+	span := ss.Spans().AppendEmpty()
+	span.SetName("GET /checkout")
+	span.SetTraceID(pcommon.TraceID([16]byte{1}))
+	span.SetSpanID(pcommon.SpanID([8]byte{2}))
+
+	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
+		return spans.Ingest(ctx, conn, traces, s.FlushedIDs())
+	}))
+
+	var gotRes, gotScope string
+	require.NoError(t, s.WithDBRead(func(db *sql.DB) error {
+		return db.QueryRow(
+			`select resource_schema_url, scope_schema_url from spans`,
+		).Scan(&gotRes, &gotScope)
+	}))
+	assert.Equal(t, resURL, gotRes, "the resource schema url must survive ingest")
+	assert.Equal(t, scopeURL, gotScope, "the scope schema url must survive ingest")
+}

--- a/desktopexporter/internal/store/store.go
+++ b/desktopexporter/internal/store/store.go
@@ -46,8 +46,11 @@ type Store struct {
 	// flushed records which dictionary rows this store has already written, so
 	// a batch whose attributes, resource and scope are all known can skip its
 	// insert. Owned here because the set describes one database: sharing it
-	// across stores would skip inserts into the wrong one. Invalidated by
-	// ingest.SweepOrphans, the only thing that deletes dictionary rows.
+	// across stores would skip inserts into the wrong one. Warmed from disk in
+	// NewStore via ingest.LoadFlushedIDs, so a persistent --db that already
+	// holds the dictionary does not re-insert everything until the cache
+	// refills. Invalidated by ingest.SweepOrphans, the only thing that deletes
+	// dictionary rows.
 	flushed *ingest.FlushedIDs
 
 	// retentionCapBytes is the store size cap enforced by EnforceRetention
@@ -151,13 +154,25 @@ func NewStore(ctx context.Context, dbPath string, logger *zap.Logger) (*Store, e
 		}
 	}
 
+	// 6) Warm the dictionary flush cache from whatever is already on disk.
+	// Without this, a persistent --db reopened with its dictionary intact
+	// would still re-insert every attribute, resource and scope until enough
+	// batches had flushed to refill an empty in-process cache -- exactly the
+	// fixed per-batch cost FlushedIDs exists to remove, paid again on every
+	// restart. Loads every id ever stored, which is bounded the same way the
+	// on-disk dictionary itself is: by retention.
+	flushed, err := ingest.LoadFlushedIDs(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("%w while warming the dictionary flush cache: %w", ErrStoreInitFailed, err)
+	}
+
 	return &Store{
 		db:           db,
 		conn:         conn,
 		dbPath:       dbPath,
 		logger:       logger,
 		schemaCompat: schemaCompat,
-		flushed:      ingest.NewFlushedIDs(),
+		flushed:      flushed,
 	}, nil
 }
 

--- a/desktopexporter/internal/store/util/uuid_binding_canary_test.go
+++ b/desktopexporter/internal/store/util/uuid_binding_canary_test.go
@@ -70,3 +70,33 @@ func TestDriverStillCannotBindUUIDLists(t *testing.T) {
 		assert.Equal(t, 1, n, "the shipped form must match the stored row")
 	})
 }
+
+// The read-side twin of the test above, and the reason every query that hands
+// a uuid back to Go writes `id::varchar` rather than `id`.
+//
+// Scanning a uuid column straight into a Go string does not error. It yields
+// the raw 16 bytes of the value, which is a perfectly valid Go string and
+// looks like plausible-if-mangled text -- so the failure surfaces somewhere far
+// away, as an id that matches nothing. The explicit cast is what makes DuckDB
+// format it as hex text.
+//
+// Pinned for the same reason as the binding limitation: it is a third-party
+// behaviour we route around, and it fails silently.
+func TestDriverStillReturnsRawBytesForUnscastUUIDs(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	defer db.Close()
+
+	const want = "11111111-2222-3333-4444-555555555555"
+
+	var raw string
+	require.NoError(t, db.QueryRow(`select ?::uuid`, want).Scan(&raw),
+		"scanning a uuid into a string still succeeds -- that is the hazard")
+	assert.NotEqual(t, want, raw,
+		"driver now returns formatted uuid text: drop the ::varchar casts on the read path")
+	assert.Len(t, raw, 16, "expected the raw 16 bytes rather than 36 characters of hex")
+
+	var cast string
+	require.NoError(t, db.QueryRow(`select (?::uuid)::varchar`, want).Scan(&cast))
+	assert.Equal(t, want, cast, "the explicit cast is what produces usable text")
+}


### PR DESCRIPTION
Storage-side identity and caching. Five commits, no wire changes.

## What changed

- **Resource identity is the OTel triplet, not a hash of every attribute** — `service.namespace,service.name,service.instance.id`, which the spec says MUST be globally unique. Hashing the whole attribute set meant anything enriching a resource mid-stream minted a new one: 48 resource rows for 35 distinct instances in the reference capture, with `telemetry.sdk.*` present on 35 and absent from 13. That instability propagated into `SeriesID`, so one instrument drew two chart lines split at the moment the attributes appeared. Fixes #347.
- **Absent means absent** — a missing field contributes an empty slot, not a substitute. Omit `service.instance.id` and every instance of that service shares a row, because the telemetry expressed no distinction. Slots are hashed positionally with length prefixes, so `service.name=x` can't collide with `service.namespace=x`.
- **Batch schema urls are stored** — `resource_schema_url` / `scope_schema_url` on spans, logs and metric_ingests. They ride on the OTLP wrappers, not on Resource or InstrumentationScope, so they're per-row rather than part of scope identity: one scope through two pipelines stamping different urls is still one scope.
- **Datapoint attribute ids derived once** — two walks each hashed every label set; the second now reads the first's output by position. ~212 ms and ~253 MB of garbage per capture, gone. Also deleted `datapointAttrIDs`, dead since an earlier fix.
- **Dictionary writes have fixed statement text** — parallel arrays and `unnest` instead of per-row `VALUES`, so the SQL no longer varies with batch size. Precondition for ever caching prepared statements.
- **Flush cache warms from disk and forgets precisely** — it was in-process and started empty, so reopening a persistent `--db` re-inserted a dictionary already there. `SweepOrphans` now uses `delete ... returning id` to drop only what it deleted, with a full `Forget()` fallback on any collection error.
- **Retention measures before sweeping** — a store inside its cap was running three anti-joins and dropping the whole flush cache every 30 seconds to protect against a prune that was never going to happen.

## Schema

Version 2 → 4. Version 3 adds the schema url columns (`create table if not exists` doesn't alter an existing table, so a v2 file dies with `invalid column count: expected 16, got 18`). Version 4 changes what a resource id *means*, so v3 rows are unreadable rather than stale.

## Notes

- Two replicas differing only by `host.name`, with no `service.instance.id`, now **merge** into one series. Direct consequence of absent-means-absent; pinned by a test.
- `ScopeID` deliberately unchanged — the API spec makes scope attributes identity-bearing, so content-addressing a scope is correct.
- The sweep costs ~14 ms on a 744 MB store, so gating it is hygiene, not a speedup. Measured, not assumed.

## Follow-ups

- **#344** attribute sets re-derived on every batch that repeats them
- **#314** ingest holds the write lock
- Statement reuse — text is now fixed, but the driver still prepares and closes per call
