### PR TITLE
Fold buckets under a merged zero threshold, and stop taking quantiles from empty ones

### DIFF
--- a/desktopexporter/internal/server/jsonrpc_handler.go
+++ b/desktopexporter/internal/server/jsonrpc_handler.go
@@ -307,7 +307,7 @@ func (h *JSONRPCHandler) getMetric(ctx context.Context, req *jsonrpc2.Request) (
 	// How many time buckets to reduce the window to. The client knows its
 	// chart width; the store cannot.
 	var targetBuckets int64
-	if len(params) == 4 {
+	if len(params) >= 4 {
 		targetBuckets, err = h.parseTimestampParam(params[3], "targetBuckets")
 		if err != nil {
 			return nil, err
@@ -317,8 +317,25 @@ func (h *JSONRPCHandler) getMetric(ctx context.Context, req *jsonrpc2.Request) (
 		}
 	}
 
+	// Which series to return. Absent or empty means all of them, which is what
+	// every caller predating this parameter sends.
+	var seriesIDs []string
+	if len(params) >= 5 && params[4] != nil {
+		raw, ok := params[4].([]any)
+		if !ok {
+			return nil, jsonrpc2.ErrInvalidParams
+		}
+		for _, v := range raw {
+			id, ok := v.(string)
+			if !ok {
+				return nil, jsonrpc2.ErrInvalidParams
+			}
+			seriesIDs = append(seriesIDs, id)
+		}
+	}
+
 	result, err := storeRead(h.store, func(db *sql.DB) (json.RawMessage, error) {
-		return metrics.GetMetric(ctx, db, streamID, startTime, endTime, targetBuckets)
+		return metrics.GetMetric(ctx, db, streamID, startTime, endTime, targetBuckets, seriesIDs)
 	})
 	if err != nil {
 		return nil, h.handleStoreError(err)

--- a/desktopexporter/internal/store/metrics/metrics.go
+++ b/desktopexporter/internal/store/metrics/metrics.go
@@ -761,7 +761,10 @@ func SearchSummaries(ctx context.Context, db *sql.DB, startTime, endTime int64, 
 // reduction, and the caller gets every datapoint. Reduction is opt-in because
 // it changes which datapoints exist in the response, and a caller that has not
 // asked for it should not have to discover that.
-func GetMetric(ctx context.Context, db *sql.DB, streamID string, startTime, endTime int64, targetBuckets int64) (json.RawMessage, error) {
+// seriesIDs narrows the response to those series; nil or empty returns every
+// series in the stream. The filter is applied before the reduction, so a
+// caller asking for two of ten series pays for two.
+func GetMetric(ctx context.Context, db *sql.DB, streamID string, startTime, endTime int64, targetBuckets int64, seriesIDs []string) (json.RawMessage, error) {
 	// Everything filters by stream_id.
 	// matched_ingests is "ingests for this stream that produced at least
 	// one datapoint in the time window." All identity columns the JSON
@@ -773,7 +776,10 @@ func GetMetric(ctx context.Context, db *sql.DB, streamID string, startTime, endT
 	}
 
 	var raw []byte
-	if err := db.QueryRowContext(ctx, query, streamID, startTime, endTime, targetBuckets).Scan(&raw); err != nil {
+	if seriesIDs == nil {
+		seriesIDs = []string{}
+	}
+	if err := db.QueryRowContext(ctx, query, streamID, startTime, endTime, targetBuckets, seriesIDs).Scan(&raw); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("GetMetric: %w", ErrStreamIDNotFound)
 		}

--- a/desktopexporter/internal/store/metrics/metrics_test.go
+++ b/desktopexporter/internal/store/metrics/metrics_test.go
@@ -2013,3 +2013,83 @@ func TestMetricSeries_SurvivesResourceEnrichment(t *testing.T) {
 	dps, _ := ts[0].(map[string]any)["datapoints"].([]any)
 	assert.Len(t, dps, 6, "both batches land on the same line")
 }
+
+// TestExpHistogramMerge_FoldsBucketsBelowMergedZeroThreshold is the first
+// end-to-end test of the server-side reduction path. Every other GetMetric call
+// in this package passes resolution 0, so the reduction machinery -- M4
+// election, the alignment chain, hist_merged -- was covered only by macro unit
+// tests and never run assembled. That is how the bug below survived.
+//
+// An exponential histogram's zero_threshold T declares that observations at or
+// below T live in zero_count rather than in a bucket. Merging datapoints with
+// different thresholds takes the larger, because the merged histogram cannot
+// claim to resolve values one of its inputs could not. The input with the
+// smaller threshold is then contributing buckets that fall entirely below the
+// merged threshold, and those counts have to move into zero_count -- otherwise
+// zero_threshold says one thing and the bucket array says another.
+//
+// Worked by hand at scale 0, where base = 2 and bucket i covers (2^i, 2^(i+1)]:
+//
+//	A: threshold 1, zeroCount 1, counts [5, 7] at offset 0
+//	B: threshold 4, zeroCount 2, counts [0, 0, 3] at offset 0
+//
+//	merged threshold = 4
+//	cutoff           = floor(log2(4) * 2^0) - 1 = 1
+//	summed counts    = [5, 7, 3] at offset 0
+//	folded           = buckets 0 and 1 = 5 + 7 = 12
+//	result           = [3] at offset 2, zeroCount 1 + 2 + 12 = 15
+func TestExpHistogramMerge_FoldsBucketsBelowMergedZeroThreshold(t *testing.T) {
+	s, ctx, teardown := setupStore(t)
+	defer teardown()
+
+	base := time.Now().Add(-time.Minute)
+	fixture := makeExpHistogramFixtureT("http.duration", pmetric.AggregationTemporalityDelta, []expHistTestDP{
+		{
+			timestamp: base, scale: 0,
+			zeroCount: 1, zeroThreshold: 1,
+			posOffset: 0, posCounts: []uint64{5, 7},
+			count: 13, sum: 40,
+		},
+		{
+			timestamp: base.Add(time.Millisecond), scale: 0,
+			zeroCount: 2, zeroThreshold: 4,
+			posOffset: 0, posCounts: []uint64{0, 0, 3},
+			count: 5, sum: 30,
+		},
+	})
+	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
+		return metrics.Ingest(ctx, conn, fixture, s.FlushedIDs())
+	}))
+
+	summaries := searchMetricsAll(t, s, ctx)
+	require.Len(t, summaries, 1)
+
+	// Resolution 1 puts both datapoints in a single bucket, which is what makes
+	// them merge at all.
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return metrics.GetMetric(ctx, db, summaries[0]["id"].(string), 0,
+			time.Now().UnixNano()+int64(time.Hour), 1)
+	})
+	require.NoError(t, err)
+	var metric map[string]any
+	require.NoError(t, json.Unmarshal(raw, &metric))
+
+	ts, _ := metric["timeseries"].([]any)
+	require.Len(t, ts, 1, "one series")
+	dps, _ := ts[0].(map[string]any)["datapoints"].([]any)
+	require.Len(t, dps, 1, "both datapoints merge into one")
+	dp := dps[0].(map[string]any)
+
+	assert.Equal(t, float64(4), dp["zeroThreshold"], "merged threshold is the larger of the two")
+	assert.Equal(t, float64(15), dp["zeroCount"],
+		"buckets below the merged threshold must be folded into zero_count")
+	assert.Equal(t, float64(2), dp["positiveBucketOffset"],
+		"the folded buckets are gone, so the array starts above the cutoff")
+
+	counts, _ := dp["positiveBucketCounts"].([]any)
+	require.Len(t, counts, 1)
+	assert.Equal(t, float64(3), counts[0], "only the bucket above the threshold survives")
+
+	// The whole point: no observation was invented or lost by moving counts.
+	assert.Equal(t, float64(18), dp["count"], "total observations conserved")
+}

--- a/desktopexporter/internal/store/metrics/metrics_test.go
+++ b/desktopexporter/internal/store/metrics/metrics_test.go
@@ -262,7 +262,7 @@ func getMetricFullByName(t *testing.T, s *store.Store, ctx context.Context, name
 	t.Helper()
 	id := findMetricID(t, s, ctx, name)
 	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
-		return metrics.GetMetric(ctx, db, id, 0, maxNano, 0)
+		return metrics.GetMetric(ctx, db, id, 0, maxNano, 0, nil)
 	})
 	require.NoError(t, err)
 	var m map[string]any
@@ -1766,7 +1766,7 @@ func TestMetricSeries_SplitByResource(t *testing.T) {
 	require.True(t, ok)
 
 	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
-		return metrics.GetMetric(ctx, db, streamID, 0, time.Now().UnixNano()+int64(time.Hour), 0)
+		return metrics.GetMetric(ctx, db, streamID, 0, time.Now().UnixNano()+int64(time.Hour), 0, nil)
 	})
 	require.NoError(t, err)
 	var metric map[string]any
