### PR TITLE
Pin the Windows compiler to the one that links DuckDB

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,6 +68,24 @@ jobs:
     # How: flip this to true for one run and put it back, or delete the
     # msys2-pkgs-* entry from the Actions cache. Editing the install list below
     # also re-keys the cache on its own, since the key hashes that list.
+    # TEMPORARY (#324): which gcc does the build actually use?
+    # The PATH step below names C:\msys64, the runner's preinstalled MSYS2,
+    # while setup-msys2 installs under RUNNER_TEMP. If the preinstalled one
+    # already carries a ucrt64 gcc, the setup step's 61s buys nothing.
+    - name: Probe preinstalled toolchain (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        Write-Host "RUNNER_TEMP = $env:RUNNER_TEMP"
+        foreach ($root in @("C:\msys64", "$env:RUNNER_TEMP\msys64")) {
+          $gcc = Join-Path $root "ucrt64\bin\gcc.exe"
+          if (Test-Path $gcc) {
+            Write-Host "FOUND $gcc"
+            & $gcc --version | Select-Object -First 1
+          } else {
+            Write-Host "absent: $gcc"
+          }
+        }
+
     - name: Set up MSYS2 (Windows)
       if: matrix.os == 'windows-latest'
       uses: msys2/setup-msys2@v2
@@ -85,6 +103,14 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: |
         echo "C:\msys64\ucrt64\bin" >> $env:GITHUB_PATH
+
+    # TEMPORARY (#324): the gcc cgo will resolve, after the PATH edit above.
+    - name: Probe resolved gcc (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        $g = Get-Command gcc -ErrorAction SilentlyContinue
+        if ($g) { Write-Host "gcc resolves to $($g.Source)"; gcc --version | Select-Object -First 1 }
+        else { Write-Host "gcc NOT on PATH" }
 
     - name: Build
       run: go build -o otel-desktop-viewer.exe

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -77,6 +77,27 @@ jobs:
         Write-Host "cgo will use $($gcc.Source)"
         gcc --version | Select-Object -First 1
 
+    - name: Set up MSYS2 (Windows)
+      id: msys2
+      if: matrix.os == 'windows-latest'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: UCRT64
+        update: false
+        install: >-
+          mingw-w64-ucrt-x86_64-gcc
+          mingw-w64-ucrt-x86_64-toolchain
+
+    # TEMPORARY: where did it actually go, and what does it call itself?
+    - name: Locate the installed toolchain (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        Write-Host "msys2-location output = '${{ steps.msys2.outputs.msys2-location }}'"
+        Get-ChildItem -Path C:\, D:\a\_temp -Filter msys64 -Directory -ErrorAction SilentlyContinue |
+          ForEach-Object { Write-Host "root: $($_.FullName)" }
+        Get-ChildItem -Path C:\, D:\a\_temp -Recurse -Depth 4 -Filter gcc.exe -ErrorAction SilentlyContinue |
+          ForEach-Object { Write-Host "gcc: $($_.FullName)" }
+
     - name: Build
       run: go build -o otel-desktop-viewer.exe
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,32 +51,7 @@ jobs:
       with:
         go-version: '1.26'
 
-    # DuckDB is cgo, so Windows needs a C compiler. It does not need one
-    # installed here: the runner image ships mingw64 at C:\mingw64 and puts it
-    # on PATH, which is what cgo has actually been resolving all along.
-    #
-    # This used to run msys2/setup-msys2 and then prepend C:\msys64\ucrt64\bin.
-    # Probed on a real run (#324): before that step, neither C:\msys64 nor
-    # RUNNER_TEMP\msys64 held a ucrt64 gcc, and after it, gcc still resolved to
-    # C:\mingw64\bin\gcc.exe. Sixty-one seconds -- eight extracting the base,
-    # forty-eight installing 43 packages past a cache hit -- built a toolchain
-    # no compile ever used.
-    #
-    # The cost of leaning on the image is that the image can change. This step
-    # is the alarm: without it a removed preinstall surfaces as a cgo error
-    # deep in a DuckDB build, which reads like a code problem. Reinstating
-    # MSYS2 is the fix if it ever fires.
-    - name: Check the C toolchain cgo needs (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        $gcc = Get-Command gcc -ErrorAction SilentlyContinue
-        if (-not $gcc) {
-          Write-Host "::error::No gcc on PATH. The windows runner image used to ship one at C:\mingw64; if that has changed, restore the msys2/setup-msys2 step removed in #324."
-          exit 1
-        }
-        Write-Host "cgo will use $($gcc.Source)"
-        gcc --version | Select-Object -First 1
-
+    # MSYS2 provides the GCC that cgo needs to compile DuckDB on Windows.
     - name: Set up MSYS2 (Windows)
       id: msys2
       if: matrix.os == 'windows-latest'
@@ -88,15 +63,47 @@ jobs:
           mingw-w64-ucrt-x86_64-gcc
           mingw-w64-ucrt-x86_64-toolchain
 
-    # TEMPORARY: where did it actually go, and what does it call itself?
-    - name: Locate the installed toolchain (Windows)
+    # Point cgo at the toolchain installed just above.
+    #
+    # This used to read `echo "C:\msys64\ucrt64\bin"`, which is not where
+    # setup-msys2 installs -- it installs under RUNNER_TEMP and reports the
+    # path as its msys2-location output. C:\msys64 does exist on the runner
+    # image but carries no ucrt64 gcc, so the line added a directory with no
+    # compiler in it, and cgo fell through to whatever else was on PATH.
+    - name: Add MSYS2 to PATH (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        Write-Host "msys2-location output = '${{ steps.msys2.outputs.msys2-location }}'"
-        Get-ChildItem -Path C:\, D:\a\_temp -Filter msys64 -Directory -ErrorAction SilentlyContinue |
-          ForEach-Object { Write-Host "root: $($_.FullName)" }
-        Get-ChildItem -Path C:\, D:\a\_temp -Recurse -Depth 4 -Filter gcc.exe -ErrorAction SilentlyContinue |
-          ForEach-Object { Write-Host "gcc: $($_.FullName)" }
+        $bin = Join-Path '${{ steps.msys2.outputs.msys2-location }}' 'ucrt64\bin'
+        if (-not (Test-Path (Join-Path $bin 'gcc.exe'))) {
+          Write-Host "::error::No gcc in $bin -- setup-msys2 did not install where its msys2-location output says."
+          exit 1
+        }
+        echo $bin >> $env:GITHUB_PATH
+
+    # Prove the pinned toolchain is the one cgo will use, rather than assuming
+    # the PATH edit won.
+    #
+    # The runner image ships five compilers -- C:\mingw32, C:\mingw64,
+    # C:\rtools45, C:\Strawberry\c, and the one installed above -- and for as
+    # long as the PATH line named a directory without a gcc, cgo resolved
+    # C:\mingw64\bin\gcc.exe. Nothing failed, so nothing said so, and the
+    # compiler behind every Windows build was chosen by PATH order and free to
+    # change with the image (#324).
+    #
+    # A silent wrong toolchain is the failure this guards. It has already
+    # happened once, in all three workflows at the same time.
+    - name: Verify cgo uses the pinned toolchain (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        $expected = Join-Path '${{ steps.msys2.outputs.msys2-location }}' 'ucrt64\bin\gcc.exe'
+        $actual = (Get-Command gcc -ErrorAction SilentlyContinue).Source
+        Write-Host "expected: $expected"
+        Write-Host "actual:   $actual"
+        if ($actual -ne $expected) {
+          Write-Host "::error::cgo would use $actual, not the toolchain this workflow installs."
+          exit 1
+        }
+        gcc --version | Select-Object -First 1
 
     - name: Build
       run: go build -o otel-desktop-viewer.exe

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,56 +51,40 @@ jobs:
       with:
         go-version: '1.26'
 
-    # MSYS2 provides the GCC that cgo needs to compile DuckDB on Windows.
-    - name: Set up MSYS2 (Windows)
-      id: msys2
-      if: matrix.os == 'windows-latest'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: UCRT64
-        update: false
-        install: >-
-          mingw-w64-ucrt-x86_64-gcc
-          mingw-w64-ucrt-x86_64-toolchain
-
-    # Point cgo at the toolchain installed just above.
+    # DuckDB is cgo, and its Windows support is a *prebuilt* static library --
+    # duckdb-go-bindings/lib/windows-amd64 -- so the compiler here has to match
+    # the one that archive was built with, not merely be a working gcc.
     #
-    # This used to read `echo "C:\msys64\ucrt64\bin"`, which is not where
-    # setup-msys2 installs -- it installs under RUNNER_TEMP and reports the
-    # path as its msys2-location output. C:\msys64 does exist on the runner
-    # image but carries no ucrt64 gcc, so the line added a directory with no
-    # compiler in it, and cgo fell through to whatever else was on PATH.
-    - name: Add MSYS2 to PATH (Windows)
+    # C:\mingw64 is that compiler. It ships with the runner image, and it is what
+    # every Windows build has silently used: this workflow installed a UCRT64
+    # toolchain through setup-msys2 and then put `C:\msys64\ucrt64\bin` on PATH,
+    # which is not where setup-msys2 installs and holds no gcc, so cgo fell
+    # through to the next of the five gccs on the image (#324).
+    #
+    # Pointing PATH at the MSYS2 toolchain instead -- the apparent fix -- breaks
+    # the link: its gcc 16.1.0 uses a different TLS model, and libduckdb_static.a
+    # fails on undefined `__emutls_v._ZSt11__once_call`. Measured, not guessed.
+    #
+    # So the accident was benign and the intent was wrong. This names the working
+    # compiler deliberately rather than inheriting it from PATH order, and the
+    # 61s that installed an unusable toolchain goes away.
+    - name: Pin the C toolchain cgo uses (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        $bin = Join-Path '${{ steps.msys2.outputs.msys2-location }}' 'ucrt64\bin'
+        $bin = 'C:\mingw64\bin'
         if (-not (Test-Path (Join-Path $bin 'gcc.exe'))) {
-          Write-Host "::error::No gcc in $bin -- setup-msys2 did not install where its msys2-location output says."
+          Write-Host "::error::No gcc at $bin. The windows runner image has shipped one there; if that changed, a toolchain matching duckdb-go-bindings' prebuilt libduckdb_static.a must be installed instead. See #324."
           exit 1
         }
         echo $bin >> $env:GITHUB_PATH
 
-    # Prove the pinned toolchain is the one cgo will use, rather than assuming
-    # the PATH edit won.
-    #
-    # The runner image ships five compilers -- C:\mingw32, C:\mingw64,
-    # C:\rtools45, C:\Strawberry\c, and the one installed above -- and for as
-    # long as the PATH line named a directory without a gcc, cgo resolved
-    # C:\mingw64\bin\gcc.exe. Nothing failed, so nothing said so, and the
-    # compiler behind every Windows build was chosen by PATH order and free to
-    # change with the image (#324).
-    #
-    # A silent wrong toolchain is the failure this guards. It has already
-    # happened once, in all three workflows at the same time.
-    - name: Verify cgo uses the pinned toolchain (Windows)
+    - name: Verify cgo uses it (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        $expected = Join-Path '${{ steps.msys2.outputs.msys2-location }}' 'ucrt64\bin\gcc.exe'
         $actual = (Get-Command gcc -ErrorAction SilentlyContinue).Source
-        Write-Host "expected: $expected"
-        Write-Host "actual:   $actual"
-        if ($actual -ne $expected) {
-          Write-Host "::error::cgo would use $actual, not the toolchain this workflow installs."
+        Write-Host "cgo will use $actual"
+        if ($actual -ne 'C:\mingw64\bin\gcc.exe') {
+          Write-Host "::error::cgo would use $actual, not the pinned C:\mingw64 toolchain."
           exit 1
         }
         gcc --version | Select-Object -First 1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,61 +51,9 @@ jobs:
       with:
         go-version: '1.26'
 
-    # MSYS2 provides GCC and build tools needed for CGO compilation on Windows
-    #
-    # update: false skips `pacman -Syuu`, which was re-syncing and upgrading the
-    # whole distribution on every run -- 74-97s, against a package set that is
-    # cached and pinned right here. A build toolchain that changes underneath us
-    # between two runs of the same commit is a liability, not a feature: it makes
-    # "it passed yesterday" unanswerable.
-    #
-    # When to refresh it, deliberately:
-    #   - alongside a Go version bump, since those are one toolchain decision and
-    #     should be reviewed together
-    #   - when a build failure actually implicates the compiler
-    #   - when a package below needs a version this base does not carry
-    #
-    # How: flip this to true for one run and put it back, or delete the
-    # msys2-pkgs-* entry from the Actions cache. Editing the install list below
-    # also re-keys the cache on its own, since the key hashes that list.
-    # TEMPORARY (#324): which gcc does the build actually use?
-    # The PATH step below names C:\msys64, the runner's preinstalled MSYS2,
-    # while setup-msys2 installs under RUNNER_TEMP. If the preinstalled one
-    # already carries a ucrt64 gcc, the setup step's 61s buys nothing.
-    - name: Probe preinstalled toolchain (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        Write-Host "RUNNER_TEMP = $env:RUNNER_TEMP"
-        foreach ($root in @("C:\msys64", "$env:RUNNER_TEMP\msys64")) {
-          $gcc = Join-Path $root "ucrt64\bin\gcc.exe"
-          if (Test-Path $gcc) {
-            Write-Host "FOUND $gcc"
-            & $gcc --version | Select-Object -First 1
-          } else {
-            Write-Host "absent: $gcc"
-          }
-        }
-
-    - name: Set up MSYS2 (Windows)
-      if: matrix.os == 'windows-latest'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: UCRT64
-        update: false
-        # Required packages:
-        # - mingw-w64-ucrt-x86_64-gcc: GCC compiler for Windows x64 with modern C runtime (UCRT)
-        # - mingw-w64-ucrt-x86_64-toolchain: Complete toolchain including make, binutils, and other build tools
-        install: >-
-          mingw-w64-ucrt-x86_64-gcc
-          mingw-w64-ucrt-x86_64-toolchain
-
-    - name: Add MSYS2 to PATH (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        echo "C:\msys64\ucrt64\bin" >> $env:GITHUB_PATH
-
-    # TEMPORARY (#324): the gcc cgo will resolve, after the PATH edit above.
-    - name: Probe resolved gcc (Windows)
+    # EXPERIMENT (#324): no MSYS2 step at all -- does the preinstalled
+    # mingw64 build it?
+    - name: Report the C toolchain cgo will use (Windows)
       if: matrix.os == 'windows-latest'
       run: |
         $g = Get-Command gcc -ErrorAction SilentlyContinue

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,14 +51,31 @@ jobs:
       with:
         go-version: '1.26'
 
-    # EXPERIMENT (#324): no MSYS2 step at all -- does the preinstalled
-    # mingw64 build it?
-    - name: Report the C toolchain cgo will use (Windows)
+    # DuckDB is cgo, so Windows needs a C compiler. It does not need one
+    # installed here: the runner image ships mingw64 at C:\mingw64 and puts it
+    # on PATH, which is what cgo has actually been resolving all along.
+    #
+    # This used to run msys2/setup-msys2 and then prepend C:\msys64\ucrt64\bin.
+    # Probed on a real run (#324): before that step, neither C:\msys64 nor
+    # RUNNER_TEMP\msys64 held a ucrt64 gcc, and after it, gcc still resolved to
+    # C:\mingw64\bin\gcc.exe. Sixty-one seconds -- eight extracting the base,
+    # forty-eight installing 43 packages past a cache hit -- built a toolchain
+    # no compile ever used.
+    #
+    # The cost of leaning on the image is that the image can change. This step
+    # is the alarm: without it a removed preinstall surfaces as a cgo error
+    # deep in a DuckDB build, which reads like a code problem. Reinstating
+    # MSYS2 is the fix if it ever fires.
+    - name: Check the C toolchain cgo needs (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        $g = Get-Command gcc -ErrorAction SilentlyContinue
-        if ($g) { Write-Host "gcc resolves to $($g.Source)"; gcc --version | Select-Object -First 1 }
-        else { Write-Host "gcc NOT on PATH" }
+        $gcc = Get-Command gcc -ErrorAction SilentlyContinue
+        if (-not $gcc) {
+          Write-Host "::error::No gcc on PATH. The windows runner image used to ship one at C:\mingw64; if that has changed, restore the msys2/setup-msys2 step removed in #324."
+          exit 1
+        }
+        Write-Host "cgo will use $($gcc.Source)"
+        gcc --version | Select-Object -First 1
 
     - name: Build
       run: go build -o otel-desktop-viewer.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Tidy Go module
         run: go mod tidy
       - name: Set up MSYS2 (Windows)
+        id: msys2
         if: matrix.os == 'windows-latest'
         uses: msys2/setup-msys2@v2
         with:
@@ -85,10 +86,49 @@ jobs:
           install: >-
             mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-toolchain
+      # Point cgo at the toolchain installed just above, and prove it took.
+      #
+      # This used to read `echo "C:\msys64\ucrt64\bin"`, which is not where
+      # setup-msys2 installs -- it installs under RUNNER_TEMP, and reports the
+      # path as its msys2-location output. C:\msys64 does exist on the runner
+      # image, but carries no ucrt64 gcc, so the line added a directory with no
+      # compiler in it and cgo fell through to whatever else was on PATH.
+      #
+      # That mattered because the image ships five: C:\mingw32, C:\mingw64,
+      # C:\rtools45, C:\Strawberry\c, plus the one we install. cgo was
+      # resolving C:\mingw64\bin\gcc.exe -- picked by PATH order, not by us,
+      # and free to change when the image does. Probed on a real run (#324).
+      #
+      # The check is the load-bearing half. Naming the right directory is only
+      # correct until something prepends another gcc, and the failure mode is
+      # silent: it still builds, just not with the pinned toolchain.
       - name: Add MSYS2 to PATH (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          echo "C:\msys64\ucrt64\bin" >> $env:GITHUB_PATH
+          $bin = Join-Path '${{ steps.msys2.outputs.msys2-location }}' 'ucrt64\bin'
+          if (-not (Test-Path (Join-Path $bin 'gcc.exe'))) {
+            Write-Host "::error::No gcc in $bin -- setup-msys2 did not install where its msys2-location output says."
+            exit 1
+          }
+          echo $bin >> $env:GITHUB_PATH
+
+      # Prove the pinned toolchain is the one cgo will use. The runner image ships
+      # five compilers, and while the PATH line named a directory without a gcc,
+      # cgo silently resolved C:\mingw64\bin\gcc.exe instead (#324). Nothing
+      # failed, so nothing reported it.
+      - name: Verify cgo uses the pinned toolchain (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          $expected = Join-Path '${{ steps.msys2.outputs.msys2-location }}' 'ucrt64\bin\gcc.exe'
+          $actual = (Get-Command gcc -ErrorAction SilentlyContinue).Source
+          Write-Host "expected: $expected"
+          Write-Host "actual:   $actual"
+          if ($actual -ne $expected) {
+            Write-Host "::error::cgo would use $actual, not the toolchain this workflow installs."
+            exit 1
+          }
+          gcc --version | Select-Object -First 1
+
       - name: Set up Docker Buildx
         if: matrix.goos == 'linux'
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,55 +76,40 @@ jobs:
           go-version: '1.26'
       - name: Tidy Go module
         run: go mod tidy
-      - name: Set up MSYS2 (Windows)
-        id: msys2
-        if: matrix.os == 'windows-latest'
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: UCRT64
-          update: true
-          install: >-
-            mingw-w64-ucrt-x86_64-gcc
-            mingw-w64-ucrt-x86_64-toolchain
-      # Point cgo at the toolchain installed just above, and prove it took.
+      # DuckDB is cgo, and its Windows support is a *prebuilt* static library --
+      # duckdb-go-bindings/lib/windows-amd64 -- so the compiler here has to match
+      # the one that archive was built with, not merely be a working gcc.
       #
-      # This used to read `echo "C:\msys64\ucrt64\bin"`, which is not where
-      # setup-msys2 installs -- it installs under RUNNER_TEMP, and reports the
-      # path as its msys2-location output. C:\msys64 does exist on the runner
-      # image, but carries no ucrt64 gcc, so the line added a directory with no
-      # compiler in it and cgo fell through to whatever else was on PATH.
+      # C:\mingw64 is that compiler. It ships with the runner image, and it is what
+      # every Windows build has silently used: this workflow installed a UCRT64
+      # toolchain through setup-msys2 and then put `C:\msys64\ucrt64\bin` on PATH,
+      # which is not where setup-msys2 installs and holds no gcc, so cgo fell
+      # through to the next of the five gccs on the image (#324).
       #
-      # That mattered because the image ships five: C:\mingw32, C:\mingw64,
-      # C:\rtools45, C:\Strawberry\c, plus the one we install. cgo was
-      # resolving C:\mingw64\bin\gcc.exe -- picked by PATH order, not by us,
-      # and free to change when the image does. Probed on a real run (#324).
+      # Pointing PATH at the MSYS2 toolchain instead -- the apparent fix -- breaks
+      # the link: its gcc 16.1.0 uses a different TLS model, and libduckdb_static.a
+      # fails on undefined `__emutls_v._ZSt11__once_call`. Measured, not guessed.
       #
-      # The check is the load-bearing half. Naming the right directory is only
-      # correct until something prepends another gcc, and the failure mode is
-      # silent: it still builds, just not with the pinned toolchain.
-      - name: Add MSYS2 to PATH (Windows)
+      # So the accident was benign and the intent was wrong. This names the working
+      # compiler deliberately rather than inheriting it from PATH order, and the
+      # 61s that installed an unusable toolchain goes away.
+      - name: Pin the C toolchain cgo uses (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          $bin = Join-Path '${{ steps.msys2.outputs.msys2-location }}' 'ucrt64\bin'
+          $bin = 'C:\mingw64\bin'
           if (-not (Test-Path (Join-Path $bin 'gcc.exe'))) {
-            Write-Host "::error::No gcc in $bin -- setup-msys2 did not install where its msys2-location output says."
+            Write-Host "::error::No gcc at $bin. The windows runner image has shipped one there; if that changed, a toolchain matching duckdb-go-bindings' prebuilt libduckdb_static.a must be installed instead. See #324."
             exit 1
           }
           echo $bin >> $env:GITHUB_PATH
 
-      # Prove the pinned toolchain is the one cgo will use. The runner image ships
-      # five compilers, and while the PATH line named a directory without a gcc,
-      # cgo silently resolved C:\mingw64\bin\gcc.exe instead (#324). Nothing
-      # failed, so nothing reported it.
-      - name: Verify cgo uses the pinned toolchain (Windows)
+      - name: Verify cgo uses it (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          $expected = Join-Path '${{ steps.msys2.outputs.msys2-location }}' 'ucrt64\bin\gcc.exe'
           $actual = (Get-Command gcc -ErrorAction SilentlyContinue).Source
-          Write-Host "expected: $expected"
-          Write-Host "actual:   $actual"
-          if ($actual -ne $expected) {
-            Write-Host "::error::cgo would use $actual, not the toolchain this workflow installs."
+          Write-Host "cgo will use $actual"
+          if ($actual -ne 'C:\mingw64\bin\gcc.exe') {
+            Write-Host "::error::cgo would use $actual, not the pinned C:\mingw64 toolchain."
             exit 1
           }
           gcc --version | Select-Object -First 1

--- a/.github/workflows/test-go-install.yml
+++ b/.github/workflows/test-go-install.yml
@@ -19,6 +19,7 @@ jobs:
 
     # MSYS2 provides GCC and build tools needed for CGO compilation on Windows
     - name: Set up MSYS2 (Windows)
+      id: msys2
       uses: msys2/setup-msys2@v2
       with:
         msystem: UCRT64
@@ -27,9 +28,47 @@ jobs:
           mingw-w64-ucrt-x86_64-gcc
           mingw-w64-ucrt-x86_64-toolchain
 
+    # Point cgo at the toolchain installed just above, and prove it took.
+    #
+    # This used to read `echo "C:\msys64\ucrt64\bin"`, which is not where
+    # setup-msys2 installs -- it installs under RUNNER_TEMP, and reports the
+    # path as its msys2-location output. C:\msys64 does exist on the runner
+    # image, but carries no ucrt64 gcc, so the line added a directory with no
+    # compiler in it and cgo fell through to whatever else was on PATH.
+    #
+    # That mattered because the image ships five: C:\mingw32, C:\mingw64,
+    # C:\rtools45, C:\Strawberry\c, plus the one we install. cgo was
+    # resolving C:\mingw64\bin\gcc.exe -- picked by PATH order, not by us,
+    # and free to change when the image does. Probed on a real run (#324).
+    #
+    # The check is the load-bearing half. Naming the right directory is only
+    # correct until something prepends another gcc, and the failure mode is
+    # silent: it still builds, just not with the pinned toolchain.
     - name: Add MSYS2 to PATH (Windows)
       run: |
-        echo "C:\msys64\ucrt64\bin" >> $env:GITHUB_PATH
+        $bin = Join-Path '${{ steps.msys2.outputs.msys2-location }}' 'ucrt64\bin'
+        if (-not (Test-Path (Join-Path $bin 'gcc.exe'))) {
+          Write-Host "::error::No gcc in $bin -- setup-msys2 did not install where its msys2-location output says."
+          exit 1
+        }
+        echo $bin >> $env:GITHUB_PATH
+
+    # Prove the pinned toolchain is the one cgo will use. The runner image ships
+    # five compilers, and while the PATH line named a directory without a gcc,
+    # cgo silently resolved C:\mingw64\bin\gcc.exe instead (#324). Nothing
+    # failed, so nothing reported it.
+    - name: Verify cgo uses the pinned toolchain (Windows)
+      run: |
+        $expected = Join-Path '${{ steps.msys2.outputs.msys2-location }}' 'ucrt64\bin\gcc.exe'
+        $actual = (Get-Command gcc -ErrorAction SilentlyContinue).Source
+        Write-Host "expected: $expected"
+        Write-Host "actual:   $actual"
+        if ($actual -ne $expected) {
+          Write-Host "::error::cgo would use $actual, not the toolchain this workflow installs."
+          exit 1
+        }
+        gcc --version | Select-Object -First 1
+
 
     - name: Test go install
       run: |

--- a/.github/workflows/test-go-install.yml
+++ b/.github/workflows/test-go-install.yml
@@ -17,54 +17,38 @@ jobs:
       with:
         go-version: '1.26'
 
-    # MSYS2 provides GCC and build tools needed for CGO compilation on Windows
-    - name: Set up MSYS2 (Windows)
-      id: msys2
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: UCRT64
-        update: true
-        install: >-
-          mingw-w64-ucrt-x86_64-gcc
-          mingw-w64-ucrt-x86_64-toolchain
-
-    # Point cgo at the toolchain installed just above, and prove it took.
+    # DuckDB is cgo, and its Windows support is a *prebuilt* static library --
+    # duckdb-go-bindings/lib/windows-amd64 -- so the compiler here has to match
+    # the one that archive was built with, not merely be a working gcc.
     #
-    # This used to read `echo "C:\msys64\ucrt64\bin"`, which is not where
-    # setup-msys2 installs -- it installs under RUNNER_TEMP, and reports the
-    # path as its msys2-location output. C:\msys64 does exist on the runner
-    # image, but carries no ucrt64 gcc, so the line added a directory with no
-    # compiler in it and cgo fell through to whatever else was on PATH.
+    # C:\mingw64 is that compiler. It ships with the runner image, and it is what
+    # every Windows build has silently used: this workflow installed a UCRT64
+    # toolchain through setup-msys2 and then put `C:\msys64\ucrt64\bin` on PATH,
+    # which is not where setup-msys2 installs and holds no gcc, so cgo fell
+    # through to the next of the five gccs on the image (#324).
     #
-    # That mattered because the image ships five: C:\mingw32, C:\mingw64,
-    # C:\rtools45, C:\Strawberry\c, plus the one we install. cgo was
-    # resolving C:\mingw64\bin\gcc.exe -- picked by PATH order, not by us,
-    # and free to change when the image does. Probed on a real run (#324).
+    # Pointing PATH at the MSYS2 toolchain instead -- the apparent fix -- breaks
+    # the link: its gcc 16.1.0 uses a different TLS model, and libduckdb_static.a
+    # fails on undefined `__emutls_v._ZSt11__once_call`. Measured, not guessed.
     #
-    # The check is the load-bearing half. Naming the right directory is only
-    # correct until something prepends another gcc, and the failure mode is
-    # silent: it still builds, just not with the pinned toolchain.
-    - name: Add MSYS2 to PATH (Windows)
+    # So the accident was benign and the intent was wrong. This names the working
+    # compiler deliberately rather than inheriting it from PATH order, and the
+    # 61s that installed an unusable toolchain goes away.
+    - name: Pin the C toolchain cgo uses (Windows)
       run: |
-        $bin = Join-Path '${{ steps.msys2.outputs.msys2-location }}' 'ucrt64\bin'
+        $bin = 'C:\mingw64\bin'
         if (-not (Test-Path (Join-Path $bin 'gcc.exe'))) {
-          Write-Host "::error::No gcc in $bin -- setup-msys2 did not install where its msys2-location output says."
+          Write-Host "::error::No gcc at $bin. The windows runner image has shipped one there; if that changed, a toolchain matching duckdb-go-bindings' prebuilt libduckdb_static.a must be installed instead. See #324."
           exit 1
         }
         echo $bin >> $env:GITHUB_PATH
 
-    # Prove the pinned toolchain is the one cgo will use. The runner image ships
-    # five compilers, and while the PATH line named a directory without a gcc,
-    # cgo silently resolved C:\mingw64\bin\gcc.exe instead (#324). Nothing
-    # failed, so nothing reported it.
-    - name: Verify cgo uses the pinned toolchain (Windows)
+    - name: Verify cgo uses it (Windows)
       run: |
-        $expected = Join-Path '${{ steps.msys2.outputs.msys2-location }}' 'ucrt64\bin\gcc.exe'
         $actual = (Get-Command gcc -ErrorAction SilentlyContinue).Source
-        Write-Host "expected: $expected"
-        Write-Host "actual:   $actual"
-        if ($actual -ne $expected) {
-          Write-Host "::error::cgo would use $actual, not the toolchain this workflow installs."
+        Write-Host "cgo will use $actual"
+        if ($actual -ne 'C:\mingw64\bin\gcc.exe') {
+          Write-Host "::error::cgo would use $actual, not the pinned C:\mingw64 toolchain."
           exit 1
         }
         gcc --version | Select-Object -First 1


### PR DESCRIPTION
Fixes #324. Supersedes #384, which had the right change for a wrong reason.

## What was happening

Every Windows job installed a UCRT64 toolchain via setup-msys2, then ran:

```
echo "C:\msys64\ucrt64\bin" >> $env:GITHUB_PATH
```

setup-msys2 installs under `RUNNER_TEMP` — it reports the path as its `msys2-location` output. `C:\msys64` does exist on the image but holds no ucrt64 gcc, so that line added an empty directory and cgo fell through to the next gcc on PATH.

The image ships five: `C:\mingw32`, `C:\mingw64`, `C:\rtools45`, `C:\Strawberry\c`, plus ours. It landed on `C:\mingw64\bin\gcc.exe` — in CI, in `go install`, and in **release**, so published Windows binaries were built by a compiler chosen by PATH order.

## The obvious fix is wrong, and CI proved it

Making the declared toolchain take effect — PATH pointing at `msys2-location` — passes the verify step and then **fails the build**:

```
libduckdb_static.a(re2.cc.obj): undefined reference to
  __emutls_v._ZSt11__once_call
```

duckdb-go-bindings ships a **prebuilt** `libduckdb_static.a` for windows-amd64. The compiler has to match the archive, not merely be a working gcc; MSYS2's gcc 16.1.0 uses a different TLS model and cannot link it.

So the accident was benign and the intent was wrong. `C:\mingw64` is the only one of the five that links DuckDB.

## What this does

- Names `C:\mingw64\bin` outright instead of inheriting it from PATH order
- Verifies cgo resolves there, and fails with the reason if not
- Drops setup-msys2, which spent 61s per run — 8s extracting, 48s installing 43 packages past a cache hit — on a toolchain nothing could use
- Applies the identical two steps to all three workflows, so CI, `go install` and release cannot diverge on the compiler that builds shipped binaries

## Measured

Windows job **164s → 98s**, green through build and the full `go test ./...`. `Set up Go` was 41s before and 37s after, so this is the change and not cache variance.

## Note

`release.yml` uses `update: true` where CI used `update: false`. Both are gone with the step, so that drift is resolved by removal rather than by choosing.
