### PR TITLE
Rank siblings once, not once per level of the tree

### DIFF
--- a/desktopexporter/internal/store/queries/spans/search_spans.sql
+++ b/desktopexporter/internal/store/queries/spans/search_spans.sql
@@ -22,28 +22,53 @@
 			where s.trace_id = search_params.trace_id
 		),
 
-		spans_tree as (
-			select
-				t.trace_id, t.span_id, t.parent_span_id, t.start_time,
-				0 as depth,
-				array[row_number() over (order by
+		-- Sibling order, decided once, before the walk.
+		--
+		-- A span's rank among its siblings is a property of the trace, not of
+		-- the traversal: it depends only on parent and start time, both known
+		-- before the first row is walked. Computing it with a window inside
+		-- the recursive arm instead re-runs a WINDOW operator once per level
+		-- of the tree, paying full operator setup each time to rank a handful
+		-- of siblings, and that cost is set by tree depth rather than by
+		-- anything the query is being asked for.
+		--
+		-- It dominated. Profiled on a 122k-span store fetching a 159-span
+		-- trace 14 levels deep, WINDOW was 27.9ms of a 46ms query -- against
+		-- 0.8ms for the sequential scan over all 117,618 spans. Ranking once
+		-- here leaves a single WINDOW over the trace's own rows.
+		--
+		-- Traversal order is unchanged, and that is checked rather than
+		-- assumed: same rows, same depths, and the md5 of the span ids in
+		-- sort_path order is identical either way.
+		ranked as materialized (
+			select t.*,
+				row_number() over (
+					partition by t.parent_span_id order by t.start_time
+				) as sibling_rank,
+				row_number() over (order by
 					case when t.parent_span_id is null then 0 else 1 end,
 					t.start_time
-				)] as sort_path
+				) as root_rank
 			from trace_spans t
-			where t.parent_span_id is null
-				or t.parent_span_id not in (select span_id from trace_spans)
+		),
+
+		spans_tree as (
+			select
+				r.trace_id, r.span_id, r.parent_span_id, r.start_time,
+				0 as depth,
+				array[r.root_rank] as sort_path
+			from ranked r
+			where r.parent_span_id is null
+				or r.parent_span_id not in (select span_id from trace_spans)
 
 			union all
 
 			select
-				t.trace_id, t.span_id, t.parent_span_id, t.start_time,
+				r.trace_id, r.span_id, r.parent_span_id, r.start_time,
 				st.depth + 1,
-				st.sort_path || array[row_number() over (
-					partition by st.span_id order by t.start_time
-				)] as sort_path
-			from trace_spans t
-			join spans_tree st on t.parent_span_id = st.span_id
+				st.sort_path || array[r.sibling_rank] as sort_path
+			from ranked r
+			join spans_tree st on r.parent_span_id = st.span_id
 		){{.MatchedCTE}},
 
 		-- The walk's result joined back to its payload, once.

--- a/desktopexporter/internal/store/spans/testdata/search_spans_no_search.sql
+++ b/desktopexporter/internal/store/spans/testdata/search_spans_no_search.sql
@@ -22,28 +22,53 @@
 			where s.trace_id = search_params.trace_id
 		),
 
-		spans_tree as (
-			select
-				t.trace_id, t.span_id, t.parent_span_id, t.start_time,
-				0 as depth,
-				array[row_number() over (order by
+		-- Sibling order, decided once, before the walk.
+		--
+		-- A span's rank among its siblings is a property of the trace, not of
+		-- the traversal: it depends only on parent and start time, both known
+		-- before the first row is walked. Computing it with a window inside
+		-- the recursive arm instead re-runs a WINDOW operator once per level
+		-- of the tree, paying full operator setup each time to rank a handful
+		-- of siblings, and that cost is set by tree depth rather than by
+		-- anything the query is being asked for.
+		--
+		-- It dominated. Profiled on a 122k-span store fetching a 159-span
+		-- trace 14 levels deep, WINDOW was 27.9ms of a 46ms query -- against
+		-- 0.8ms for the sequential scan over all 117,618 spans. Ranking once
+		-- here leaves a single WINDOW over the trace's own rows.
+		--
+		-- Traversal order is unchanged, and that is checked rather than
+		-- assumed: same rows, same depths, and the md5 of the span ids in
+		-- sort_path order is identical either way.
+		ranked as materialized (
+			select t.*,
+				row_number() over (
+					partition by t.parent_span_id order by t.start_time
+				) as sibling_rank,
+				row_number() over (order by
 					case when t.parent_span_id is null then 0 else 1 end,
 					t.start_time
-				)] as sort_path
+				) as root_rank
 			from trace_spans t
-			where t.parent_span_id is null
-				or t.parent_span_id not in (select span_id from trace_spans)
+		),
+
+		spans_tree as (
+			select
+				r.trace_id, r.span_id, r.parent_span_id, r.start_time,
+				0 as depth,
+				array[r.root_rank] as sort_path
+			from ranked r
+			where r.parent_span_id is null
+				or r.parent_span_id not in (select span_id from trace_spans)
 
 			union all
 
 			select
-				t.trace_id, t.span_id, t.parent_span_id, t.start_time,
+				r.trace_id, r.span_id, r.parent_span_id, r.start_time,
 				st.depth + 1,
-				st.sort_path || array[row_number() over (
-					partition by st.span_id order by t.start_time
-				)] as sort_path
-			from trace_spans t
-			join spans_tree st on t.parent_span_id = st.span_id
+				st.sort_path || array[r.sibling_rank] as sort_path
+			from ranked r
+			join spans_tree st on r.parent_span_id = st.span_id
 		),
 
 		-- The walk's result joined back to its payload, once.

--- a/desktopexporter/internal/store/spans/testdata/search_spans_with_search.sql
+++ b/desktopexporter/internal/store/spans/testdata/search_spans_with_search.sql
@@ -22,28 +22,53 @@
 			where s.trace_id = search_params.trace_id
 		),
 