@@ -1899,7 +1899,7 @@ func TestMetricSeries_IDsAreStableAcrossReingest(t *testing.T) {
 	require.Len(t, summaries, 1)
 	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
 		return metrics.GetMetric(ctx, db, summaries[0]["id"].(string), 0,
-			time.Now().UnixNano()+int64(time.Hour), 0)
+			time.Now().UnixNano()+int64(time.Hour), 0, nil)
 	})
 	require.NoError(t, err)
 	var metric map[string]any
@@ -2002,7 +2002,7 @@ func TestMetricSeries_SurvivesResourceEnrichment(t *testing.T) {
 	streamID, ok := summaries[0]["id"].(string)
 	require.True(t, ok)
 	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
-		return metrics.GetMetric(ctx, db, streamID, 0, time.Now().UnixNano()+int64(time.Hour), 0)
+		return metrics.GetMetric(ctx, db, streamID, 0, time.Now().UnixNano()+int64(time.Hour), 0, nil)
 	})
 	require.NoError(t, err)
 	var metric map[string]any
@@ -2068,7 +2068,7 @@ func TestExpHistogramMerge_FoldsBucketsBelowMergedZeroThreshold(t *testing.T) {
 	// them merge at all.
 	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
 		return metrics.GetMetric(ctx, db, summaries[0]["id"].(string), 0,
-			time.Now().UnixNano()+int64(time.Hour), 1)
+			time.Now().UnixNano()+int64(time.Hour), 1, nil)
 	})
 	require.NoError(t, err)
 	var metric map[string]any
