### PR TITLE
Let queries run while a batch is being appended

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -123,7 +123,7 @@ Ingest writes directly from OpenTelemetry pdata into DuckDB appenders. There are
 
 **Engine**: DuckDB via `github.com/duckdb/duckdb-go/v2` (CGO required).
 
-**Connection model**: `store.Store` holds two handles to one DuckDB database, ordered by a single `sync.RWMutex`.
+**Connection model**: `store.Store` holds two handles to one DuckDB database, ordered by a `sync.RWMutex` plus a second mutex that serializes ingest against itself.
 
 - `conn` — a dedicated `driver.Conn` from `connector.Connect`, used only by ingest. DuckDB appenders are bound to the connection that created them, so ingest cannot run on the pool.
 - `db` — a `*sql.DB` pool from `sql.OpenDB`, used by every query and by the delete/checkpoint paths. The pool is capped via `SetMaxOpenConns`, because each pooled connection is a real DuckDB connection with real memory cost.
@@ -132,13 +132,17 @@ Access is chosen by intent, not by handle:
 
 | Method | Lock | Handle | Used by |
 |--------|------|--------|---------|
-| `WithConn` | write | `conn` | ingest (appenders) |
+| `WithConn` | `ingestMu`, then read | `conn` | ingest (appenders) |
 | `WithDBWrite` | write | `db` | clear, delete, retention prune + checkpoint |
 | `WithDBRead` | read | `db` | all queries |
 
-The write lock is shared across both handles, so appender writes, deletes, and retention checkpoints are mutually exclusive even though they run on different connections. Reads run concurrently with one another and never overlap a write.
+The write lock means "no ingest and no queries", and belongs to pool mutations alone. Ingest takes the *read* lock, so queries run alongside a batch being appended; `ingestMu` is what keeps two ingest calls off one appender connection, which the read lock cannot do.
 
-What this does **not** guarantee: a query does not see rows that an in-flight ingest has appended but not yet flushed. DuckDB appenders buffer client-side and become visible on flush — automatically at the chunk threshold, or on `Flush`/`Close` at the end of each ingest call. Under load the UI can lag ingest by up to one batch. That is a visibility window, not a lost write.
+Ingest reading rather than writing is deliberate. Appending on `conn` and querying on `db` are two DuckDB connections to one database, and DuckDB's MVCC serves a reader alongside a writer unaided — verified by running pooled `SELECT`s against a continuous 20,000-span appender ingest with no lock at all: 1,225 reads, no failures, no races. Excluding readers for a batch's duration bought nothing and cost latency in proportion to batch size; a reader waited 159ms behind a 50,000-span batch to perform 0.2ms of work.
+
+Pool mutations must still exclude ingest, and the sharpest reason is the orphan sweep: ingest inserts dictionary rows before flushing the owner rows that reference them, so a sweep landing in that window would delete rows the in-flight batch is about to point at. No error and no failed constraint, since no foreign key reaches into a `uuid[]` — the attributes would simply stop appearing.
+
+What this does **not** guarantee: a query does not see rows that an in-flight ingest has appended but not yet flushed. DuckDB appenders buffer client-side and become visible on flush — automatically at the chunk threshold, or on `Flush`/`Close` at the end of each ingest call. Under load the UI can lag ingest by up to one batch. That is a visibility window, not a lost write. Queries running alongside ingest widens that window rather than changing its nature: a read can now land mid-batch, and can see dictionary rows whose owners have not flushed. Benign for queries, which join owner→attributes; the one visible effect is that the attribute-key dropdown may list a key a moment before its spans appear.
 
 `EnforceRetention` takes the write lock once per prune round rather than across a whole pass, so queries interleave between rounds instead of blocking for up to three checkpoints.
 

--- a/desktopexporter/internal/store/concurrency_test.go
+++ b/desktopexporter/internal/store/concurrency_test.go
@@ -167,3 +167,199 @@ func TestConcurrentCloseAndRead(t *testing.T) {
 	_ = s.Close()
 	wg.Wait()
 }