-		spans_tree as (
-			select
-				t.trace_id, t.span_id, t.parent_span_id, t.start_time,
-				0 as depth,
-				array[row_number() over (order by
+		-- Sibling order, decided once, before the walk.
+		--
+		-- A span's rank among its siblings is a property of the trace, not of
+		-- the traversal: it depends only on parent and start time, both known
+		-- before the first row is walked. Computing it with a window inside
+		-- the recursive arm instead re-runs a WINDOW operator once per level
+		-- of the tree, paying full operator setup each time to rank a handful
+		-- of siblings, and that cost is set by tree depth rather than by
+		-- anything the query is being asked for.
+		--
+		-- It dominated. Profiled on a 122k-span store fetching a 159-span
+		-- trace 14 levels deep, WINDOW was 27.9ms of a 46ms query -- against
+		-- 0.8ms for the sequential scan over all 117,618 spans. Ranking once
+		-- here leaves a single WINDOW over the trace's own rows.
+		--
+		-- Traversal order is unchanged, and that is checked rather than
+		-- assumed: same rows, same depths, and the md5 of the span ids in
+		-- sort_path order is identical either way.
+		ranked as materialized (
+			select t.*,
+				row_number() over (
+					partition by t.parent_span_id order by t.start_time
+				) as sibling_rank,
+				row_number() over (order by
 					case when t.parent_span_id is null then 0 else 1 end,
 					t.start_time
-				)] as sort_path
+				) as root_rank
 			from trace_spans t
-			where t.parent_span_id is null
-				or t.parent_span_id not in (select span_id from trace_spans)
+		),
+
+		spans_tree as (
+			select
+				r.trace_id, r.span_id, r.parent_span_id, r.start_time,
+				0 as depth,
+				array[r.root_rank] as sort_path
+			from ranked r
+			where r.parent_span_id is null
+				or r.parent_span_id not in (select span_id from trace_spans)
 
 			union all
 
 			select
-				t.trace_id, t.span_id, t.parent_span_id, t.start_time,
+				r.trace_id, r.span_id, r.parent_span_id, r.start_time,
 				st.depth + 1,
-				st.sort_path || array[row_number() over (
-					partition by st.span_id order by t.start_time
-				)] as sort_path
-			from trace_spans t
-			join spans_tree st on t.parent_span_id = st.span_id
+				st.sort_path || array[r.sibling_rank] as sort_path
+			from ranked r
+			join spans_tree st on r.parent_span_id = st.span_id
 		),
 		matched_spans as (
 			select s.span_id


### PR DESCRIPTION
Follow-up to #377, found by profiling the fixed cost that #377 left behind.

**Where the time was**

Profiled on a 122k-span store, fetching a 159-span trace 14 levels deep:

| operator | time | rows |
|---|---|---|
| **WINDOW** | **27.92 ms** | 158 |
| REC_CTE | 19.23 ms | 159 |
| HASH_GROUP_BY | 4.31 ms | 47 |
| SEQ_SCAN (whole table) | 0.82 ms | 117,618 |

Scanning all 117,618 spans costs 0.82 ms. Ranking 158 siblings costs 27.92 ms. The expensive operator was the one handling the fewest rows.

**Why**

The window sat inside the recursive arm, so it ran once per level of the tree — fourteen full operator setups to order a handful of children each time. That is why the cost tracked tree depth rather than anything the query was asked for, and why the fetch latency stayed flat against store size while sitting stubbornly around 25–30 ms.

Sibling rank depends only on `parent_span_id` and `start_time`, both known before the walk starts, because `trace_spans` already holds the entire trace. The recursion's job is reachability and depth, not sibling order.

**Measured** — end to end through the RPC, frozen 244,942-span store, 21 runs after warm-up:

| | median | p10 | p90 |
|---|---|---|---|
| before | 28.73 ms | 28.06 ms | 60.24 ms |
| after | **25.11 ms** | 24.00 ms | **31.05 ms** |

12.6% off the median, 48% off p90. The tail moves further than the middle, which is what per-level operator setup would predict. A CLI-only measurement suggested ~30%, but that includes opening the database and formatting results; the RPC number is the honest one.

**This does not remove the floor.** A 159-span trace still costs ~25 ms for a 171 KB response, and `REC_CTE` is the next term. It removes one clearly wasted cost.

**Correctness, checked rather than argued**

- The full RPC response is **byte-identical** — same sha256, not just the same SQL result.
- The md5 of span ids in `sort_path` order matches.
- All **46** traces in the store with orphans, multiple roots, or no true root walk to the same rows, depths and order. 45 of those have no `parent_span_id is null` span at all and are held together entirely by promoted orphans — the case where the equivalence could have broken.
- Separately confirmed that no span in the store is unreachable from a root: 0 of 122,224. Cycles are structurally unreachable here, since a span becomes a root only when its parent is *absent*, and cycle members always have a present parent.
- Full Go suite green; only the two golden SQL snapshots changed.