@@ -2092,4 +2092,64 @@ func TestExpHistogramMerge_FoldsBucketsBelowMergedZeroThreshold(t *testing.T) {
 
 	// The whole point: no observation was invented or lost by moving counts.
 	assert.Equal(t, float64(18), dp["count"], "total observations conserved")
+}
+
+// TestGetMetric_SeriesFilter covers the parameter that makes server-side
+// cross-series aggregation possible: the caller names the series it wants and
+// the store narrows before the reduction, so asking for two of ten costs two.
+//
+// Empty means all, which is what every caller predating the parameter sends.
+func TestGetMetric_SeriesFilter(t *testing.T) {
+	s, ctx, teardown := setupStore(t)
+	defer teardown()
+
+	base := time.Now().Add(-time.Minute)
+	var dps []expHistTestDP
+	for si := 0; si < 3; si++ {
+		for j := 0; j < 4; j++ {
+			dps = append(dps, expHistTestDP{
+				timestamp: base.Add(time.Duration(j) * time.Second),
+				attrs:     map[string]string{"route": fmt.Sprintf("/r%d", si)},
+				scale:     0, zeroCount: 1, zeroThreshold: 1,
+				posOffset: 0, posCounts: []uint64{1, 2},
+				count: 4, sum: 10,
+			})
+		}
+	}
+	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
+		return metrics.Ingest(ctx, conn,
+			makeExpHistogramFixtureT("filter.me", pmetric.AggregationTemporalityDelta, dps),
+			s.FlushedIDs())
+	}))
+
+	summaries := searchMetricsAll(t, s, ctx)
+	require.Len(t, summaries, 1)
+	streamID := summaries[0]["id"].(string)
+	end := time.Now().UnixNano() + int64(time.Hour)
+
+	seriesKeys := func(ids []string) []string {
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return metrics.GetMetric(ctx, db, streamID, 0, end, 0, ids)
+		})
+		require.NoError(t, err)
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(raw, &m))
+		var out []string
+		for _, e := range m["timeseries"].([]any) {
+			out = append(out, e.(map[string]any)["attributesKey"].(string))
+		}
+		return out
+	}
+
+	all := seriesKeys(nil)
+	require.Len(t, all, 3, "nil returns every series")
+
+	assert.Equal(t, []string{all[1]}, seriesKeys([]string{all[1]}),
+		"asking for one series returns exactly that series")
+
+	got := seriesKeys([]string{all[0], all[2]})
+	assert.ElementsMatch(t, []string{all[0], all[2]}, got,
+		"asking for two returns exactly those two")
+
+	assert.Len(t, seriesKeys([]string{}), 3, "empty means all, not none")
 }

