### PR TITLE
Fail CI when the committed bundle is stale

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -153,3 +153,12 @@ jobs:
 
     - name: Format check (Prettier)
       run: npm run format:check
+
+    # The built bundle is committed and served by the Go binary, so it can go
+    # stale without any source file changing -- a dependency bump alone is
+    # enough. Nothing caught that, and the drift would surface inside whichever
+    # unrelated PR next ran build-ts. Runs from the repo root because the
+    # comparison spans both the frontend and the embedded copy.
+    - name: Built assets are current
+      working-directory: ${{ github.workspace }}
+      run: make build-ts-check

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,29 @@ dev-go: kill-port
 build-ts:
 	cd desktopexporter/internal/frontend && npm run build && rm -rf ../../internal/server/static/* && cp -r dist/* ../../internal/server/static/
 
+# The built bundle is committed, so it can fall out of step with the sources
+# and with package-lock.json -- and nothing noticed. A dependency bump changes
+# the output without touching a single source file, so the lockfile and the
+# bundle disagree from the moment it merges, and the drift lands in whichever
+# unrelated PR next runs build-ts.
+#
+# Vite's output is reproducible: same sources and same lockfile give
+# byte-identical files, hashed names included. So a rebuild that differs from
+# what is committed means what is committed is stale, and that is a check
+# rather than a guess.
+#
+# .gitkeep is excluded because it is ours -- it keeps the directory in git and
+# build-ts's globs never touch it.
+.PHONY: build-ts-check
+build-ts-check:
+	cd desktopexporter/internal/frontend && npm run build
+	@diff -r --exclude=.gitkeep \
+		desktopexporter/internal/frontend/dist \
+		desktopexporter/internal/server/static \
+		|| (echo ""; \
+		    echo "internal/server/static is stale. Run 'make build-ts' and commit the result."; \
+		    exit 1)
+
 .PHONY: format-ts
 format-ts:
 	cd desktopexporter/internal/frontend && npm run format
@@ -129,7 +152,7 @@ run: build-ts
 # local ran `format:check`, so seven unformatted files went out across several
 # commits before CI caught them.
 .PHONY: test
-test: format-go-check format-ts-check validate-ts test-go test-ts
+test: format-go-check format-ts-check validate-ts build-ts-check test-go test-ts
 
 .PHONY: release-dry-run
 release-dry-run:


### PR DESCRIPTION
The built frontend is committed to `internal/server/static` and served by the Go binary, and nothing checked it against its sources.

A dependency bump is enough to break that on its own. The open dependabot PR (#360) edits only `package.json` and `package-lock.json`, but changes the build output by 24 KB and one chunk. Merging it leaves the lockfile and the committed bundle describing different builds, and the difference then appears inside whichever unrelated PR next runs `make build-ts`.

- **`make build-ts-check`** builds and diffs against the committed copy. `.gitkeep` is excluded — it keeps the directory in git and `build-ts`'s globs never touch it.
- **Added to the frontend CI job**, after the existing checks, where `npm ci` has already run.
- **Added to `make test`**, which exists to mirror CI locally.

This works because vite's output is reproducible: identical sources and lockfile give byte-identical files, hashed names included. Confirmed by building twice and comparing hashes, so a differing rebuild means staleness rather than build nondeterminism.

Verified in both directions: exit 2 against a deliberately modified asset with a message naming the fix, exit 0 when in sync.

Deliberately not a git hook. A pre-commit rebuild stages generated files into someone else's commit; a pre-push one cannot amend the commit it is pushing, so it could only reject. CI is the right place.
