### PR TITLE
Memoise attribute-set derivation across batches

### DIFF
--- a/desktopexporter/internal/store/ingest/attribute_memo.go
+++ b/desktopexporter/internal/store/ingest/attribute_memo.go
@@ -1,0 +1,246 @@
+package ingest
+
+import (
+	"hash/maphash"
+	"math"
+	"sync"
+
+	"github.com/duckdb/duckdb-go/v2"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// The attribute-set memo: content to (rows, ids), for the duration of the
+// process.
+//
+// AttributeSet is a pure function -- a sha256 per label, a sort, and the two
+// slices that come out -- and we ran it once per datapoint. The reference
+// capture's 294,607 datapoints hold 89 distinct label sets, so that is ~208ms
+// and ~238MB of garbage per ingest spent rediscovering 89 answers. The
+// repetition is across batches, not inside them: a batch holds one datapoint
+// per series, so a per-batch memo would have nothing to hit.
+//
+// Package-level rather than threaded through the store, which is unusual here
+// and deliberate. FlushedIDs is per-store because it asserts something about
+// one database's contents and has to be invalidated when they change; this
+// asserts that the same bytes hash to the same ids, which is true of every
+// store in the process and can never stop being true. Scoping it per store
+// would buy isolation nothing needs and cost a parameter on three Ingest
+// signatures and their hundred-odd callers.
+//
+// The returned slices are shared with the memo and with every later caller
+// holding the same set. Nothing mutates them today -- rows are read into the
+// dictionary map, ids go to an appender -- and nothing should start.
+//
+// The trade, measured on an M4 Pro over five-label sets: the repeating shape
+// goes from ~830ns and 808B per call to ~104ns and no allocation, while a
+// stream whose every datapoint carries a unique label set -- a request id, say,
+// which the memo can never serve -- costs ~955ns against ~830ns, about 15%
+// more. That case is accepted rather than detected and switched off. A unique
+// set per datapoint means a new dictionary row per datapoint too, so the write
+// this memo sits in front of grows with the same N it fails on; adding a mode
+// to save 15% of one function there would be tuning the smaller term, and the
+// threshold that decided when to flip it would be one more thing to get
+// wrong.
+const (
+	// Distinct sets held before the memo resets. The reference capture needs
+	// 89; the headroom is for label sets we have not seen, not for a
+	// high-cardinality label, which no size defeats.
+	attributeMemoCap = 4096
+)
+
+type rawAttr struct {
+	key string
+	typ pcommon.ValueType
+	str string
+	// Int, Double and Bool all live here: the value's bits, so comparison is
+	// one integer compare and the fingerprint needs no formatting.
+	num uint64
+}
+
+type memoEntry struct {
+	scope string
+	raw   []rawAttr
+	rows  []Attribute
+	ids   []duckdb.UUID
+}
+
+var attributeMemo = struct {
+	mu      sync.Mutex
+	seed    maphash.Seed
+	buckets map[uint64][]memoEntry
+	n       int
+	hits    uint64
+	misses  uint64
+}{
+	seed:    maphash.MakeSeed(),
+	buckets: map[uint64][]memoEntry{},
+}
+
+// fingerprint hashes a set's raw content without formatting or allocating.
+//
+// Reports false when the set holds a Map, Slice or Bytes value. Those reach
+// their string form through fmt, which is neither cheap nor obviously stable to
+// hash against, and datapoint labels are scalars in practice -- so they take
+// the uncached path rather than putting a formatting call on this one.
+//
+// Order-sensitive, because confirmation below walks the map in the same order.
+// A producer that reorders an otherwise identical set gets a miss, not a wrong
+// answer: AttributeSet sorts by id, so the result is the same either way.
+func fingerprint(attrs pcommon.Map, scope string) (uint64, bool) {
+	var h maphash.Hash
+	h.SetSeed(attributeMemo.seed)
+	h.WriteString(scope)
+	for k, v := range attrs.All() {
+		h.WriteString(k)
+		var n uint64
+		switch v.Type() {
+		case pcommon.ValueTypeStr:
+			h.WriteString(v.Str())
+		case pcommon.ValueTypeInt:
+			n = uint64(v.Int())
+		case pcommon.ValueTypeDouble:
+			n = math.Float64bits(v.Double())
+		case pcommon.ValueTypeBool:
+			if v.Bool() {
+				n = 1
+			}
+		case pcommon.ValueTypeEmpty:
+		default:
+			return 0, false
+		}
+		var b [9]byte
+		b[0] = byte(v.Type())
+		for i := range 8 {
+			b[i+1] = byte(n >> (8 * i))
+		}
+		h.Write(b[:])
+	}
+	return h.Sum64(), true
+}
+
+// matches confirms a candidate entry holds exactly this set, so that a
+// fingerprint collision costs a wasted slot rather than silently attaching
+// another series' attributes. Walks the map without materialising it.
+func matches(attrs pcommon.Map, scope string, e *memoEntry) bool {
+	if e.scope != scope || len(e.raw) != attrs.Len() {
+		return false
+	}
+	i := 0
+	ok := true
+	for k, v := range attrs.All() {
+		r := e.raw[i]
+		i++
+		if r.key != k || r.typ != v.Type() {
+			ok = false
+			break
+		}
+		switch v.Type() {
+		case pcommon.ValueTypeStr:
+			if r.str != v.Str() {
+				ok = false
+			}
+		case pcommon.ValueTypeInt:
+			if r.num != uint64(v.Int()) {
+				ok = false
+			}
+		case pcommon.ValueTypeDouble:
+			if r.num != math.Float64bits(v.Double()) {
+				ok = false
+			}
+		case pcommon.ValueTypeBool:
+			var n uint64
+			if v.Bool() {
+				n = 1
+			}
+			if r.num != n {
+				ok = false
+			}
+		}
+		if !ok {
+			break
+		}
+	}
+	return ok
+}
+
+func rawOf(attrs pcommon.Map) []rawAttr {
+	raw := make([]rawAttr, 0, attrs.Len())
+	for k, v := range attrs.All() {
+		r := rawAttr{key: k, typ: v.Type()}
+		switch v.Type() {
+		case pcommon.ValueTypeStr:
+			r.str = v.Str()
+		case pcommon.ValueTypeInt:
+			r.num = uint64(v.Int())
+		case pcommon.ValueTypeDouble:
+			r.num = math.Float64bits(v.Double())
+		case pcommon.ValueTypeBool:
+			if v.Bool() {
+				r.num = 1
+			}
+		}
+		raw = append(raw, r)
+	}
+	return raw
+}
+
+// memoLookup returns a previously derived set, or false. The caller supplies
+// the fingerprint so that a miss pays for hashing once rather than again on the
+// way to memoStore -- which is the whole cost of the memo on a stream it can
+// never help.
+func memoLookup(fp uint64, attrs pcommon.Map, scope string) ([]Attribute, []duckdb.UUID, bool) {
+	attributeMemo.mu.Lock()
+	defer attributeMemo.mu.Unlock()
+	for i := range attributeMemo.buckets[fp] {
+		e := &attributeMemo.buckets[fp][i]
+		if matches(attrs, scope, e) {
+			attributeMemo.hits++
+			return e.rows, e.ids, true
+		}
+	}
+	attributeMemo.misses++
+	return nil, nil, false
+}
+
+// memoStore records a derivation.
+//
+// At the cap the whole memo is dropped rather than evicted one entry at a time.
+// LRU bookkeeping would sit on the ingest hot path to little end: the sets that
+// matter report every interval and are re-admitted immediately, while a
+// high-cardinality label defeats any fixed size anyway -- what a reset
+// guarantees is that the memo cannot pin memory for sets that stopped
+// reporting, which freezing on a full table would.
+func memoStore(fp uint64, attrs pcommon.Map, scope string, rows []Attribute, ids []duckdb.UUID) {
+	attributeMemo.mu.Lock()
+	defer attributeMemo.mu.Unlock()
+	if attributeMemo.n >= attributeMemoCap {
+		attributeMemo.buckets = map[uint64][]memoEntry{}
+		attributeMemo.n = 0
+	}
+	attributeMemo.buckets[fp] = append(attributeMemo.buckets[fp], memoEntry{
+		scope: scope,
+		raw:   rawOf(attrs),
+		rows:  rows,
+		ids:   ids,
+	})
+	attributeMemo.n++
+}
+
+// AttributeMemoStats reports hits, misses and how many distinct sets are held.
+// For tests and benchmarks; the hit rate is the whole case for the memo.
+func AttributeMemoStats() (hits, misses uint64, entries int) {
+	attributeMemo.mu.Lock()
+	defer attributeMemo.mu.Unlock()
+	return attributeMemo.hits, attributeMemo.misses, attributeMemo.n
+}
+
+// ResetAttributeMemo empties the memo. For tests that measure it; ingest never
+// needs it, since the mapping it caches cannot go stale.
+func ResetAttributeMemo() {
+	attributeMemo.mu.Lock()
+	defer attributeMemo.mu.Unlock()
+	attributeMemo.buckets = map[uint64][]memoEntry{}
+	attributeMemo.n = 0
+	attributeMemo.hits = 0
+	attributeMemo.misses = 0
+}

--- a/desktopexporter/internal/store/ingest/attribute_memo.go
+++ b/desktopexporter/internal/store/ingest/attribute_memo.go
@@ -27,6 +27,23 @@ import (
 // would buy isolation nothing needs and cost a parameter on three Ingest
 // signatures and their hundred-odd callers.
 //
+// "Needs no invalidation" is a claim about ids, not about rows, and the
+// difference is the dangerous part. This memo must never be read as "those rows
+// are already in the database" -- retention and SweepOrphans delete dictionary
+// rows the memo still holds ids for, and a memo that skipped re-registering
+// them would leave owner arrays pointing at rows that no longer exist. No
+// error, no failed constraint; the attributes would just stop appearing. What
+// prevents it is that AddAttributes registers the returned rows unconditionally
+// and the insert stays gated on FlushedIDs, which the sweep clears.
+// TestDictionaryIntegrityAcrossClearAndReingest in the store package is the
+// guard: it sweeps span attributes away and re-ingests content whose attributes
+// are byte-identical, so the re-ingest is served from here and must still write
+// the rows back. It predates this memo and was written for exactly this shape
+// of mistake.
+//
+// Memory is bounded and returned: 4095 five-label sets measure 3.65 MB, ~933 B
+// each, and a reset releases all of it.
+//
 // The returned slices are shared with the memo and with every later caller
 // holding the same set. Nothing mutates them today -- rows are read into the
 // dictionary map, ids go to an appender -- and nothing should start.

--- a/desktopexporter/internal/store/ingest/attribute_memo_bench_test.go
+++ b/desktopexporter/internal/store/ingest/attribute_memo_bench_test.go
@@ -1,0 +1,56 @@
+package ingest_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/ingest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// captureShapedSets mirrors the reference capture: 89 distinct five-label sets,
+// which 294,607 datapoints resolve to.
+func captureShapedSets(n int) []pcommon.Map {
+	sets := make([]pcommon.Map, n)
+	for i := range n {
+		m := pcommon.NewMap()
+		m.PutStr("driver", fmt.Sprintf("D%02d", i))
+		m.PutStr("team", fmt.Sprintf("T%02d", i%10))
+		m.PutStr("session", "race")
+		m.PutInt("lap", int64(i))
+		m.PutStr("compound", "medium")
+		sets[i] = m
+	}
+	return sets
+}
+
+// BenchmarkAttributeSetCaptureShape is the shape the change is justified by:
+// the same 89 sets reporting over and over, which is what a metrics session is.
+func BenchmarkAttributeSetCaptureShape(b *testing.B) {
+	sets := captureShapedSets(89)
+	ingest.ResetAttributeMemo()
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		ingest.AttributeSet(sets[i%len(sets)], ingest.ScopeDatapoint)
+		i++
+	}
+	b.StopTimer()
+	hits, misses, _ := ingest.AttributeMemoStats()
+	if hits+misses > 0 {
+		b.ReportMetric(100*float64(hits)/float64(hits+misses), "%hit")
+	}
+}
+
+// BenchmarkAttributeSetAllDistinct is the adversarial shape: a label the memo
+// can never hit, so this measures what the lookup costs when it always misses.
+func BenchmarkAttributeSetAllDistinct(b *testing.B) {
+	sets := captureShapedSets(20000)
+	ingest.ResetAttributeMemo()
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		ingest.AttributeSet(sets[i%len(sets)], ingest.ScopeDatapoint)
+		i++
+	}
+}