--- a/desktopexporter/internal/store/queries/ddl/macros/bucket_quantile_linear.sql
+++ b/desktopexporter/internal/store/queries/ddl/macros/bucket_quantile_linear.sql
@@ -28,7 +28,15 @@ create or replace macro bucket_quantile_linear(buckets, q) as (
 					chosen as (
 						select
 							params.target as target,
-							list_filter(with_acc.bs, lambda b: b.acc >= params.target)[1] as b
+							-- cnt > 0 first: a quantile is never *inside* an empty
+							-- bucket. For q > 0 this changes nothing, since an empty
+							-- bucket's running total equals its predecessor's and the
+							-- earlier bucket already satisfies the target. It matters
+							-- only at q = 0, where target is 0 and the leading zero
+							-- bucket that exp_buckets always emits would otherwise be
+							-- selected with cnt = 0 -- the 0/0 the interp kernels now
+							-- guard against.
+							list_filter(with_acc.bs, lambda b: b.cnt > 0 and b.acc >= params.target)[1] as b
 						from with_acc, params
 					)
 				select interp_linear(b.lo, b.hi, b.acc_prev, b.cnt, target) from chosen

--- a/desktopexporter/internal/store/queries/ddl/macros/bucket_quantile_loglin.sql
+++ b/desktopexporter/internal/store/queries/ddl/macros/bucket_quantile_loglin.sql
@@ -19,7 +19,15 @@ create or replace macro bucket_quantile_loglin(buckets, q) as (
 					chosen as (
 						select
 							params.target as target,
-							list_filter(with_acc.bs, lambda b: b.acc >= params.target)[1] as b
+							-- cnt > 0 first: a quantile is never *inside* an empty
+							-- bucket. For q > 0 this changes nothing, since an empty
+							-- bucket's running total equals its predecessor's and the
+							-- earlier bucket already satisfies the target. It matters
+							-- only at q = 0, where target is 0 and the leading zero
+							-- bucket that exp_buckets always emits would otherwise be
+							-- selected with cnt = 0 -- the 0/0 the interp kernels now
+							-- guard against.
+							list_filter(with_acc.bs, lambda b: b.cnt > 0 and b.acc >= params.target)[1] as b
 						from with_acc, params
 					)
 				select interp_loglin(b.lo, b.hi, b.acc_prev, b.cnt, target) from chosen

--- a/desktopexporter/internal/store/queries/ddl/macros/interp_linear.sql
+++ b/desktopexporter/internal/store/queries/ddl/macros/interp_linear.sql
@@ -1,5 +1,19 @@
 -- Interpolation kernels.
 -- interp_loglin falls back to linear when lo*hi <= 0 (zero endpoint or sign mismatch)
+--
+-- cnt = 0 returns lo rather than dividing. An empty bucket contains no
+-- observations, so there is no position within it to interpolate to, and the
+-- bucket's own lower edge is the only defensible answer.
+--
+-- This is reachable, not defensive: exp_buckets emits a zero bucket
+-- {lo: 0, hi: 0, cnt: 0} even when zero_count is 0, and at q = 0 the target is
+-- 0, so the running total of that empty leading bucket already satisfies
+-- acc >= target and it gets selected. Without the guard the expression is
+-- 0 + (0 - 0) * (0 - 0) / 0 -- a plain division by zero that surfaced as a NaN
+-- quantile, where the TypeScript implementation returned 0.
 create or replace macro interp_linear(lo, hi, acc_prev, cnt, target) as (
-		lo + (hi - lo) * (target - acc_prev) / cnt
+		case
+			when cnt is null or cnt = 0 then lo
+			else lo + (hi - lo) * (target - acc_prev) / cnt
+		end
 	)

--- a/desktopexporter/internal/store/queries/ddl/macros/interp_loglin.sql
+++ b/desktopexporter/internal/store/queries/ddl/macros/interp_loglin.sql
@@ -1,5 +1,16 @@
+-- Log-linear interpolation within a bucket, for exponential histograms whose
+-- bucket boundaries are geometric rather than evenly spaced.
+--
+-- cnt = 0 returns lo before anything else is evaluated: the exponential branch
+-- divides by cnt too (pow(hi/lo, (target - acc_prev) / cnt)), so deferring to
+-- interp_linear's guard would only cover half the cases. See interp_linear for
+-- why an empty bucket is reachable here at all.
+--
+-- Falls back to linear when lo * hi <= 0, i.e. a zero endpoint or a sign
+-- mismatch, because pow() cannot span zero.
 create or replace macro interp_loglin(lo, hi, acc_prev, cnt, target) as (
 		case
+			when cnt is null or cnt = 0 then lo
 			when lo = 0 or hi = 0 or sign(lo) <> sign(hi)
 				then interp_linear(lo, hi, acc_prev, cnt, target)
 			else lo * pow(hi / lo, (target - acc_prev) / cnt)

--- a/desktopexporter/internal/store/queries/metrics/get_metric.sql
+++ b/desktopexporter/internal/store/queries/metrics/get_metric.sql
@@ -3,7 +3,14 @@
 			select ?::uuid as stream_id,
 				?::bigint as time_start,
 				?::bigint as time_end,
-				?::bigint as target_buckets
+				?::bigint as target_buckets,
+				-- Which series the caller cares about. Empty means all of them,
+				-- which is the unfiltered behaviour every existing caller gets.
+				--
+				-- Bound as varchar[] and cast in SQL rather than as a uuid list:
+				-- the driver corrupts a bound []duckdb.UUID silently, matching
+				-- nothing (see the uuid_binding canary in store/util).
+				?::varchar[] as series_ids
 		),
 		stream as (
 			select s.* from metric_streams s, input
@@ -35,6 +42,11 @@
 			from datapoints d, input, stream s
 			where d.stream_id = input.stream_id
 			  and d.timestamp >= input.time_start and d.timestamp <= input.time_end
+			  -- Narrowing here rather than after the merge: the reduction and
+			  -- every alignment stage downstream then run over only the series
+			  -- asked for, instead of merging series the caller will discard.
+			  and (len(input.series_ids) = 0
+			       or list_contains(input.series_ids, d.series_id::varchar))
 		),
 		-- The dp_attrs_agg and exemplar_attrs CTEs are gone: attrs_json
 		-- resolves each row's id array in place, so there is nothing to

--- a/desktopexporter/internal/store/queries/metrics/get_metric.sql
+++ b/desktopexporter/internal/store/queries/metrics/get_metric.sql
@@ -333,6 +333,47 @@
 			group by p.series_id, p.bucket_start
 		),
 
+		-- Reconcile the merged zero threshold with the merged buckets.
+		--
+		-- hist_merged takes the largest zero_threshold of the group, because a
+		-- merged histogram cannot claim to resolve values that one of its inputs
+		-- did not. That leaves the input with the *smaller* threshold contributing
+		-- buckets covering (its T, the merged T] -- a range the merged threshold
+		-- now declares empty. Those buckets have to move into zero_count, or the
+		-- datapoint says one thing in zero_threshold and another in its arrays.
+		--
+		-- Two CTEs rather than one because SQL cannot reference a select alias
+		-- from the same select list, and calling the macro once per output column
+		-- would evaluate it six times.
+		--
+		-- Explicit-bounds histograms fall through untouched: they carry no zero
+		-- threshold, exp_zero_cutoff returns NULL for a null or non-positive one,
+		-- and fold_below_cutoff treats a NULL cutoff as "fold nothing". No branch
+		-- on metric_type is needed.
+		--
+		-- Mirrors mergeExpHistogramStreams in histogram-merge.ts, which computes
+		-- the same cutoff for both signs from the same (threshold, scale) and adds
+		-- both folded totals into zero_count.
+		hist_folds as (
+			select m.*,
+				fold_below_cutoff(m.positive_bucket_counts, m.positive_bucket_offset,
+				                  exp_zero_cutoff(m.zero_threshold, m.scale)) as pos_fold,
+				fold_below_cutoff(m.negative_bucket_counts, m.negative_bucket_offset,
+				                  exp_zero_cutoff(m.zero_threshold, m.scale)) as neg_fold
+			from hist_merged m
+		),
+		hist_folded as (
+			select f.* exclude (pos_fold, neg_fold, zero_count,
+					positive_bucket_offset, positive_bucket_counts,
+					negative_bucket_offset, negative_bucket_counts),
+				f.zero_count + f.pos_fold.folded + f.neg_fold.folded as zero_count,
+				f.pos_fold.offset as positive_bucket_offset,
+				f.pos_fold.counts as positive_bucket_counts,
+				f.neg_fold.offset as negative_bucket_offset,
+				f.neg_fold.counts as negative_bucket_counts
+			from hist_folds f
+		),
+
 		-- What the projection reads. Merging replaces a bucket's datapoints
 		-- with one merged datapoint; electing keeps real rows and filters them
 		-- by retained_ids; no reduction passes everything through.
@@ -369,7 +410,7 @@
 				m.negative_bucket_offset, m.negative_bucket_counts,
 				null::double as double_value, null::bigint as int_value,
 				null::varchar as value_type, m.is_monotonic
-			from hist_merged m
+			from hist_folded m
 			-- A bucket whose datapoints disagree about explicit bounds cannot
 			-- be merged; there is no rescale that reconciles two boundary sets.
 			-- Dropping the row would hide it, so the merge refuses to run and

--- a/desktopexporter/internal/store/queries/schema_test.go
+++ b/desktopexporter/internal/store/queries/schema_test.go
@@ -3,6 +3,7 @@ package queries_test
 import (
 	"database/sql"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/queries"
@@ -960,6 +961,65 @@ func TestMacros_BucketExtents(t *testing.T) {
 			require.True(t, mn.Valid, "expected extents, got NULL")
 			assert.Equal(t, tc.min, mn.Float64, "min")
 			assert.Equal(t, tc.max, mx.Float64, "max")
+		})
+	}
+}
+
+// TestMacros_QuantileSkipsEmptyBuckets pins that a quantile is never taken from
+// a bucket holding nothing.
+//
+// exp_buckets always emits a zero bucket, even when zero_count is 0. At q = 0
+// the target is 0, so that empty bucket's running total already satisfies
+// acc >= target and it used to be selected -- yielding 0/0 in the interpolation
+// kernel, and a NaN quantile, for a histogram whose smallest observation was
+// well above zero.
+//
+// For q > 0 the filter is a no-op: an empty bucket's running total equals its
+// predecessor's, so if it meets the target the earlier bucket already did and
+// is chosen first. The p50 cases here are what would regress if that reasoning
+// were wrong.
+func TestMacros_QuantileSkipsEmptyBuckets(t *testing.T) {
+	db := setupMacroDB(t)
+
+	cases := []struct {
+		name  string
+		query string
+		want  float64
+	}{
+		{
+			// scale=0 -> base=2, buckets (1,2] and (2,4] and (4,8].
+			// No zero region, so the smallest observation is above 1.
+			name:  "q=0 returns the first populated bucket's lower edge, not 0",
+			query: "select exp_hist_quantile(0, 0, [], 0, 0, [10, 20, 30], 0.0)",
+			want:  1.0,
+		},
+		{
+			// A genuine zero region: the zero bucket is populated, so it is
+			// selected on its merits and 0 is the right answer.
+			name:  "q=0 with a real zero region still returns 0",
+			query: "select exp_hist_quantile(0, 0, [], 5, 0, [10, 20, 30], 0.0)",
+			want:  0.0,
+		},
+		{
+			// An empty bucket in the middle must not absorb the target.
+			name:  "empty interior bucket is skipped",
+			query: "select exp_hist_quantile(0, 0, [], 0, 0, [10, 0, 30], 0.25)",
+			want:  2.0,
+		},
+		{
+			// Unchanged by the filter -- guards the "no-op for q > 0" claim.
+			name:  "p50 unaffected",
+			query: "select exp_hist_quantile(0, 0, [], 0, 0, [10, 20, 30], 0.5)",
+			want:  4.0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got float64
+			require.NoError(t, db.QueryRow(tc.query).Scan(&got))
+			require.False(t, math.IsNaN(got), "quantile must not be NaN")
+			assert.InDelta(t, tc.want, got, 1e-9)
 		})
 	}
 }


