### PR TITLE
Dictionary explicit_bounds, referenced by bounds_id

### DIFF
--- a/desktopexporter/internal/store/ingest/dictionary.go
+++ b/desktopexporter/internal/store/ingest/dictionary.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql/driver"
+	"encoding/binary"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -286,6 +288,7 @@ type Dictionary struct {
 	attributes map[duckdb.UUID]Attribute
 	resources  map[duckdb.UUID]Resource
 	scopes     map[duckdb.UUID]Scope
+	bounds     map[duckdb.UUID][]float64
 
 	// flushed is the store's record of what is already in the database. May be
 	// nil, which disables the optimisation and restores the always-insert
@@ -303,6 +306,7 @@ func NewDictionary(flushed *FlushedIDs) *Dictionary {
 		attributes: map[duckdb.UUID]Attribute{},
 		resources:  map[duckdb.UUID]Resource{},
 		scopes:     map[duckdb.UUID]Scope{},
+		bounds:     map[duckdb.UUID][]float64{},
 		flushed:    flushed,
 	}
 }
@@ -315,6 +319,36 @@ func (d *Dictionary) AddAttributes(attrs pcommon.Map, scope string) []duckdb.UUI
 		d.attributes[r.ID] = r
 	}
 	return ids
+}
+
+// BoundsID derives the dictionary id for one explicit-bounds vector.
+//
+// Hashed over the IEEE-754 bits of each bound rather than a decimal rendering:
+// bits are the value's identity with no formatting decision to drift between
+// producers, and a count prefix makes the encoding unambiguous the same way
+// hashID's length prefixes do. Pure and cheap, which is what lets pass 2
+// recompute it at append time instead of threading it through dpIdentity.
+func BoundsID(bounds []float64) duckdb.UUID {
+	h := sha256.New()
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], uint64(len(bounds)))
+	h.Write(buf[:])
+	for _, b := range bounds {
+		binary.BigEndian.PutUint64(buf[:], math.Float64bits(b))
+		h.Write(buf[:])
+	}
+	var id duckdb.UUID
+	copy(id[:], h.Sum(nil)[:16])
+	return id
+}
+
+// AddBounds records one explicit-bounds vector and returns its id.
+func (d *Dictionary) AddBounds(bounds []float64) duckdb.UUID {
+	id := BoundsID(bounds)
+	if _, ok := d.bounds[id]; !ok {
+		d.bounds[id] = bounds
+	}
+	return id
 }
 
 // AddResource records a resource and returns its id.
@@ -364,7 +398,10 @@ func (d *Dictionary) Flush(ctx context.Context, conn driver.Conn) error {
 	if err := d.flushResources(ctx, conn); err != nil {
 		return err
 	}
-	return d.flushScopes(ctx, conn)
+	if err := d.flushScopes(ctx, conn); err != nil {
+		return err
+	}
+	return d.flushBounds(ctx, conn)
 }
 
 // flushRows is the sequence every dictionary flush shares: filter down to
@@ -425,6 +462,23 @@ func (d *Dictionary) flushAttributes(ctx context.Context, conn driver.Conn) erro
 				scopes = append(scopes, a.Scope)
 			}
 			return []any{ids, keys, values, types, scopes}
+		})
+}
+
+const boundsUpsert = `insert into histogram_bounds (id, bounds)
+	select unnest(?::varchar[])::uuid, unnest(?::double[][])
+	on conflict (id) do nothing`
+
+func (d *Dictionary) flushBounds(ctx context.Context, conn driver.Conn) error {
+	return flushRows(ctx, conn, d.flushed, d.bounds, boundsUpsert, "histogram_bounds",
+		func(rows map[duckdb.UUID][]float64) []any {
+			ids := make([]string, 0, len(rows))
+			vectors := make([][]float64, 0, len(rows))
+			for id, b := range rows {
+				ids = append(ids, formatUUID(id))
+				vectors = append(vectors, b)
+			}
+			return []any{ids, vectors}
 		})
 }
 

