### PR TITLE
Put the schema break above the commit list in release notes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -140,6 +140,29 @@ changelog:
 
 release:
   name_template: "v{{ .Version }}"
+  # Goreleaser builds the notes from commit subjects, which is fine for a list
+  # of changes and useless for the one thing a reader needs before upgrading.
+  # The store refuses a database written by a different schema version rather
+  # than guessing at its shape, so an upgrade that crosses one is a stop, not a
+  # migration -- and that belongs above the commits, not somewhere inside them.
+  #
+  # The first paragraph is evergreen: it states the rule, which holds for every
+  # release. The second names the version this one breaks with and should be
+  # updated or dropped when the next release does not cross a schema change.
+  header: |
+    ## Before you upgrade
+
+    The store keeps a schema version and will not open a database written by a
+    different one. It says so and stops, naming the file and what to do:
+    delete it, or pass a different `--db`. Nothing is migrated and nothing is
+    silently reinterpreted.
+
+    **This release crosses that line from 0.4.x.** Databases written by 0.4.x
+    will not open. If you run with `--db` and want to keep looking at what is
+    in there, keep a 0.4.x binary around; otherwise delete the file and let
+    0.5.0 make a new one. Running without `--db` is unaffected, since that is
+    in-memory and starts empty every time.
+
   footer: >-
     ---
     Released by [CtrlSpice](https://github.com/CtrlSpice) using [GoReleaser](https://github.com/goreleaser/goreleaser).

--- a/desktopexporter/internal/store/metrics/sdk_cumulative_test.go
+++ b/desktopexporter/internal/store/metrics/sdk_cumulative_test.go
@@ -1,0 +1,176 @@
+package metrics_test
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	cpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+// collector is a minimal OTLP metrics service that keeps what it is sent.
+type collector struct {
+	cpb.UnimplementedMetricsServiceServer
+	batches []pmetric.Metrics
+}
+
+func (c *collector) Export(_ context.Context, req *cpb.ExportMetricsServiceRequest) (*cpb.ExportMetricsServiceResponse, error) {
+	// Round-trip through the wire bytes rather than reading fields across: the
+	// point of this test is that nothing of ours interprets the SDK's output.
+	raw, err := proto.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	er := pmetricotlp.NewExportRequest()
+	if err := er.UnmarshalProto(raw); err != nil {
+		return nil, err
+	}
+	md := pmetric.NewMetrics()
+	er.Metrics().CopyTo(md)
+	c.batches = append(c.batches, md)
+	return &cpb.ExportMetricsServiceResponse{}, nil
+}
+
+// TestCumulativeMergeAgainstTheOtelSDK is the independence check the merge was
+// missing.
+//
+// Every other test of this path builds its cumulative datapoints from our own
+// understanding of what cumulative means -- fixtures we wrote, or real deltas we
+// accumulated ourselves. A shared misreading survives all of them: the merge and
+// the fixture would be wrong the same way and agree. Cumulative is also OTLP's
+// default, so it is the temporality most services actually send, and a subtly
+// wrong merge yields plausible quantiles rather than an error.
+//
+// Here the running totals come from the OpenTelemetry Go SDK, encoded by its own
+// OTLP exporter and decoded straight into pdata. Nothing between the instrument
+// and the store is ours, so agreement means our reading of cumulative matches
+// the SDK's -- an implementation written by people who never saw this query.
+//
+// The observations are chosen so the answer is known independently of both: the
+// second collection's values, and only those, are what a merge across the window
+// must report.
+func TestCumulativeMergeAgainstTheOtelSDK(t *testing.T) {
+	ctx := context.Background()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	sink := &collector{}
+	srv := grpc.NewServer()
+	cpb.RegisterMetricsServiceServer(srv, sink)
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.Stop()
+
+	exp, err := otlpmetricgrpc.New(ctx,
+		otlpmetricgrpc.WithEndpoint(lis.Addr().String()),
+		otlpmetricgrpc.WithInsecure(),
+		// Explicit, though it is also the default: this test is about cumulative.
+		otlpmetricgrpc.WithTemporalitySelector(func(sdkmetric.InstrumentKind) metricdata.Temporality {
+			return metricdata.CumulativeTemporality
+		}),
+	)
+	require.NoError(t, err)
+
+	reader := sdkmetric.NewPeriodicReader(exp, sdkmetric.WithInterval(time.Hour))
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	bounds := []float64{1, 5, 10}
+	hist, err := provider.Meter("sdk-cumulative-test").Float64Histogram(
+		"request.duration",
+		otelmetric.WithExplicitBucketBoundaries(bounds...),
+	)
+	require.NoError(t, err)
+	attrs := otelmetric.WithAttributes(attribute.String("route", "/checkout"))
+
+	// First collection: the baseline a window-spanning merge cannot see, because
+	// last-minus-first subtracts it.
+	firstCycle := []float64{0.5, 0.7, 2.0}
+	for _, v := range firstCycle {
+		hist.Record(ctx, v, attrs)
+	}
+	require.NoError(t, provider.ForceFlush(ctx))
+
+	// Second collection: the observations the merge must recover exactly. Spread
+	// across every bucket including the overflow, so a mistake in any one shows.
+	secondCycle := []float64{0.5, 3.0, 7.0, 7.5, 50.0}
+	for _, v := range secondCycle {
+		hist.Record(ctx, v, attrs)
+	}
+	require.NoError(t, provider.ForceFlush(ctx))
+	require.NoError(t, provider.Shutdown(ctx))
+
+	// At least one batch per forced collection, plus whatever Shutdown flushes.
+	// The extra one is harmless and worth allowing rather than suppressing: it
+	// carries the same running totals as the collection before it, since nothing
+	// was recorded in between, so last-minus-first is unchanged. Real services
+	// send exactly this on exit.
+	require.GreaterOrEqual(t, len(sink.batches), 2, "one batch per collection")
+
+	s, storeCtx, teardown := setupStore(t)
+	defer teardown()
+	for _, md := range sink.batches {
+		require.NoError(t, s.WithConn(func(conn driver.Conn) error {
+			return metrics.Ingest(storeCtx, conn, md, s.FlushedIDs())
+		}))
+	}
+
+	summaries := searchMetricsAll(t, s, storeCtx)
+	require.Len(t, summaries, 1)
+	require.Equal(t, "Cumulative", summaries[0]["aggregationTemporality"],
+		"the SDK must have sent cumulative, or this test proves nothing")
+
+	// One bucket over everything, so the merge is last-minus-first across both
+	// collections.
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return metrics.GetMetric(storeCtx, db, summaries[0]["id"].(string),
+			0, 1<<62, 1, nil, nil, 0, true, 0, 0, nil, "", nil, 0)
+	})
+	require.NoError(t, err)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	dps := got["timeseries"].([]any)[0].(map[string]any)["datapoints"].([]any)
+	require.Len(t, dps, 1, "one bucket is one merged datapoint")
+	merged := dps[0].(map[string]any)
+
+	// What the second collection alone contains, computed here from the values
+	// rather than read from either side.
+	wantCounts := make([]float64, len(bounds)+1)
+	wantSum := 0.0
+	for _, v := range secondCycle {
+		wantSum += v
+		i := len(bounds)
+		for j, b := range bounds {
+			if v <= b {
+				i = j
+				break
+			}
+		}
+		wantCounts[i]++
+	}
+
+	assert.Equal(t, float64(len(secondCycle)), merged["count"],
+		"the merge must recover exactly the second collection's observation count")
+	assert.InDelta(t, wantSum, merged["sum"], 1e-9,
+		"and its sum: the first collection is the baseline and subtracts away")
+
+	gotCounts := merged["bucketCounts"].([]any)
+	require.Len(t, gotCounts, len(wantCounts))
+	for i, want := range wantCounts {
+		assert.Equalf(t, want, gotCounts[i], "bucket %d", i)
+	}
+}