### PR DESCRIPTION
Three histogram fixes found by making the SQL and TypeScript implementations
compare notes.

## Fixed

- **Merged zero threshold left buckets below it** — `hist_merged` took the
  largest `zero_threshold` of the group but never folded the buckets that then
  fell under it into `zero_count`, so the datapoint contradicted itself and
  disagreed with the TS merge. The macros to do it existed, tested, with zero
  call sites. Fixes #351.
- **`q = 0` divided by zero** — `exp_buckets` always emits a zero bucket, so at
  `target = 0` that empty bucket satisfied `acc >= target` and got selected;
  the interpolation kernels then evaluated `0/0`. Quantiles now come from
  buckets that hold something. No-op for every `q > 0`, since an empty bucket's
  running total equals its predecessor's.
- **Interp kernels guard `cnt = 0`** — both branches of `interp_loglin` divide
  by `cnt`. Defensive now that the selection is fixed.

## Added

- **`series_ids` on `getMetric`** — callers name the series they want, narrowed
  in `filtered_dps` before the reduction, so asking for two of ten costs two.
  Empty means all. First slice of #353.

## Measured

24,000 datapoints across 8 series, chart resolution:

| | |
|---|---|
| uniform scale | 111.7 ms |
| scale drift within a series | 140.8 ms |
| cross-series merge, divergent scales | +14 ms |

#317's quadratic downscale is not a blocker: the reduction bounds each merge
group to ~240 datapoints of 40 buckets before the quadratic term bites.

## Verified

- SQL vs TS differential over 1,200 cases (5 scales x 5 positive shapes x
  3 negative x 2 zero counts x 8 quantiles): **1,180 agreed**, and all 20
  disagreements were `q = 0` — the shared defect above.
- Every fix mutation-checked: disabling the fold, the empty-bucket filter, or
  the series filter each fails its own test.

## Notes

- TS `bucketQuantile` has the same empty-bucket defect, deliberately left
  alone: it returns `0` rather than NaN, `q = 0` is not in
  `DEFAULT_HISTOGRAM_QUANTILES`, and the module is deleted by #353.
- Extremes should come from the datapoint's `min`/`max`, not from `q = 0`/`q = 1`.