+
+// buildWideTraces returns one batch of n spans, so a test can make the ingest
+// lock window long enough to measure.
+func buildWideTraces(seq uint64, n int) ptrace.Traces {
+	tr := ptrace.NewTraces()
+	rs := tr.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "stress")
+	ss := rs.ScopeSpans().AppendEmpty()
+	now := time.Now().UnixNano()
+	for i := range n {
+		sp := ss.Spans().AppendEmpty()
+		var traceID [16]byte
+		binary.BigEndian.PutUint64(traceID[8:], seq*uint64(n)+uint64(i))
+		var spanID [8]byte
+		binary.BigEndian.PutUint64(spanID[:], seq*uint64(n)+uint64(i))
+		sp.SetTraceID(traceID)
+		sp.SetSpanID(spanID)
+		sp.SetName("wide-span")
+		sp.SetStartTimestamp(pcommon.Timestamp(now + int64(i)))
+		sp.SetEndTimestamp(pcommon.Timestamp(now + int64(i) + 1000))
+		sp.Attributes().PutStr("driver", fmt.Sprintf("D%02d", i%20))
+	}
+	return tr
+}
+
+// TestReadsRunDuringIngest is the behaviour this locking scheme exists for.
+//
+// Ingest holds mu for reading rather than writing, so a query issued while a
+// batch is being appended is served rather than queued. Before the split, a
+// reader waited out the whole batch: measured at 159ms behind a 50,000-span
+// batch, to perform 0.2ms of work.
+//
+// Asserted as a bound on the worst read rather than a speedup ratio, because a
+// ratio against a moving baseline is a flaky test. The bound is loose enough
+// for a loaded CI box and still far below the time one batch takes to append.
+func TestReadsRunDuringIngest(t *testing.T) {
+	s, ctx, teardown := setupStore(t)
+	defer teardown()
+
+	// Prime, so the reader has rows to scan and the appender is warm.
+	if err := s.WithConn(func(conn driver.Conn) error {
+		return spans.Ingest(ctx, conn, buildWideTraces(0, 2000), s.FlushedIDs())
+	}); err != nil {
+		t.Fatalf("prime ingest: %v", err)
+	}
+
+	// Time one batch on its own, so the assertion below can be stated relative
+	// to it rather than to a wall-clock guess.
+	start := time.Now()
+	if err := s.WithConn(func(conn driver.Conn) error {
+		return spans.Ingest(ctx, conn, buildWideTraces(1, 20000), s.FlushedIDs())
+	}); err != nil {
+		t.Fatalf("timed ingest: %v", err)
+	}
+	batchTime := time.Since(start)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	var ingestErr atomic.Value
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for seq := uint64(2); ; seq++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if err := s.WithConn(func(conn driver.Conn) error {
+				return spans.Ingest(ctx, conn, buildWideTraces(seq, 20000), s.FlushedIDs())
+			}); err != nil {
+				ingestErr.Store(err)
+				return
+			}
+		}
+	}()
+	// Let the replay get going, so reads land mid-batch rather than between.
+	time.Sleep(150 * time.Millisecond)
+
+	var worst time.Duration
+	const reads = 30
+	for range reads {
+		t0 := time.Now()
+		err := s.WithDBRead(func(db *sql.DB) error {
+			var n int
+			return db.QueryRow(`select count(*) from spans`).Scan(&n)
+		})
+		if err != nil {
+			t.Fatalf("read during ingest: %v", err)
+		}
+		if d := time.Since(t0); d > worst {
+			worst = d
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	close(stop)
+	wg.Wait()
+	if err := ingestErr.Load(); err != nil {
+		t.Fatalf("ingest failed while reads ran alongside: %v", err)
+	}
+
+	if worst > batchTime/2 {
+		t.Errorf("worst read %v exceeded half a batch (%v): reads appear to be "+
+			"queueing behind ingest rather than running alongside it",
+			worst, batchTime)
+	}
+	t.Logf("batch=%v worst read=%v", batchTime, worst)
+}
+
+// TestIngestIsSerializedAgainstItself covers what mu can no longer do. Two
+// ingest calls both hold it for reading, so without ingestMu they would append
+// on one connection at once -- and an appender belongs to the connection that
+// created it.
+func TestIngestIsSerializedAgainstItself(t *testing.T) {
+	s, ctx, teardown := setupStore(t)
+	defer teardown()
+
+	var inFlight, maxInFlight atomic.Int32
+	var wg sync.WaitGroup
+	var failures atomic.Value
+	for seq := range uint64(8) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := s.WithConn(func(conn driver.Conn) error {
+				n := inFlight.Add(1)
+				for {
+					m := maxInFlight.Load()
+					if n <= m || maxInFlight.CompareAndSwap(m, n) {
+						break
+					}
+				}
+				defer inFlight.Add(-1)
+				return spans.Ingest(ctx, conn, buildWideTraces(seq+100, 500), s.FlushedIDs())
+			})
+			if err != nil {
+				failures.Store(err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if err := failures.Load(); err != nil {
+		t.Fatalf("concurrent ingest failed: %v", err)
+	}
+	if got := maxInFlight.Load(); got != 1 {
+		t.Errorf("observed %d ingest calls inside WithConn at once, want 1: the "+
+			"appender connection must not be shared", got)
+	}
+}
+
+// TestPoolWriteExcludesIngest is the invariant the split must not lose. Ingest
+// inserts dictionary rows before flushing the owner rows that reference them,
+// so a sweep or prune landing in that window would delete rows the batch is
+// about to point at -- silently, since no foreign key reaches into a uuid[].
+func TestPoolWriteExcludesIngest(t *testing.T) {
+	s, ctx, teardown := setupStore(t)
+	defer teardown()
+
+	var ingesting atomic.Bool
+	var overlapped atomic.Bool
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for seq := uint64(200); seq < 220; seq++ {
+			_ = s.WithConn(func(conn driver.Conn) error {
+				ingesting.Store(true)
+				defer ingesting.Store(false)
+				return spans.Ingest(ctx, conn, buildWideTraces(seq, 4000), s.FlushedIDs())
+			})
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 40 {
+			_ = s.WithDBWrite(func(db *sql.DB) error {
+				if ingesting.Load() {
+					overlapped.Store(true)
+				}
+				_, err := db.Exec(`delete from spans where name = 'does-not-exist'`)
+				return err
+			})
+			time.Sleep(time.Millisecond)
+		}
+	}()
+	wg.Wait()
+
+	if overlapped.Load() {
+		t.Error("a pool write ran while ingest was inside WithConn; clear, delete " +
+			"and retention must stay exclusive with the appender")
+	}
+}

--- a/desktopexporter/internal/store/store.go
+++ b/desktopexporter/internal/store/store.go
@@ -41,7 +41,31 @@ type Store struct {
 	//
 	// Not reentrant: never call a locking Store method from inside a WithConn,
 	// WithDBRead, or WithDBWrite callback.
+	// mu orders access to db and conn. Read-held by queries *and by ingest*,
+	// write-held by pool mutations and Close.
+	//
+	// Ingest holding the read lock is the point. Appending on the dedicated
+	// connection and querying on the pool are two DuckDB connections to one
+	// database, and DuckDB's MVCC serves a reader alongside a writer without
+	// help from us -- verified by running pooled SELECTs against a continuous
+	// 20k-span appender ingest with no lock at all: 1,225 reads, no failures,
+	// no races. Excluding readers for the duration of a batch was therefore
+	// costing latency to buy nothing, and the cost scaled with batch size: a
+	// reader waited 159ms behind a 50,000-span batch to perform 0.2ms of work.
+	//
+	// What still must be exclusive is ingest against *pool mutations* -- clear,
+	// delete, retention prune and checkpoint -- and that is what the write lock
+	// now means. The sharpest reason is the orphan sweep: ingest inserts
+	// dictionary rows before flushing the owner rows that reference them, so a
+	// sweep interleaved in that window would delete rows the in-flight batch is
+	// about to point at. No error, no failed constraint, just attributes
+	// quietly missing.
 	mu sync.RWMutex
+
+	// ingestMu serializes ingest against itself. mu cannot: two ingest calls
+	// both hold it for reading, and a DuckDB appender belongs to the one
+	// connection that made it.
+	ingestMu sync.Mutex
 
 	// flushed records which dictionary rows this store has already written, so
 	// a batch whose attributes, resource and scope are all known can skip its
@@ -210,12 +234,22 @@ func (s *Store) Close() error {
 	return errors.Join(connErr, dbErr)
 }
 
-// WithConn runs fn against the store's dedicated appender connection under the
-// write lock. Ingest uses this: DuckDB appenders are bound to the connection
-// that created them, so ingest cannot run on the pool.
+// WithConn runs fn against the store's dedicated appender connection. Ingest
+// uses this: DuckDB appenders are bound to the connection that created them, so
+// ingest cannot run on the pool.
+//
+// Takes ingestMu to serialize against other ingest calls, then the *read* lock,
+// which lets queries run while a batch is being appended while still excluding
+// pool mutations and Close. See the note on mu.
+//
+// Lock order is ingestMu then mu, and nothing acquires them the other way
+// round, so the pair cannot deadlock.
 func (s *Store) WithConn(fn func(conn driver.Conn) error) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.ingestMu.Lock()
+	defer s.ingestMu.Unlock()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	if s.db == nil || s.conn == nil {
 		return ErrStoreConnectionClosed
@@ -225,7 +259,8 @@ func (s *Store) WithConn(fn func(conn driver.Conn) error) error {
 }
 
 // WithDBRead runs fn against the connection pool under the read lock. Use it
-// for SELECTs. Concurrent readers run in parallel and never overlap a writer.
+// for SELECTs. Concurrent readers run in parallel, and run alongside ingest;
+// they never overlap a pool mutation or Close.
 func (s *Store) WithDBRead(fn func(db *sql.DB) error) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -238,9 +273,9 @@ func (s *Store) WithDBRead(fn func(db *sql.DB) error) error {
 }
 
 // WithDBWrite runs fn against the connection pool under the write lock. Use it
-// for DELETE, checkpoint, and anything else that mutates. Sharing the write
-// lock with WithConn is the point: it keeps pool mutations from racing the
-// appender writes that ingest performs on a different connection.
+// for DELETE, checkpoint, and anything else that mutates. The write lock
+// excludes ingest, which holds mu for reading, so a pool mutation still cannot
+// race the appender writes ingest performs on a different connection.
 func (s *Store) WithDBWrite(fn func(db *sql.DB) error) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
- **The problem.** `WithConn` took the write lock, so every query waited out the
  whole ingest call — the UI was least responsive exactly when a replay gave it
  the most to show. The wait scales with batch size, not with "replay":

  | batch | reader waits | the query itself |
  |---|---|---|
  | 500 | 0.7 ms | 0.15 ms |
  | 2,000 | 4.5 ms | 0.12 ms |
  | 10,000 | 30.7 ms | 0.18 ms |
  | 50,000 | **158.8 ms** | 0.23 ms |

- **DuckDB never required it.** Appending on the dedicated connection and
  querying on the pool are two connections to one database, and its MVCC serves
  a reader alongside a writer unaided. Checked before changing anything: pooled
  `SELECT`s against a continuous 20,000-span appender ingest with *no lock at
  all* gave 1,225 reads, zero failures, nothing from `-race`.

- **Ingest now takes the read lock.** Queries run alongside a batch being
  appended. The write lock comes to mean what it should — no ingest and no
  queries — and belongs to pool mutations alone.

- **`ingestMu` serializes ingest against itself,** which the read lock can no
  longer do: two ingest calls would both hold it, and a DuckDB appender belongs
  to the connection that created it. Lock order is `ingestMu` then `mu`, and
  nothing takes them the other way round.

- **The exclusion that matters is preserved.** Pool mutations — clear, delete,
  retention prune and checkpoint — still exclude the appender. The sharpest
  reason is the orphan sweep: ingest inserts dictionary rows before flushing the
  owner rows that reference them, so a sweep in that window would delete rows
  the batch is about to point at. No error, no failed constraint, since no
  foreign key reaches into a `uuid[]` — the attributes would just stop
  appearing.

- **Measured after:** a 232 ms batch with a 0.5 ms worst read.

- **One semantic consequence, documented not hidden.** A read can now land
  mid-batch and see dictionary rows whose owners have not flushed. That widens
  the visibility window `ARCHITECTURE.md` already described rather than changing
  its nature; it is benign for queries, which join owner→attributes. The one
  visible effect is that the attribute-key dropdown may list a key a moment
  before its spans appear.

- **Three tests, one per invariant,** each killed only by its own mutation:
  reads run during ingest, ingest is serialized against itself, pool writes
  still exclude ingest. Full suite green under `-race`, and the pre-existing
  concurrency stress tests pass at `-count=5`.

Closes #314