--- a/desktopexporter/internal/store/metrics/sdk_cumulative_test.go
+++ b/desktopexporter/internal/store/metrics/sdk_cumulative_test.go
@@ -19,32 +19,23 @@ import (
 	otelmetric "go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	cpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/proto"
 )
 
-// collector is a minimal OTLP metrics service that keeps what it is sent.
+// collector receives exported metrics the same way the viewer's own receiver
+// does: pmetricotlp.RegisterGRPCServer, the registration otlpreceiver uses at
+// otlp.go:105, whose Export is handed a decoded pmetricotlp.ExportRequest. The
+// decode is pdata's, not ours -- this type only keeps what arrives.
 type collector struct {
-	cpb.UnimplementedMetricsServiceServer
+	pmetricotlp.UnimplementedGRPCServer
 	batches []pmetric.Metrics
 }
 
-func (c *collector) Export(_ context.Context, req *cpb.ExportMetricsServiceRequest) (*cpb.ExportMetricsServiceResponse, error) {
-	// Round-trip through the wire bytes rather than reading fields across: the
-	// point of this test is that nothing of ours interprets the SDK's output.
-	raw, err := proto.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	er := pmetricotlp.NewExportRequest()
-	if err := er.UnmarshalProto(raw); err != nil {
-		return nil, err
-	}
+func (c *collector) Export(_ context.Context, req pmetricotlp.ExportRequest) (pmetricotlp.ExportResponse, error) {
 	md := pmetric.NewMetrics()
-	er.Metrics().CopyTo(md)
+	req.Metrics().CopyTo(md)
 	c.batches = append(c.batches, md)
-	return &cpb.ExportMetricsServiceResponse{}, nil
+	return pmetricotlp.NewExportResponse(), nil
 }
 
 // TestCumulativeMergeAgainstTheOtelSDK is the independence check the merge was
@@ -58,9 +49,11 @@ func (c *collector) Export(_ context.Context, req *cpb.ExportMetricsServiceReque
 // wrong merge yields plausible quantiles rather than an error.
 //
 // Here the running totals come from the OpenTelemetry Go SDK, encoded by its own
-// OTLP exporter and decoded straight into pdata. Nothing between the instrument
-// and the store is ours, so agreement means our reading of cumulative matches
-// the SDK's -- an implementation written by people who never saw this query.
+// OTLP exporter, and decoded by pdata's gRPC server -- the same registration the
+// viewer's receiver uses. The glue below keeps what arrives and does no
+// arithmetic, so no code of ours produces or interprets the cumulative values
+// under test. Agreement therefore means our reading of cumulative matches an
+// implementation written by people who never saw this query.
 //
 // The observations are chosen so the answer is known independently of both: the
 // second collection's values, and only those, are what a merge across the window
@@ -72,7 +65,7 @@ func TestCumulativeMergeAgainstTheOtelSDK(t *testing.T) {
 	require.NoError(t, err)
 	sink := &collector{}
 	srv := grpc.NewServer()
-	cpb.RegisterMetricsServiceServer(srv, sink)
+	pmetricotlp.RegisterGRPCServer(srv, sink)
 	go func() { _ = srv.Serve(lis) }()
 	defer srv.Stop()
 

--- a/go.mod
+++ b/go.mod
@@ -13,22 +13,33 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.64.0
 	go.opentelemetry.io/collector/component/componenttest v0.158.0
+	go.opentelemetry.io/collector/config/configoptional v1.64.0
 	go.opentelemetry.io/collector/confmap v1.64.0
 	go.opentelemetry.io/collector/confmap/provider/envprovider v1.64.0
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.64.0
+	go.opentelemetry.io/collector/confmap/xconfmap v0.158.0
 	go.opentelemetry.io/collector/connector v0.158.0
 	go.opentelemetry.io/collector/consumer v1.64.0
 	go.opentelemetry.io/collector/exporter v1.64.0
 	go.opentelemetry.io/collector/exporter/exporterhelper v0.158.0
 	go.opentelemetry.io/collector/extension v1.64.0
+	go.opentelemetry.io/collector/extension/extensiontest v0.158.0
 	go.opentelemetry.io/collector/otelcol v0.158.0
 	go.opentelemetry.io/collector/pdata v1.64.0
 	go.opentelemetry.io/collector/processor/batchprocessor v0.158.0
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.158.0
 	go.opentelemetry.io/collector/service v0.158.0
+	go.opentelemetry.io/otel v1.44.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0
+	go.opentelemetry.io/otel/metric v1.44.0
+	go.opentelemetry.io/otel/sdk/metric v1.44.0
+	go.opentelemetry.io/otel/trace v1.44.0
+	go.opentelemetry.io/proto/otlp v1.10.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/exp/jsonrpc2 v0.0.0-20260718201538-764159d718ef
 	golang.org/x/sys v0.47.0
+	google.golang.org/grpc v1.82.1
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -98,11 +109,9 @@ require (
 	go.opentelemetry.io/collector/config/configmiddleware v1.64.0 // indirect
 	go.opentelemetry.io/collector/config/confignet v1.64.0 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.64.0 // indirect
-	go.opentelemetry.io/collector/config/configoptional v1.64.0 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.64.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.158.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.64.0 // indirect
-	go.opentelemetry.io/collector/confmap/xconfmap v0.158.0 // indirect
 	go.opentelemetry.io/collector/connector/connectortest v0.158.0 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.158.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.158.0 // indirect
@@ -113,7 +122,6 @@ require (
 	go.opentelemetry.io/collector/extension/extensionauth v1.64.0 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.158.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.158.0 // indirect
-	go.opentelemetry.io/collector/extension/extensiontest v0.158.0 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.158.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.158.0 // indirect
@@ -142,10 +150,8 @@ require (
 	go.opentelemetry.io/contrib/propagators/b3 v1.44.0 // indirect
 	go.opentelemetry.io/contrib/propagators/jaeger v1.44.0 // indirect
 	go.opentelemetry.io/contrib/propagators/ot v1.44.0 // indirect
-	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.20.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.20.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 // indirect
@@ -155,12 +161,8 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/log v0.20.0 // indirect
-	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.20.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/trace v1.44.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
@@ -176,7 +178,5 @@ require (
 	gonum.org/v1/gonum v0.17.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.82.1 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -34,12 +34,10 @@ require (
 	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
-	go.opentelemetry.io/proto/otlp v1.10.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/exp/jsonrpc2 v0.0.0-20260718201538-764159d718ef
 	golang.org/x/sys v0.47.0
 	google.golang.org/grpc v1.82.1
-	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -163,6 +161,7 @@ require (
 	go.opentelemetry.io/otel/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.20.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
@@ -178,5 +177,6 @@ require (
 	gonum.org/v1/gonum v0.17.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Goreleaser builds release notes from commit subjects, so the one thing a reader needs before upgrading would sit in a list of twenty.

The store refuses a database written by a different schema version — it names the file and stops, nothing is migrated. 0.5.0 is the first release where that check has teeth.

`release.header` renders it above the changelog. First paragraph is the rule and holds for every release; the second names 0.4.x and should be dropped when a release doesn't cross a schema change.

`release.header` checked against goreleaser's schema.