--- a/desktopexporter/internal/store/ingest/attribute_memo_test.go
+++ b/desktopexporter/internal/store/ingest/attribute_memo_test.go
@@ -1,0 +1,228 @@
+package ingest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func mapOf(build func(m pcommon.Map)) pcommon.Map {
+	m := pcommon.NewMap()
+	build(m)
+	return m
+}
+
+// TestAttributeMemoAgreesWithDerivation is the memo's whole safety argument: it
+// stands in front of a pure function, so for every input the cached answer must
+// be the answer the derivation would have given. Each case is asked twice --
+// once cold, once warm -- because only the second is served by the memo.
+func TestAttributeMemoAgreesWithDerivation(t *testing.T) {
+	cases := []struct {
+		name  string
+		attrs pcommon.Map
+		scope string
+	}{
+		{"empty", mapOf(func(m pcommon.Map) {}), ScopeDatapoint},
+		{"one string", mapOf(func(m pcommon.Map) { m.PutStr("k", "v") }), ScopeDatapoint},
+		{"every scalar type", mapOf(func(m pcommon.Map) {
+			m.PutStr("s", "text")
+			m.PutInt("i", -42)
+			m.PutDouble("d", 3.5)
+			m.PutBool("b", true)
+			m.PutEmpty("e")
+		}), ScopeSpan},
+		// Values that collide under a careless fingerprint: same bits read as a
+		// different type, and numbers whose string forms differ from their bits.
+		{"int and double sharing bits", mapOf(func(m pcommon.Map) {
+			m.PutInt("n", 1)
+			m.PutDouble("f", 1)
+		}), ScopeDatapoint},
+		{"negative zero", mapOf(func(m pcommon.Map) { m.PutDouble("z", negZero()) }), ScopeDatapoint},
+		{"false is not empty", mapOf(func(m pcommon.Map) { m.PutBool("b", false) }), ScopeDatapoint},
+		// Complex values take the uncached path; they must still be correct.
+		{"nested map", mapOf(func(m pcommon.Map) {
+			m.PutStr("plain", "x")
+			m.PutEmptyMap("nested").PutStr("inner", "y")
+		}), ScopeResource},
+		{"slice", mapOf(func(m pcommon.Map) {
+			m.PutEmptySlice("list").AppendEmpty().SetInt(7)
+		}), ScopeResource},
+		{"bytes", mapOf(func(m pcommon.Map) {
+			m.PutEmptyBytes("raw").Append(1, 2, 3)
+		}), ScopeLog},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			wantRows, wantIDs := attributeSetUncached(c.attrs, c.scope)
+			if c.attrs.Len() == 0 {
+				wantRows, wantIDs = nil, nil
+			}
+			for _, pass := range []string{"cold", "warm"} {
+				rows, ids := AttributeSet(c.attrs, c.scope)
+				assert.Equalf(t, wantRows, rows, "%s pass rows", pass)
+				assert.Equalf(t, wantIDs, ids, "%s pass ids", pass)
+			}
+		})
+	}
+}
+
+func negZero() float64 { z := 0.0; return -z }
+
+// TestAttributeMemoSeparatesScopes covers the mistake that would be silent:
+// the same labels under two scopes are different dictionary entries, and a memo
+// keyed on labels alone would serve one for the other.
+func TestAttributeMemoSeparatesScopes(t *testing.T) {
+	attrs := mapOf(func(m pcommon.Map) { m.PutStr("http.method", "GET") })
+
+	_, spanIDs := AttributeSet(attrs, ScopeSpan)
+	_, logIDs := AttributeSet(attrs, ScopeLog)
+	_, spanAgain := AttributeSet(attrs, ScopeSpan)
+
+	require.Len(t, spanIDs, 1)
+	assert.NotEqual(t, spanIDs[0], logIDs[0],
+		"scope is part of dictionary identity, so these are different rows")
+	assert.Equal(t, spanIDs, spanAgain,
+		"and the warm read must return the span answer, not whichever was cached last")
+}
+
+// TestAttributeMemoConfirmsOnCollision forces two different sets into one
+// bucket and asserts each still resolves to its own ids.
+//
+// The fingerprint is 64-bit and a natural collision is not reachable in a test,
+// so the entry is planted directly. That is the point: the memo must not trust
+// the fingerprint, and the exact comparison is what makes a collision cost a
+// wasted slot instead of attaching another series' attributes.
+func TestAttributeMemoConfirmsOnCollision(t *testing.T) {
+	ResetAttributeMemo()
+	t.Cleanup(ResetAttributeMemo)
+
+	mine := mapOf(func(m pcommon.Map) { m.PutStr("pod", "a") })
+	theirs := mapOf(func(m pcommon.Map) { m.PutStr("pod", "b") })
+
+	wantMine, wantMineIDs := attributeSetUncached(mine, ScopeDatapoint)
+	theirsRows, theirsIDs := AttributeSet(theirs, ScopeDatapoint)
+
+	// Plant "theirs" under the fingerprint "mine" will compute.
+	fp, ok := fingerprint(mine, ScopeDatapoint)
+	require.True(t, ok)
+	attributeMemo.mu.Lock()
+	attributeMemo.buckets[fp] = append(attributeMemo.buckets[fp], memoEntry{
+		scope: ScopeDatapoint,
+		raw:   rawOf(theirs),
+		rows:  theirsRows,
+		ids:   theirsIDs,
+	})
+	attributeMemo.mu.Unlock()
+
+	rows, ids := AttributeSet(mine, ScopeDatapoint)
+	assert.Equal(t, wantMine, rows, "the colliding entry must be rejected, not returned")
+	assert.Equal(t, wantMineIDs, ids)
+	assert.NotEqual(t, theirsIDs, ids, "pod=b's ids must never answer for pod=a")
+}
+
+// TestAttributeMemoHitsRepeatedSets is the case the change rests on: the
+// reference capture's 294,607 datapoints hold 89 distinct label sets, so all
+// but the first 89 derivations should be served from the memo.
+func TestAttributeMemoHitsRepeatedSets(t *testing.T) {
+	ResetAttributeMemo()
+	t.Cleanup(ResetAttributeMemo)
+
+	const distinct = 89
+	const reports = 200
+	sets := make([]pcommon.Map, distinct)
+	for i := range distinct {
+		sets[i] = mapOf(func(m pcommon.Map) {
+			m.PutStr("driver", fmt.Sprintf("D%02d", i))
+			m.PutStr("session", "race")
+			m.PutInt("lap", int64(i))
+		})
+	}
+	for range reports {
+		for _, s := range sets {
+			AttributeSet(s, ScopeDatapoint)
+		}
+	}
+
+	hits, misses, entries := AttributeMemoStats()
+	assert.Equal(t, uint64(distinct), misses,
+		"each distinct set is derived once and only once")
+	assert.Equal(t, uint64(distinct*(reports-1)), hits)
+	assert.Equal(t, distinct, entries)
+}
+
+// TestAttributeMemoResetsAtCap keeps the memo from pinning memory under a
+// high-cardinality label, which no fixed size defeats.
+func TestAttributeMemoResetsAtCap(t *testing.T) {
+	ResetAttributeMemo()
+	t.Cleanup(ResetAttributeMemo)
+
+	for i := range attributeMemoCap + 10 {
+		AttributeSet(mapOf(func(m pcommon.Map) {
+			m.PutStr("request.id", fmt.Sprintf("r%d", i))
+		}), ScopeSpan)
+	}
+	_, _, entries := AttributeMemoStats()
+	assert.LessOrEqual(t, entries, attributeMemoCap,
+		"a unique label per request must not grow the memo without bound")
+	assert.Positive(t, entries, "and the memo must still be usable after a reset")
+}
+
+// TestAttributeMemoFingerprintSpreads guards the half of the design the
+// correctness tests cannot see.
+//
+// The fingerprint is only a bucketing hint: exact comparison is what makes an
+// answer right, so a fingerprint that ignored the values entirely -- or the
+// scope -- would still return correct results and pass every test above. It
+// would also drop every set into one bucket and turn each lookup into a linear
+// scan of the whole memo, which at the cap is slower than deriving the answer
+// and is exactly the cost the memo exists to remove.
+func TestAttributeMemoFingerprintSpreads(t *testing.T) {
+	ResetAttributeMemo()
+	t.Cleanup(ResetAttributeMemo)
+
+	// Same keys and types throughout, so only the values distinguish them --
+	// and only *numeric* values, because a string value reaches the hash
+	// through a different branch. A fixture that varied a string too would
+	// still spread if the numeric branch were dropped entirely.
+	const distinct = 256
+	for i := range distinct {
+		AttributeSet(mapOf(func(m pcommon.Map) {
+			m.PutStr("pod", "fixed")
+			m.PutInt("shard", int64(i))
+			m.PutDouble("weight", float64(i)/8)
+		}), ScopeDatapoint)
+	}
+
+	attributeMemo.mu.Lock()
+	buckets := len(attributeMemo.buckets)
+	widest := 0
+	for _, b := range attributeMemo.buckets {
+		if len(b) > widest {
+			widest = len(b)
+		}
+	}
+	attributeMemo.mu.Unlock()
+
+	assert.GreaterOrEqual(t, buckets, distinct*3/4,
+		"sets differing only in value must land in distinct buckets, or lookup "+
+			"degrades to a scan of everything the memo holds")
+	assert.LessOrEqual(t, widest, 4,
+		"and no bucket should collect a meaningful share of them")
+
+	// Scope is part of dictionary identity, so it has to reach the fingerprint
+	// too -- otherwise every scope's copy of a label set stacks in one bucket.
+	before := buckets
+	attrs := mapOf(func(m pcommon.Map) { m.PutStr("http.method", "GET") })
+	for _, scope := range []string{ScopeSpan, ScopeLog, ScopeDatapoint, ScopeResource} {
+		AttributeSet(attrs, scope)
+	}
+	attributeMemo.mu.Lock()
+	after := len(attributeMemo.buckets)
+	attributeMemo.mu.Unlock()
+	assert.Equal(t, before+4, after,
+		"one identical label set under four scopes is four entries in four buckets")
+}

