### PR TITLE
Cache the hashed assets, revalidate the document

### DIFF
--- a/desktopexporter/internal/server/server.go
+++ b/desktopexporter/internal/server/server.go
@@ -1,8 +1,11 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"embed"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -152,26 +155,70 @@ func staticFS() (fs.FS, error) {
 // client router owns the route (e.g. a deep-linked /traces/{id} or a refreshed
 // /metrics). Paths with a file extension that do not exist 404 normally. Non-GET
 // requests fall through to the file server.
+// Cache policy for the embedded frontend. Two populations, two rules.
+//
+// Everything under assets/ is content-hashed by Vite, so its URL changes
+// whenever its bytes do and it can be cached forever. index.html is the
+// opposite: a stable name whose contents *name* those hashed files. Cache it
+// and someone who upgrades the binary keeps HTML pointing at chunks the new
+// build does not contain -- a blank page and a pile of 404s, cleared only by a
+// hard reload nobody knows to do. no-cache does not mean "do not store", it
+// means "revalidate before use", which is exactly the difference.
+//
+// Nothing was sent before: assets come from an embed.FS, whose files report a
+// zero mod time, and Go deliberately omits Last-Modified when the time is
+// zero. It never synthesises an ETag either. So there was no freshness
+// directive and no validator, and the browser re-fetched all 2MB on every load.
+const (
+	immutableCacheControl  = "public, max-age=31536000, immutable"
+	revalidateCacheControl = "no-cache"
+)
+
 func spaHandler(fsys fs.FS, logger *zap.Logger) http.Handler {
 	fileServer := http.FileServerFS(fsys)
-	serveIndex := func(writer http.ResponseWriter) {
-		bytes, err := fs.ReadFile(fsys, "index.html")
-		if err != nil {
-			logger.Error("reading index.html", zap.Error(err))
+
+	// The validator Go will not invent. Computed once: the FS is embedded, so
+	// these bytes cannot change while the process runs. It turns each
+	// revalidation of index.html into a 304 rather than another copy of the
+	// document.
+	indexBytes, indexErr := fs.ReadFile(fsys, "index.html")
+	indexETag := ""
+	if indexErr == nil {
+		sum := sha256.Sum256(indexBytes)
+		indexETag = `"` + hex.EncodeToString(sum[:16]) + `"`
+	}
+
+	serveIndex := func(writer http.ResponseWriter, request *http.Request) {
+		if indexErr != nil {
+			logger.Error("reading index.html", zap.Error(indexErr))
 			http.Error(writer, "Failed to load page", http.StatusInternalServerError)
 			return
 		}
 		writer.Header().Set("Content-Type", "text/html; charset=utf-8")
-		writer.Write(bytes)
+		writer.Header().Set("Cache-Control", revalidateCacheControl)
+		writer.Header().Set("ETag", indexETag)
+		// ServeContent rather than Write, for the conditional request handling:
+		// it answers a matching If-None-Match with 304 and no body. The zero
+		// mod time is what kept Last-Modified out; the ETag above replaces it.
+		http.ServeContent(writer, request, "index.html", time.Time{}, bytes.NewReader(indexBytes))
 	}
+
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.Method == http.MethodGet || request.Method == http.MethodHead {
 			name := strings.TrimPrefix(path.Clean(request.URL.Path), "/")
 			if info, err := fs.Stat(fsys, name); name == "" || err != nil || info.IsDir() {
 				if path.Ext(name) == "" {
-					serveIndex(writer)
+					serveIndex(writer, request)
 					return
 				}
+			}
+			// Keyed on the assets/ prefix rather than "anything the file
+			// server handles", because a direct GET /index.html lands here
+			// too -- and that is the one file this header must never reach.
+			if strings.HasPrefix(name, "assets/") {
+				writer.Header().Set("Cache-Control", immutableCacheControl)
+			} else {
+				writer.Header().Set("Cache-Control", revalidateCacheControl)
 			}
 		}
 		fileServer.ServeHTTP(writer, request)

--- a/desktopexporter/internal/server/server_test.go
+++ b/desktopexporter/internal/server/server_test.go
@@ -236,6 +236,19 @@ func TestStaticCacheHeaders(t *testing.T) {
 		}
 	})
 
+	// Relied on rather than implemented: since Go 1.23, serveError deletes
+	// Cache-Control, Etag, Last-Modified and Content-Encoding on the error
+	// path, because a caller may have set them for the success case. Without
+	// that, a request for an asset that does not exist would be answered with
+	// a year-long immutable 404 -- and a later build that adds the file could
+	// not dislodge it. Asserted because the whole prefix rule leans on it.
+	t.Run("a missing asset is not cached", func(t *testing.T) {
+		resp := get("/assets/never-existed-000000.js")
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+		assert.Empty(t, resp.Header.Get("Cache-Control"),
+			"a 404 must not inherit the immutable header meant for real assets")
+	})
+
 	t.Run("index carries an ETag and honours If-None-Match", func(t *testing.T) {
 		resp := get("/")
 		etag := resp.Header.Get("ETag")

--- a/desktopexporter/internal/server/server_test.go
+++ b/desktopexporter/internal/server/server_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/telemetry"
@@ -190,4 +191,62 @@ func TestStartBindConflict(t *testing.T) {
 
 	err = s.Start()
 	require.Error(t, err)
+}
+
+// TestStaticCacheHeaders covers the two populations the embedded frontend
+// splits into, and the one mistake that would be expensive.
+//
+// Nothing was sent before this: assets are served from an embed.FS, whose files
+// report a zero mod time, and Go omits Last-Modified when the time is zero and
+// never synthesises an ETag. No freshness directive, no validator, so the
+// browser re-fetched the whole 2MB frontend on every page load.
+func TestStaticCacheHeaders(t *testing.T) {
+	fsys := fstest.MapFS{
+		"index.html":              &fstest.MapFile{Data: []byte("<!doctype html><div id=app>")},
+		"assets/index-abc123.js":  &fstest.MapFile{Data: []byte("console.log(1)")},
+		"assets/style-def456.css": &fstest.MapFile{Data: []byte("body{}")},
+	}
+	handler := spaHandler(fsys, zap.NewNop())
+
+	get := func(target string) *http.Response {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, target, nil))
+		return rec.Result()
+	}
+
+	t.Run("hashed assets are immutable", func(t *testing.T) {
+		for _, target := range []string{"/assets/index-abc123.js", "/assets/style-def456.css"} {
+			resp := get(target)
+			assert.Equal(t, immutableCacheControl, resp.Header.Get("Cache-Control"),
+				"%s is content-hashed, so its URL changes when its bytes do", target)
+		}
+	})
+
+	// The dangerous one. index.html has a stable name and its contents name the
+	// hashed files, so caching it hands an upgraded binary's user stale HTML
+	// pointing at chunks that no longer exist.
+	t.Run("index.html is never immutable", func(t *testing.T) {
+		for _, target := range []string{"/", "/traces", "/index.html"} {
+			resp := get(target)
+			cc := resp.Header.Get("Cache-Control")
+			assert.Equal(t, revalidateCacheControl, cc, "%s must revalidate", target)
+			assert.NotContains(t, cc, "immutable",
+				"%s serves the document that names every hashed asset", target)
+		}
+	})
+
+	t.Run("index carries an ETag and honours If-None-Match", func(t *testing.T) {
+		resp := get("/")
+		etag := resp.Header.Get("ETag")
+		require.NotEmpty(t, etag, "no validator means revalidation re-sends the whole document")
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("If-None-Match", etag)
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusNotModified, rec.Code,
+			"a matching validator should cost a 304, not another copy")
+		assert.Empty(t, rec.Body.String())
+	})
 }


### PR DESCRIPTION
The frontend was re-downloaded in full on every page load — 2MB across 64 files, with no `Cache-Control`, no `ETag`, no `Last-Modified`. `FileServerFS` would normally give revalidation for free, but these files come from an `embed.FS` whose entries report a zero mod time, and Go omits `Last-Modified` when the time is zero and never invents an `ETag`.

Two populations, two rules:

- **`assets/`** is content-hashed by Vite, so a URL changes whenever its bytes do — cached for a year, `immutable`.
- **`index.html`** has a stable name and its contents *name* those hashed files. Caching it hands anyone who upgrades a document pointing at chunks the new build doesn't have: a blank page and 404s, cleared only by a hard reload they've no reason to try. It gets `no-cache` (revalidate, not "don't store") plus a content `ETag`, so revalidating costs a 304 rather than another copy.

Scoped on the `assets/` prefix rather than on which branch serves the file, because a direct `GET /index.html` also goes through the file server — and that's the one file `immutable` must never reach.

Tests cover both populations and that boundary; applying `immutable` broadly, or to the document, each fail.

Closes #349