--- a/desktopexporter/internal/store/ingest/flushed.go
+++ b/desktopexporter/internal/store/ingest/flushed.go
@@ -106,7 +106,7 @@ type idQueryer interface {
 // NewFlushedIDs.
 func LoadFlushedIDs(ctx context.Context, db idQueryer) (*FlushedIDs, error) {
 	f := NewFlushedIDs()
-	for _, table := range [...]string{"attributes", "resources", "scopes"} {
+	for _, table := range [...]string{"attributes", "resources", "scopes", "histogram_bounds"} {
 		if err := warmFlushedFrom(ctx, db, table, f); err != nil {
 			return nil, fmt.Errorf("LoadFlushedIDs: %w: %w", ErrIngestInternal, err)
 		}

--- a/desktopexporter/internal/store/ingest/sweep.go
+++ b/desktopexporter/internal/store/ingest/sweep.go
@@ -76,6 +76,15 @@ var sweepQueries = []string{
 	) returning id::varchar`,
 
 	`delete from attributes where id not in (` + liveAttributeIDs + `) returning id::varchar`,
+
+	// Bounds are referenced only by datapoints, and through a real foreign
+	// key rather than a LIST -- but the sweep still has to run, because a
+	// foreign key stops a bad delete, it does not collect a row nothing
+	// points at. bounds_id is nullable (only explicit-bucket histograms carry
+	// one), hence the is-not-null guard on the live set.
+	`delete from histogram_bounds where id not in (
+		select bounds_id from datapoints where bounds_id is not null
+	) returning id::varchar`,
 }
 
 // SweepOrphans deletes dictionary, resource and scope rows nothing references.

--- a/desktopexporter/internal/store/metrics/metrics.go
+++ b/desktopexporter/internal/store/metrics/metrics.go
@@ -361,6 +361,16 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 // is flushed before collectSeries runs, because series rows reference these ids
 // and no foreign key can enforce that ordering into a uuid[].
 func addMetricAttributes(dict *ingest.Dictionary, metric pmetric.Metric, out [][]duckdb.UUID) [][]duckdb.UUID {
+	// Bounds vectors are dictionary rows the datapoints will reference, so
+	// they must be registered in this pass: the dictionary flushes before the
+	// appenders open, and a foreign key holds datapoints to it. Pass 2 does
+	// not need the ids handed over -- BoundsID is a pure hash, so the appender
+	// recomputes it from the same bytes.
+	if metric.Type() == pmetric.MetricTypeHistogram {
+		for _, dp := range metric.Histogram().DataPoints().All() {
+			dict.AddBounds(dp.ExplicitBounds().AsRaw())
+		}
+	}
 	eachDatapoint(metric, func(attrs pcommon.Map, exemplars pmetric.ExemplarSlice) {
 		out = append(out, ingest.NonNil(dict.AddAttributes(attrs, ingest.ScopeDatapoint)))
 		addExemplarAttributes(dict, exemplars)
@@ -664,7 +674,7 @@ func ingestHistogramDatapoints(appenders map[string]*duckdb.Appender, streamID, 
 		if err := appenders["datapoints"].AppendRow(
 			datapointID, streamID, ident.series, ingestID, int64(dp.Timestamp()), int64(dp.StartTimestamp()), uint32(dp.Flags()),
 			nil, nil, nil,
-			dp.Count(), dp.Sum(), dp.Min(), dp.Max(), dp.BucketCounts().AsRaw(), dp.ExplicitBounds().AsRaw(),
+			dp.Count(), dp.Sum(), dp.Min(), dp.Max(), dp.BucketCounts().AsRaw(), ingest.BoundsID(dp.ExplicitBounds().AsRaw()),
 			nil, nil, nil, nil, nil, nil, nil,
 			ident.attrs,
 		); err != nil {

--- a/desktopexporter/internal/store/metrics/metrics_test.go
+++ b/desktopexporter/internal/store/metrics/metrics_test.go
@@ -4858,3 +4858,89 @@ func TestGetMetric_ColumnWindowMergesTheWholeColumn(t *testing.T) {
 			"of 100 observations each; more means the fetched window is wider than "+
 			"the column", perColumn)
 }
+
+// TestHistogramBoundsAreStoredOnce pins the bounds dictionary: the vector is a
+// property of the instrument, so a series reporting all session writes it one
+// time, however many datapoints arrive -- and a stream whose bounds genuinely
+// change mid-flight gets a second row, not a collision, because OTel only
+// makes fixed bounds a practice, never a promise.
+func TestHistogramBoundsAreStoredOnce(t *testing.T) {
+	s, ctx, teardown := setupStore(t)
+	defer teardown()
+
+	base := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	boundsA := []float64{1, 5, 10}
+	boundsB := []float64{2, 4, 8, 16}
+	var dps []histTestDP
+	for i := range 40 {
+		b := boundsA
+		counts := []uint64{1, 2, 3, 4}
+		if i >= 30 {
+			// The pathological case: the SDK was reconfigured mid-stream.
+			b = boundsB
+			counts = []uint64{1, 2, 3, 4, 5}
+		}
+		dps = append(dps, histTestDP{
+			timestamp: base.Add(time.Duration(i) * 10 * time.Second),
+			attrs:     map[string]string{"pod": "a"},
+			bounds:    b,
+			counts:    counts,
+			count:     10, sum: 30, min: 0.5, max: 9.5,
+		})
+	}
+	fixture := makeHistogramFixtureT("bounds.hist", pmetric.AggregationTemporalityDelta, dps)
+	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
+		return metrics.Ingest(ctx, conn, fixture, s.FlushedIDs())
+	}))
+
+	assert.Equal(t, 2, countRows(t, s, ctx, `select count(*) from histogram_bounds`),
+		"40 datapoints carry 2 distinct bounds vectors, so the dictionary holds 2 rows")
+	assert.Zero(t, countRows(t, s, ctx,
+		`select count(*) from datapoints
+		 where bounds_id is not null
+		   and not exists (select 1 from histogram_bounds hb where hb.id = bounds_id)`),
+		"every reference resolves; nothing may point at a row that is not there")
+
+	// The wire is unchanged: each datapoint comes back with the exact vector
+	// it arrived with, resolved through the dictionary.
+	summaries := searchMetricsAll(t, s, ctx)
+	require.Len(t, summaries, 1)
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return metrics.GetMetric(ctx, db, summaries[0]["id"].(string),
+			base.Add(-time.Hour).UnixNano(), base.Add(time.Hour).UnixNano(),
+			0, nil, nil, 0, true, 0, 0, nil, "", nil, 0)
+	})
+	require.NoError(t, err)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	seen := map[int]int{}
+	for _, ts := range got["timeseries"].([]any) {
+		for _, d := range ts.(map[string]any)["datapoints"].([]any) {
+			eb := d.(map[string]any)["explicitBounds"].([]any)
+			seen[len(eb)]++
+		}
+	}
+	assert.Equal(t, map[int]int{3: 30, 4: 10}, seen,
+		"each datapoint resolves its own vector -- 30 with the original bounds, "+
+			"10 with the reconfigured ones")
+
+	// Sweep: clearing the metrics orphans both rows, and the sweep takes them.
+	require.NoError(t, s.WithDBWrite(func(db *sql.DB) error {
+		return metrics.Clear(ctx, db)
+	}))
+	require.NoError(t, s.WithDBWrite(func(db *sql.DB) error {
+		return ingest.SweepOrphans(ctx, db, s.FlushedIDs())
+	}))
+	assert.Zero(t, countRows(t, s, ctx, `select count(*) from histogram_bounds`),
+		"bounds nothing references are garbage, and retention measures garbage "+
+			"as if it were data")
+
+	// And re-ingest after the sweep still works: the FlushedIDs entries for the
+	// swept rows must have been forgotten, or the dictionary skips the insert
+	// and the datapoints' foreign key has nothing to point at.
+	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
+		return metrics.Ingest(ctx, conn, makeHistogramFixtureT("bounds.hist",
+			pmetric.AggregationTemporalityDelta, dps), s.FlushedIDs())
+	}))
+	assert.Equal(t, 2, countRows(t, s, ctx, `select count(*) from histogram_bounds`))
+}

--- a/desktopexporter/internal/store/queries/ddl/tables/_order
+++ b/desktopexporter/internal/store/queries/ddl/tables/_order
@@ -17,5 +17,6 @@ logs.sql
 metric_streams.sql
 metric_series.sql
 metric_ingests.sql
+histogram_bounds.sql
 datapoints.sql
 exemplars.sql

--- a/desktopexporter/internal/store/queries/ddl/tables/datapoints.sql
+++ b/desktopexporter/internal/store/queries/ddl/tables/datapoints.sql
@@ -22,7 +22,12 @@ create table if not exists datapoints (
 		min double,
 		max double,
 		bucket_counts ubigint[],
-		explicit_bounds double[],
+		-- References histogram_bounds instead of carrying the vector. The
+		-- reference costs a fixed 16 bytes; the vector it replaces repeats
+		-- identically on every datapoint of a histogram series, and uuid
+		-- columns do not dictionary-compress the way varchars do -- the
+		-- dedupe has to be structural.
+		bounds_id uuid,
 		scale integer,
 		zero_count ubigint,
 		zero_threshold double,
@@ -42,5 +47,6 @@ create table if not exists datapoints (
 		attribute_ids uuid[] not null,
 		foreign key (stream_id) references metric_streams(id),
 		foreign key (series_id) references metric_series(id),
-		foreign key (metric_ingest_id) references metric_ingests(id)
+		foreign key (metric_ingest_id) references metric_ingests(id),
+		foreign key (bounds_id) references histogram_bounds(id)
 	)

--- a/desktopexporter/internal/store/queries/ddl/tables/histogram_bounds.sql
+++ b/desktopexporter/internal/store/queries/ddl/tables/histogram_bounds.sql
@@ -1,0 +1,21 @@
+-- The bounds dictionary: one row per distinct explicit-bounds vector.
+--
+-- Bucket boundaries are a property of the instrument, not the observation, so
+-- a histogram reporting every few seconds writes the same ~25-double array on
+-- every datapoint -- the same shape of duplication the attribute dictionary
+-- removed, and one the storage layer's varchar compression cannot touch,
+-- because a double[] is not a varchar.
+--
+-- A dictionary rather than a column on metric_streams: OTel does not promise
+-- bounds are fixed per stream, it is only the overwhelming practice. Hashing
+-- handles the exception instead of assuming it away -- a stream whose SDK is
+-- reconfigured mid-flight simply references a second row.
+--
+-- id is content-derived (sha256 over the IEEE-754 bits of each bound,
+-- length-prefixed, truncated to a uuid), so the same vector hashes to the same
+-- row across batches and restarts with no read-back, exactly as attribute ids
+-- do.
+create table if not exists histogram_bounds (
+		id uuid primary key,
+		bounds double[] not null
+	)

--- a/desktopexporter/internal/store/queries/metrics/get_metric.sql
+++ b/desktopexporter/internal/store/queries/metrics/get_metric.sql
@@ -125,7 +125,12 @@
 		-- than a denormalized column on datapoints: it is a primary-key lookup
 		-- from metric_ingest_id, and datapoints is the largest table here.
 		filtered_dps as (
-			select d.*,
+			-- bounds_id resolves to the vector here, under the name the rest
+			-- of the query has always read, so the dictionary is invisible
+			-- past this point. The join is a primary-key lookup against a
+			-- table with one row per distinct instrument configuration.
+			select d.* exclude (bounds_id),
+				hb.bounds as explicit_bounds,
 				-- The offset this row's bucket is shifted by: the viewer's zone
 				-- resolved at this instant, or the single offset the caller sent
 				-- when it named no zone.
@@ -134,7 +139,9 @@
 				s.metric_type as metric_type,
 				s.aggregation_temporality as aggregation_temporality,
 				s.is_monotonic as is_monotonic
-			from datapoints d, input, stream s
+			from datapoints d
+			left join histogram_bounds hb on hb.id = d.bounds_id,
+				input, stream s
 			where d.stream_id = input.stream_id
 			  and d.timestamp >= input.time_start and d.timestamp <= input.time_end
 			  -- Narrowing here rather than after the merge: the reduction and

--- a/desktopexporter/internal/store/schema/version.go
+++ b/desktopexporter/internal/store/schema/version.go
@@ -49,7 +49,12 @@ package schema
 //
 // Files written before versioning existed carry no stamp at all and are
 // detected separately.
-const Version = 4
+//
+// Version 5 moved explicit_bounds off datapoints into the histogram_bounds
+// dictionary, referenced by bounds_id. A version 4 file has the vector where
+// this build expects a reference, so its histogram datapoints are unreadable
+// under this schema, not merely stale.
+const Version = 5
 
 // VersionTableQuery creates the version table.
 //


### PR DESCRIPTION
Bucket boundaries are a property of the instrument, so a histogram series writes the same ~25-double vector on every datapoint — and lists of doubles don't compress: measured at 197 bytes per row, essentially raw. `histogram_bounds` stores each distinct vector once; datapoints carry a 16-byte `bounds_id`.

- **Dictionary, not a `metric_streams` column** — OTel makes fixed bounds a practice, not a promise. A reconfigured SDK references a second row instead of colliding.
- **Content-derived id** (sha256 over IEEE-754 bits, count-prefixed): pass 1 registers, pass 2 recomputes at append time — a pure hash needs no plumbing through `dpIdentity`.
- **Invisible to the query**: `filtered_dps` resolves the reference under the old column name; nothing downstream changed. The whole existing histogram suite passed untouched on first run, which is the read-path proof.
- **Sweep + FlushedIDs** extended; re-ingest after a sweep re-inserts (the FK would fail loudly if it didn't).

**The honest measurement:** on the reference corpus this is a wash — +3 blocks. The Canada replay is gauge-dominated (6,638 histogram datapoints of 247,462), so the 1.3 MB of removed vectors is roughly repaid by the reference column, dictionary, and FK index. The result that matters is the per-row constant: **197 B → 16 B per histogram datapoint**, which is ~18 MB per 100k on the duration-histogram-dominated stores production services actually have. The dictionary held 4 rows for the whole corpus, the cumulative twin sharing its source's vector across streams.

**Why now:** schema version 4 → 5. It rides 0.5.0's already-announced break; shipped later it forces its own.

Mutation-checked: a random id in place of the hash fails ingest against the FK; removing the sweep query leaves orphans the test counts; dropping the join nulls every bounds assertion.

Closes #319