--- a/desktopexporter/internal/store/ingest/dictionary.go
+++ b/desktopexporter/internal/store/ingest/dictionary.go
@@ -217,7 +217,28 @@ func AttributeSet(attrs pcommon.Map, scope string) ([]Attribute, []duckdb.UUID) 
 	if attrs.Len() == 0 {
 		return nil, nil
 	}
+	// Content maps to ids by a pure function, so the same series reporting
+	// again asks a question already answered. See attribute_memo.go.
+	//
+	// Hashed once and the fingerprint carried through, so a set the memo cannot
+	// serve -- a high-cardinality label, or a value type it declines to hash --
+	// pays for one pass and not two.
+	fp, cacheable := fingerprint(attrs, scope)
+	if cacheable {
+		if rows, ids, ok := memoLookup(fp, attrs, scope); ok {
+			return rows, ids
+		}
+	}
+	rows, ids := attributeSetUncached(attrs, scope)
+	if cacheable {
+		memoStore(fp, attrs, scope, rows, ids)
+	}
+	return rows, ids
+}
 
+// attributeSetUncached is the derivation itself, unchanged by the memo in front
+// of it -- which is what lets a test assert the two agree on arbitrary input.
+func attributeSetUncached(attrs pcommon.Map, scope string) ([]Attribute, []duckdb.UUID) {
 	rows := make([]Attribute, 0, attrs.Len())
 	for k, v := range attrs.All() {
 		value, typ := util.ValueToStringAndType(v)


### PR DESCRIPTION
- **The problem.** Turning a datapoint's labels into dictionary ids costs a
  hash per label, a sort, and ten allocations. We paid it once per datapoint,
  though the same series sends the same labels every interval. The reference
  capture holds 294,607 datapoints and **89 distinct label sets** — so the work
  ran 294,607 times to produce 89 answers, about 208 ms and 238 MB of garbage
  per ingest.

- **The fix.** A lookup table from a label set to the ids already derived for
  it. The derivation is a pure function — the same labels always give the same
  ids, which is what makes dedupe work across restarts — so a stored answer
  cannot go stale.

- **Why not per batch.** A batch carries roughly one datapoint per series, so
  its label sets are already distinct. The repetition is between batches.

- **Why package-level, not per store.** `FlushedIDs` is per store because it
  describes one database's contents and must be cleared when they change. This
  describes a calculation, so every store in the process can share it. Scoping
  it would add a parameter to three `Ingest` signatures and ~107 callers for no
  gain.

- **Why lookup is cheap.** A 64-bit fingerprint over the raw values — reading
  ints, floats and strings directly, so nothing is formatted or allocated —
  then an exact comparison to confirm. The fingerprint only picks the bucket;
  the comparison decides. A collision therefore costs a wasted slot, never the
  wrong ids. Map, Slice and Bytes values skip the table rather than put a `fmt`
  call on this path.

- **Bounded by reset.** At 4096 entries the table empties instead of evicting
  one at a time. Sets that matter report every interval and are re-added at
  once, and no fixed size survives a label that is unique per request.

- **Measured** (M4 Pro, five labels): 830 ns / 808 B / 10 allocs →
  **104 ns / 0 B / 0 allocs**, at a 99.97% hit rate.

- **The trade, accepted not hidden.** A unique label set per datapoint costs
  ~955 ns against ~830, about 15% more. That stream grows the dictionary write
  by the same N, so this is the smaller term; a mode switch would be one more
  threshold to get wrong.

- **Mutation testing changed the tests.** Dropping the scope, or the numeric
  bits, from the fingerprint left every test green — answers stayed correct,
  but the table collapsed into one bucket and each lookup became a full scan.
  No correctness test can see that, so there is now one on how entries spread.

Closes #344
