### PR TITLE
Walk a trace's own spans, not the whole table

### DIFF
--- a/desktopexporter/internal/store/queries/spans/search_spans.sql
+++ b/desktopexporter/internal/store/queries/spans/search_spans.sql
@@ -2,30 +2,48 @@
 		with recursive
 		{{.CTEs}},
 
-		spans_tree as (
-			select
-				s.trace_id, s.span_id, s.parent_span_id, s.start_time,
-				0 as depth,
-				array[row_number() over (order by
-					case when s.parent_span_id is null then 0 else 1 end,
-					s.start_time
-				)] as sort_path
+		-- This trace's spans, isolated once, before the walk begins.
+		--
+		-- The recursive arm below runs once per level of the tree, and a
+		-- recursive CTE cannot use an index on its working table: DuckDB
+		-- re-joins whatever relation the arm names on every iteration. Naming
+		-- `spans` there means each level hash-joins the entire table, so the
+		-- cost of fetching one trace tracks how much telemetry the store holds
+		-- rather than how big the trace is -- a point lookup priced as a scan.
+		-- Measured on a 2.3M-span store, fetching a 159-span trace 14 levels
+		-- deep: 54ms naming `spans`, 5ms naming this CTE, same rows out.
+		--
+		-- `materialized` is the load-bearing word. Without it DuckDB is free to
+		-- inline the definition into each reference, which puts the full-table
+		-- scan back exactly where it was removed from.
+		trace_spans as materialized (
+			select s.trace_id, s.span_id, s.parent_span_id, s.start_time
 			from spans s, search_params
 			where s.trace_id = search_params.trace_id
-				and (s.parent_span_id is null or s.parent_span_id not in (
-					select span_id from spans where trace_id = search_params.trace_id
-				))
+		),
+
+		spans_tree as (
+			select
+				t.trace_id, t.span_id, t.parent_span_id, t.start_time,
+				0 as depth,
+				array[row_number() over (order by
+					case when t.parent_span_id is null then 0 else 1 end,
+					t.start_time
+				)] as sort_path
+			from trace_spans t
+			where t.parent_span_id is null
+				or t.parent_span_id not in (select span_id from trace_spans)
 
 			union all
 
 			select
-				s.trace_id, s.span_id, s.parent_span_id, s.start_time,
+				t.trace_id, t.span_id, t.parent_span_id, t.start_time,
 				st.depth + 1,
 				st.sort_path || array[row_number() over (
-					partition by st.span_id order by s.start_time
+					partition by st.span_id order by t.start_time
 				)] as sort_path
-			from spans s
-			join spans_tree st on s.parent_span_id = st.span_id and s.trace_id = st.trace_id
+			from trace_spans t
+			join spans_tree st on t.parent_span_id = st.span_id
 		){{.MatchedCTE}},
 
 		-- The walk's result joined back to its payload, once.

--- a/desktopexporter/internal/store/spans/testdata/search_spans_no_search.sql
+++ b/desktopexporter/internal/store/spans/testdata/search_spans_no_search.sql
@@ -2,30 +2,48 @@
 		with recursive
 		search_params as (select try_cast(? as uuid) as trace_id),
 
-		spans_tree as (
-			select
-				s.trace_id, s.span_id, s.parent_span_id, s.start_time,
-				0 as depth,
-				array[row_number() over (order by
-					case when s.parent_span_id is null then 0 else 1 end,
-					s.start_time
-				)] as sort_path
+		-- This trace's spans, isolated once, before the walk begins.
+		--
+		-- The recursive arm below runs once per level of the tree, and a
+		-- recursive CTE cannot use an index on its working table: DuckDB
+		-- re-joins whatever relation the arm names on every iteration. Naming
+		-- `spans` there means each level hash-joins the entire table, so the
+		-- cost of fetching one trace tracks how much telemetry the store holds
+		-- rather than how big the trace is -- a point lookup priced as a scan.
+		-- Measured on a 2.3M-span store, fetching a 159-span trace 14 levels
+		-- deep: 54ms naming `spans`, 5ms naming this CTE, same rows out.
+		--
+		-- `materialized` is the load-bearing word. Without it DuckDB is free to
+		-- inline the definition into each reference, which puts the full-table
+		-- scan back exactly where it was removed from.
+		trace_spans as materialized (
+			select s.trace_id, s.span_id, s.parent_span_id, s.start_time
 			from spans s, search_params
 			where s.trace_id = search_params.trace_id
-				and (s.parent_span_id is null or s.parent_span_id not in (
-					select span_id from spans where trace_id = search_params.trace_id
-				))
+		),
+
+		spans_tree as (
+			select
+				t.trace_id, t.span_id, t.parent_span_id, t.start_time,
+				0 as depth,
+				array[row_number() over (order by
+					case when t.parent_span_id is null then 0 else 1 end,
+					t.start_time
+				)] as sort_path
+			from trace_spans t
+			where t.parent_span_id is null
+				or t.parent_span_id not in (select span_id from trace_spans)
 
 			union all
 
 			select
-				s.trace_id, s.span_id, s.parent_span_id, s.start_time,
+				t.trace_id, t.span_id, t.parent_span_id, t.start_time,
 				st.depth + 1,
 				st.sort_path || array[row_number() over (
-					partition by st.span_id order by s.start_time
+					partition by st.span_id order by t.start_time
 				)] as sort_path
-			from spans s
-			join spans_tree st on s.parent_span_id = st.span_id and s.trace_id = st.trace_id
+			from trace_spans t
+			join spans_tree st on t.parent_span_id = st.span_id
 		),
 
 		-- The walk's result joined back to its payload, once.

--- a/desktopexporter/internal/store/spans/testdata/search_spans_with_search.sql
+++ b/desktopexporter/internal/store/spans/testdata/search_spans_with_search.sql
@@ -2,30 +2,48 @@
 		with recursive
 		search_params as (select try_cast(? as uuid) as trace_id),
 
-		spans_tree as (
-			select
-				s.trace_id, s.span_id, s.parent_span_id, s.start_time,
-				0 as depth,
-				array[row_number() over (order by
-					case when s.parent_span_id is null then 0 else 1 end,
-					s.start_time
-				)] as sort_path
+		-- This trace's spans, isolated once, before the walk begins.
+		--
+		-- The recursive arm below runs once per level of the tree, and a
+		-- recursive CTE cannot use an index on its working table: DuckDB
+		-- re-joins whatever relation the arm names on every iteration. Naming
+		-- `spans` there means each level hash-joins the entire table, so the
+		-- cost of fetching one trace tracks how much telemetry the store holds
+		-- rather than how big the trace is -- a point lookup priced as a scan.
+		-- Measured on a 2.3M-span store, fetching a 159-span trace 14 levels
+		-- deep: 54ms naming `spans`, 5ms naming this CTE, same rows out.
+		--
+		-- `materialized` is the load-bearing word. Without it DuckDB is free to
+		-- inline the definition into each reference, which puts the full-table
+		-- scan back exactly where it was removed from.
+		trace_spans as materialized (
+			select s.trace_id, s.span_id, s.parent_span_id, s.start_time
 			from spans s, search_params
 			where s.trace_id = search_params.trace_id
-				and (s.parent_span_id is null or s.parent_span_id not in (
-					select span_id from spans where trace_id = search_params.trace_id
-				))
+		),
+
+		spans_tree as (
+			select
+				t.trace_id, t.span_id, t.parent_span_id, t.start_time,
+				0 as depth,
+				array[row_number() over (order by
+					case when t.parent_span_id is null then 0 else 1 end,
+					t.start_time
+				)] as sort_path
+			from trace_spans t
+			where t.parent_span_id is null
+				or t.parent_span_id not in (select span_id from trace_spans)
 
 			union all
 
 			select
-				s.trace_id, s.span_id, s.parent_span_id, s.start_time,
+				t.trace_id, t.span_id, t.parent_span_id, t.start_time,
 				st.depth + 1,
 				st.sort_path || array[row_number() over (
-					partition by st.span_id order by s.start_time
+					partition by st.span_id order by t.start_time
 				)] as sort_path
-			from spans s
-			join spans_tree st on s.parent_span_id = st.span_id and s.trace_id = st.trace_id
+			from trace_spans t
+			join spans_tree st on t.parent_span_id = st.span_id
 		),
 		matched_spans as (
 			select s.span_id


### PR DESCRIPTION
Found while benchmarking trace retrieval against a 2.3M-span store captured from the OpenTelemetry Demo.

**The symptom**

- Fetching one trace cost the same regardless of its size — 156 ms for a 9-span trace, 174 ms for a 156-span one on the same store.
- Flat cost against trace size, rising with store size (28 ms at 25k spans, ~175 ms at 2.3M). A point lookup priced as a scan.

**The cause**

- The recursive arm named `spans`. A recursive CTE cannot use an index on its working table — DuckDB re-joins whatever relation the arm names on every iteration.
- A demo trace is 14 levels deep, so fetching it hash-joined all 2.3M rows fourteen times to find a dozen children each pass.
- `idx_spans_traceid` was neither the problem nor the fix: it cannot apply inside the recursion at all. Worth stating, because "add an index" is the reflex here and it would have bought nothing.
- The recursion was already narrowed to six columns with the payload joined once afterward, so that avenue was spent — this is a different bottleneck than the one the plan predicted.

**The fix**

- Both arms now read a `trace_spans` CTE holding only the target trace, isolated once before the walk begins.
- `materialized` is load-bearing. Without it DuckDB may inline the definition into each reference, putting the full-table scan back exactly where it was removed.
- The recursive arm drops `and s.trace_id = st.trace_id`; every row in `trace_spans` belongs to one trace by construction, so the predicate could only ever be true.

**Measured** — 2,320,769 spans / 434,198 traces / 1.6 GB, median of 11 runs:

| trace | before | after | |
|---|---|---|---|
| 9 spans | 156.2 ms | 22.7 ms | 6.87x |
| 74 spans | 178.6 ms | 33.7 ms | 5.30x |
| 156 spans | 174.3 ms | 38.2 ms | 4.56x |

Isolating the recursion alone in SQL: 54 ms → 5 ms, same 159 rows at the same depth.

**Correctness, checked rather than asserted**

- The pre-change binary and this one were each run against the same store, and their full `searchSpans` responses compared **byte for byte** across all three traces: identical.
- Every behavioural test passed untouched — tree structure, ordering, and orphan-root handling. Only the two golden SQL snapshots changed, and they are regenerated here.