### PR TITLE
Stop installing a Windows toolchain nothing compiles with

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,6 +68,24 @@ jobs:
     # How: flip this to true for one run and put it back, or delete the
     # msys2-pkgs-* entry from the Actions cache. Editing the install list below
     # also re-keys the cache on its own, since the key hashes that list.
+    # TEMPORARY (#324): which gcc does the build actually use?
+    # The PATH step below names C:\msys64, the runner's preinstalled MSYS2,
+    # while setup-msys2 installs under RUNNER_TEMP. If the preinstalled one
+    # already carries a ucrt64 gcc, the setup step's 61s buys nothing.
+    - name: Probe preinstalled toolchain (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        Write-Host "RUNNER_TEMP = $env:RUNNER_TEMP"
+        foreach ($root in @("C:\msys64", "$env:RUNNER_TEMP\msys64")) {
+          $gcc = Join-Path $root "ucrt64\bin\gcc.exe"
+          if (Test-Path $gcc) {
+            Write-Host "FOUND $gcc"
+            & $gcc --version | Select-Object -First 1
+          } else {
+            Write-Host "absent: $gcc"
+          }
+        }
+
     - name: Set up MSYS2 (Windows)
       if: matrix.os == 'windows-latest'
       uses: msys2/setup-msys2@v2
@@ -85,6 +103,14 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: |
         echo "C:\msys64\ucrt64\bin" >> $env:GITHUB_PATH
+
+    # TEMPORARY (#324): the gcc cgo will resolve, after the PATH edit above.
+    - name: Probe resolved gcc (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        $g = Get-Command gcc -ErrorAction SilentlyContinue
+        if ($g) { Write-Host "gcc resolves to $($g.Source)"; gcc --version | Select-Object -First 1 }
+        else { Write-Host "gcc NOT on PATH" }
 
     - name: Build
       run: go build -o otel-desktop-viewer.exe

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,61 +51,9 @@ jobs:
       with:
         go-version: '1.26'
 
-    # MSYS2 provides GCC and build tools needed for CGO compilation on Windows
-    #
-    # update: false skips `pacman -Syuu`, which was re-syncing and upgrading the
-    # whole distribution on every run -- 74-97s, against a package set that is
-    # cached and pinned right here. A build toolchain that changes underneath us
-    # between two runs of the same commit is a liability, not a feature: it makes
-    # "it passed yesterday" unanswerable.
-    #
-    # When to refresh it, deliberately:
-    #   - alongside a Go version bump, since those are one toolchain decision and
-    #     should be reviewed together
-    #   - when a build failure actually implicates the compiler
-    #   - when a package below needs a version this base does not carry
-    #
-    # How: flip this to true for one run and put it back, or delete the
-    # msys2-pkgs-* entry from the Actions cache. Editing the install list below
-    # also re-keys the cache on its own, since the key hashes that list.
-    # TEMPORARY (#324): which gcc does the build actually use?
-    # The PATH step below names C:\msys64, the runner's preinstalled MSYS2,
-    # while setup-msys2 installs under RUNNER_TEMP. If the preinstalled one
-    # already carries a ucrt64 gcc, the setup step's 61s buys nothing.
-    - name: Probe preinstalled toolchain (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        Write-Host "RUNNER_TEMP = $env:RUNNER_TEMP"
-        foreach ($root in @("C:\msys64", "$env:RUNNER_TEMP\msys64")) {
-          $gcc = Join-Path $root "ucrt64\bin\gcc.exe"
-          if (Test-Path $gcc) {
-            Write-Host "FOUND $gcc"
-            & $gcc --version | Select-Object -First 1
-          } else {
-            Write-Host "absent: $gcc"
-          }
-        }
-
-    - name: Set up MSYS2 (Windows)
-      if: matrix.os == 'windows-latest'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: UCRT64
-        update: false
-        # Required packages:
-        # - mingw-w64-ucrt-x86_64-gcc: GCC compiler for Windows x64 with modern C runtime (UCRT)
-        # - mingw-w64-ucrt-x86_64-toolchain: Complete toolchain including make, binutils, and other build tools
-        install: >-
-          mingw-w64-ucrt-x86_64-gcc
-          mingw-w64-ucrt-x86_64-toolchain
-
-    - name: Add MSYS2 to PATH (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        echo "C:\msys64\ucrt64\bin" >> $env:GITHUB_PATH
-
-    # TEMPORARY (#324): the gcc cgo will resolve, after the PATH edit above.
-    - name: Probe resolved gcc (Windows)
+    # EXPERIMENT (#324): no MSYS2 step at all -- does the preinstalled
+    # mingw64 build it?
+    - name: Report the C toolchain cgo will use (Windows)
       if: matrix.os == 'windows-latest'
       run: |
         $g = Get-Command gcc -ErrorAction SilentlyContinue

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,14 +51,31 @@ jobs:
       with:
         go-version: '1.26'
 
-    # EXPERIMENT (#324): no MSYS2 step at all -- does the preinstalled
-    # mingw64 build it?
-    - name: Report the C toolchain cgo will use (Windows)
+    # DuckDB is cgo, so Windows needs a C compiler. It does not need one
+    # installed here: the runner image ships mingw64 at C:\mingw64 and puts it
+    # on PATH, which is what cgo has actually been resolving all along.
+    #
+    # This used to run msys2/setup-msys2 and then prepend C:\msys64\ucrt64\bin.
+    # Probed on a real run (#324): before that step, neither C:\msys64 nor
+    # RUNNER_TEMP\msys64 held a ucrt64 gcc, and after it, gcc still resolved to
+    # C:\mingw64\bin\gcc.exe. Sixty-one seconds -- eight extracting the base,
+    # forty-eight installing 43 packages past a cache hit -- built a toolchain
+    # no compile ever used.
+    #
+    # The cost of leaning on the image is that the image can change. This step
+    # is the alarm: without it a removed preinstall surfaces as a cgo error
+    # deep in a DuckDB build, which reads like a code problem. Reinstating
+    # MSYS2 is the fix if it ever fires.
+    - name: Check the C toolchain cgo needs (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        $g = Get-Command gcc -ErrorAction SilentlyContinue
-        if ($g) { Write-Host "gcc resolves to $($g.Source)"; gcc --version | Select-Object -First 1 }
-        else { Write-Host "gcc NOT on PATH" }
+        $gcc = Get-Command gcc -ErrorAction SilentlyContinue
+        if (-not $gcc) {
+          Write-Host "::error::No gcc on PATH. The windows runner image used to ship one at C:\mingw64; if that has changed, restore the msys2/setup-msys2 step removed in #324."
+          exit 1
+        }
+        Write-Host "cgo will use $($gcc.Source)"
+        gcc --version | Select-Object -First 1
 
     - name: Build
       run: go build -o otel-desktop-viewer.exe


### PR DESCRIPTION
Fixes #324.

## The issue's premise was wrong

It attributes the Windows job's cost to MSYS2 base extraction. The step timings put it elsewhere:

| phase | time |
|---|---|
| download (already in toolcache) | 0.8s |
| extract base | 8.0s |
| package cache restore — a hit | 2.4s |
| **pacman installs 43 packages** | **48.4s** |

`cache: true` was already on and the key already hit. The cost is installing `mingw-w64-ucrt-x86_64-toolchain`, a meta-package, on every run.

## And the toolchain was never used

Probed on a real run rather than reasoned about:

- **Before** setup-msys2: neither `C:\msys64\ucrt64\bin\gcc.exe` nor `RUNNER_TEMP\msys64\ucrt64\bin\gcc.exe` exists
- **After** setup-msys2 and the `C:\msys64\ucrt64\bin` PATH line: `gcc resolves to C:\mingw64\bin\gcc.exe`

cgo has been using the runner image's preinstalled mingw64 the whole time. The 61s produced a compiler nothing invoked.

## What this does

- Removes the setup-msys2 step and the PATH line
- Replaces them with a step that checks gcc exists and fails naming the fix

The trade is a dependency on the runner image. That is what the check is for: without it, a removed preinstall surfaces as a cgo error deep in a DuckDB build, which reads like a code problem rather than an image change.

## Verified

Windows job green with no MSYS2 at all — build and the full `go test ./...`, which is where DuckDB's cgo actually gets exercised. The MSYS2 step goes 61s → 0. Wall-clock was 164s → 145s on these two runs, but `Set up Go` varied 41s → 74s between them, so treat the step number as the real one and the total as noisy.

## Not touched

`release.yml` and `test-go-install.yml` carry the same pattern, and `release.yml` uses `update: true`, so it pays even more. Left alone deliberately — that job builds the binaries people download, and switching its toolchain is a separate decision from CI.
