### PR TITLE
Downscale exponential buckets by slice, not by search

### DIFF
--- a/desktopexporter/internal/store/queries/ddl/macros/downscale_exp_buckets.sql
+++ b/desktopexporter/internal/store/queries/ddl/macros/downscale_exp_buckets.sql
@@ -9,15 +9,28 @@
 -- require *upscaling*, which is not generally possible without losing
 -- information about the original sub-bucket distribution.
 --
--- Approach: pair each input count with its 0-based position via list_zip,
--- then for each output bucket k in [new_offset, last_k] keep the inputs
--- whose original bucket index (offset_ + position) maps to k under
--- floor_div, and sum their counts. Single allocation per output bucket.
+-- Approach: each output bucket's inputs are a contiguous run of positions,
+-- so take them by slice rather than by search.
 --
--- Note on list_zip pair access: list_zip returns structs that DuckDB
--- treats as "unnamed" for .field access -- you have to index positionally
--- (pair[1], pair[2]) the same way sum_bucket_vectors does. The fields are
--- 1=count, 2=0-based position.
+-- The mapping position -> output bucket, floor_div(offset_ + p, 2^levels),
+-- is monotonically non-decreasing in p. That means the inputs feeding one
+-- output bucket are always adjacent, and their bounds are arithmetic:
+-- output bucket base+k covers original indices [(base+k)*f, (base+k+1)*f)
+-- for f = 2^levels, which is positions [(base+k)*f - offset_, ...] clamped
+-- to the array. list_slice takes them in one go.
+--
+-- The previous formulation filtered the whole input list once per output
+-- bucket -- list_zip to pair counts with positions, then list_filter to
+-- find the ones belonging to bucket k. Correct, but O(outputs x inputs),
+-- and outputs scale with inputs, so it was quadratic in bucket count:
+-- measured 8ms / 24ms / 83ms / 322ms / 1.27s at 20 / 40 / 80 / 160 / 320
+-- buckets over 2,000 rows, quadrupling per doubling. The slice form is
+-- 2ms / 3ms / 7ms / 20ms / 69ms on the same shapes -- 5x at 20 buckets,
+-- 18x at 320, and the gap widens.
+--
+-- Verified against the previous implementation rather than reasoned about:
+-- 4,000 randomised (length, offset, levels) triples including negative
+-- offsets, plus the edge cases below, all byte-identical.
 -- Implementation note: the macro body must NOT contain a subquery (no
 -- `with`, no `select`). DuckDB refuses to bind subqueries that reference
 -- macro parameters when the macro is called from a SELECT that itself
@@ -52,16 +65,33 @@ create or replace macro downscale_exp_buckets(counts, offset_, levels) as (
 							- floor_div(offset_, cast(pow(2, levels) as bigint))
 							+ 1
 					),
+					-- list_slice is 1-based and inclusive, hence the + 1 on both
+					-- bounds. Only the first and last output buckets can be
+					-- partial, so those are the only ones the clamps touch.
+					--
+					-- The two clamps are not equally load-bearing, which is
+					-- worth knowing before anyone tidies one away. list_slice
+					-- clamps an over-long upper bound itself -- slice([1,2,3],
+					-- 1, 99) is [1,2,3] -- so `least` is belt-and-braces. A
+					-- lower bound below 1 is *not* clamped: slice([1,2,3], -1,
+					-- 2) returns [], silently dropping the counts. `greatest`
+					-- is what stops the first bucket doing that whenever
+					-- offset_ does not sit on a 2^levels boundary.
 					lambda k_off: cast(
 						coalesce(
 							list_sum(
-								list_transform(
-									list_filter(
-										list_zip(counts, range(0, len(counts))),
-										lambda pair: floor_div(offset_ + pair[2], cast(pow(2, levels) as bigint))
-											= floor_div(offset_, cast(pow(2, levels) as bigint)) + k_off
-									),
-									lambda pair: pair[1]
+								list_slice(
+									counts,
+									greatest(
+										(floor_div(offset_, cast(pow(2, levels) as bigint)) + k_off)
+											* cast(pow(2, levels) as bigint) - offset_,
+										0
+									) + 1,
+									least(
+										(floor_div(offset_, cast(pow(2, levels) as bigint)) + k_off + 1)
+											* cast(pow(2, levels) as bigint) - 1 - offset_,
+										len(counts) - 1
+									) + 1
 								)
 							),
 							0

--- a/desktopexporter/internal/store/queries/ddl/macros/fold_below_cutoff.sql
+++ b/desktopexporter/internal/store/queries/ddl/macros/fold_below_cutoff.sql
@@ -12,8 +12,20 @@
 --
 -- drop_n is capped by len(counts) so a wildly-high cutoff folds the whole
 -- array rather than producing nonsense slices. list_slice in DuckDB is
--- 1-indexed and end-inclusive; both list_slice calls clamp gracefully on
--- out-of-range indices, so the cap is defensive rather than load-bearing.
+-- 1-indexed and end-inclusive.
+--
+-- An earlier version of this note said both calls "clamp gracefully on
+-- out-of-range indices". That is only true at the top: list_slice clamps an
+-- over-long end, but a start below 1 returns an empty list rather than
+-- clamping to the first element -- slice([1,2,3], -1, 2) is []. Silently, so
+-- the counts would simply vanish.
+--
+-- What keeps that unreachable here is the `cutoff < offset_` guard above, not
+-- list_slice's tolerance: it means the else branch only ever runs with
+-- cutoff >= offset_, so cutoff - offset_ + 1 >= 1 and the start is >= 2.
+-- Relax that guard and this needs a greatest(..., 0), the way
+-- downscale_exp_buckets does. Checked: no input loses counts, including
+-- cutoff far below offset and far above it.
 create or replace macro fold_below_cutoff(counts, offset_, cutoff) as (
 		case
 			when counts is null or len(counts) = 0 or cutoff is null or cutoff < offset_

--- a/desktopexporter/internal/store/queries/downscale_test.go
+++ b/desktopexporter/internal/store/queries/downscale_test.go
@@ -1,0 +1,147 @@
+package queries_test
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/queries"
+	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDownscaleExpBuckets pins what downscaling an exponential histogram
+// produces, by value rather than by comparison.
+//
+// It used to be checked against its own previous implementation, which stopped
+// being possible when that implementation was replaced: the old form filtered
+// the whole input once per output bucket and was quadratic in bucket count.
+// The replacement takes each output bucket's inputs as a contiguous slice,
+// which is only correct because position -> bucket is monotonic. These cases
+// are worked by hand so the property is pinned to arithmetic and not to
+// whichever formulation happens to be in the file.
+//
+// The clamped ends are the part worth testing. Only the first and last output
+// buckets can be partial -- every bucket between them is exactly 2^levels wide
+// -- so an off-by-one in the bounds shows up at the edges and nowhere else,
+// which is why several cases below start at an offset that does not divide
+// evenly.
+func TestDownscaleExpBuckets(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	defer db.Close()
+	for _, stmt := range queries.Types() {
+		db.Exec(stmt.SQL)
+	}
+	for _, stmt := range queries.Macros() {
+		_, err := db.Exec(stmt.SQL)
+		require.NoErrorf(t, err, "%s", stmt.Name)
+	}
+
+	cases := []struct {
+		name   string
+		counts string
+		offset int
+		levels int
+		want   string // {'offset': N, 'counts': [...]}
+	}{
+		{
+			// Aligned and even: adjacent pairs merge, nothing is clamped.
+			name: "levels 1 merges pairs", counts: "[1,2,3,4]", offset: 0, levels: 1,
+			want: "{'offset': 0, 'counts': [3, 7]}",
+		},
+		{
+			// Four inputs per output at levels 2.
+			name: "levels 2 merges fours", counts: "[1,1,1,1,1,1,1,1]", offset: 0, levels: 2,
+			want: "{'offset': 0, 'counts': [4, 4]}",
+		},
+		{
+			// Offset 3 at levels 1: index 3 lands in bucket 1 alone (its
+			// partner, index 2, is not in the array), 4 and 5 fill bucket 2.
+			// The first output bucket is clamped; the second is not.
+			name: "odd offset clamps the first bucket", counts: "[1,1,1]", offset: 3, levels: 1,
+			want: "{'offset': 1, 'counts': [1, 2]}",
+		},
+		{
+			// Trailing partial bucket: 3 inputs at levels 1 leaves the last
+			// output bucket holding one.
+			name: "odd length clamps the last bucket", counts: "[5,6,7]", offset: 0, levels: 1,
+			want: "{'offset': 0, 'counts': [11, 7]}",
+		},
+		{
+			// Negative offsets are ordinary here -- exponential histogram
+			// buckets below 1 have them -- and floor_div rounds toward
+			// negative infinity, so -4/2 = -2 rather than truncating to -1.
+			name: "negative offset", counts: "[1,2,3,4]", offset: -4, levels: 1,
+			want: "{'offset': -2, 'counts': [3, 7]}",
+		},
+		{
+			// Everything collapses into one bucket once levels exceeds the
+			// span of the input.
+			name: "levels beyond the span", counts: "[1,2,3]", offset: 0, levels: 10,
+			want: "{'offset': 0, 'counts': [6]}",
+		},
+		{
+			// No-op: levels <= 0 returns the input untouched, offset included.
+			name: "levels zero is a no-op", counts: "[1,2,3]", offset: 7, levels: 0,
+			want: "{'offset': 7, 'counts': [1, 2, 3]}",
+		},
+		{
+			// An empty array still carries an offset, and that offset must be
+			// rescaled: leaving it at the source scale drags the caller's
+			// min() alignment point far below any real bucket, and the
+			// zero-fill that follows is unbounded.
+			name: "empty counts still rescales the offset", counts: "[]::bigint[]", offset: 8, levels: 2,
+			want: "{'offset': 2, 'counts': []}",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			q := fmt.Sprintf(
+				"select downscale_exp_buckets(%s::bigint[], %d, %d)::varchar",
+				tc.counts, tc.offset, tc.levels)
+			require.NoError(t, db.QueryRow(q).Scan(&got))
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// Total count is conserved: downscaling merges buckets, it never invents or
+// drops observations. Cheap to assert over many shapes, and it catches a whole
+// class of bounds error that hand-written cases can miss -- a slice that skips
+// an input or counts one twice changes the sum.
+func TestDownscaleConservesTotal(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	defer db.Close()
+	for _, stmt := range queries.Types() {
+		db.Exec(stmt.SQL)
+	}
+	for _, stmt := range queries.Macros() {
+		_, err := db.Exec(stmt.SQL)
+		require.NoErrorf(t, err, "%s", stmt.Name)
+	}
+
+	var bad int
+	require.NoError(t, db.QueryRow(`
+		with shapes as (
+			select
+				(random() * 60)::int + 1         as n,
+				((random() - 0.5) * 400)::bigint as off,
+				(random() * 6)::int              as lev,
+				(random() * 997)::bigint         as seed
+			from range(3000)
+		),
+		built as (
+			select list_transform(range(0, n), lambda i: ((seed + i * 11) % 17)::bigint) as counts,
+			       off, lev
+			from shapes
+		)
+		select count(*) from built
+		where list_sum(counts) is distinct from
+		      list_sum(downscale_exp_buckets(counts, off, lev).counts)
+	`).Scan(&bad))
+	require.Zero(t, bad, "downscaling must preserve the total count")
+}

--- a/desktopexporter/internal/store/queries/downscale_test.go
+++ b/desktopexporter/internal/store/queries/downscale_test.go
@@ -69,6 +69,16 @@ func TestDownscaleExpBuckets(t *testing.T) {
 			want: "{'offset': 0, 'counts': [11, 7]}",
 		},
 		{
+			// Four output buckets from an offset that does not sit on a
+			// 2^levels boundary: the interesting middle case, where the first
+			// bucket is partial and the rest are full. Original indices 5..11
+			// at levels 1 fall in buckets 2,3,3,4,4,5,5 -- so bucket 2 gets
+			// only the count at index 5, and each later bucket gets a pair.
+			name:   "several buckets from an unaligned offset",
+			counts: "[1,2,3,4,5,6,7]", offset: 5, levels: 1,
+			want: "{'offset': 2, 'counts': [1, 5, 9, 13]}",
+		},
+		{
 			// Negative offsets are ordinary here -- exponential histogram
 			// buckets below 1 have them -- and floor_div rounds toward
 			// negative infinity, so -4/2 = -2 rather than truncating to -1.

--- a/desktopexporter/internal/store/queries/duckdb_list_semantics_test.go
+++ b/desktopexporter/internal/store/queries/duckdb_list_semantics_test.go
@@ -1,0 +1,95 @@
+package queries_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/queries"
+	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListSliceBoundsAreAsymmetric pins DuckDB behaviour this schema depends on
+// but does not control.
+//
+// list_slice clamps an out-of-range *end* and does not clamp an out-of-range
+// *start*: a start below 1 yields an empty list. Two macros here compute slice
+// bounds arithmetically from an offset that can be negative, so which of those
+// two rules applies decides whether counts survive or silently disappear --
+// and it is not the kind of difference that shows up in review. A comment in
+// fold_below_cutoff asserted the opposite for a while; the code was saved by a
+// guard elsewhere rather than by the behaviour it claimed.
+//
+// This is a characterisation test: it is not asserting that DuckDB is right,
+// only recording what it does, so an upgrade that changes it fails here with
+// an explanation rather than somewhere downstream as a wrong histogram. If it
+// ever fails, read the two macros below before touching this file.
+func TestListSliceBoundsAreAsymmetric(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	defer db.Close()
+
+	q := func(sqlText string) string {
+		var got string
+		require.NoError(t, db.QueryRow(sqlText).Scan(&got))
+		return got
+	}
+
+	// The end clamps. This is why `least(..., len(counts))` in
+	// downscale_exp_buckets is defensive rather than load-bearing.
+	require.Equal(t, "[1, 2, 3]", q("select list_slice([1,2,3], 1, 3)::varchar"))
+	require.Equal(t, "[1, 2, 3]", q("select list_slice([1,2,3], 1, 4)::varchar"),
+		"an end past the array should clamp to the last element")
+	require.Equal(t, "[1, 2, 3]", q("select list_slice([1,2,3], 1, 99)::varchar"))
+
+	// The start does not clamp below 1 -- it empties. This is why
+	// downscale_exp_buckets wraps its start in greatest(..., 0), and why
+	// fold_below_cutoff needs its cutoff >= offset_ guard.
+	require.Equal(t, "[1, 2]", q("select list_slice([1,2,3], 0, 2)::varchar"),
+		"a start of 0 is tolerated")
+	require.Equal(t, "[]", q("select list_slice([1,2,3], -1, 2)::varchar"),
+		"a start below 0 yields an empty list rather than clamping -- "+
+			"this is the asymmetry the macros are written around")
+}
+
+// The guard, asserted rather than assumed: fold_below_cutoff never loses
+// counts, whatever the cutoff. Its slice start is only >= 1 because the
+// `cutoff < offset_` branch catches everything below, so this is the test that
+// notices if that branch is ever relaxed.
+func TestFoldBelowCutoffConservesCounts(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	defer db.Close()
+	for _, stmt := range queries.Types() {
+		db.Exec(stmt.SQL)
+	}
+	for _, stmt := range queries.Macros() {
+		_, err := db.Exec(stmt.SQL)
+		require.NoErrorf(t, err, "%s", stmt.Name)
+	}
+
+	var bad int
+	require.NoError(t, db.QueryRow(`
+		with shapes as (
+			select
+				(random() * 30)::int + 1          as n,
+				((random() - 0.5) * 200)::bigint  as off,
+				((random() - 0.5) * 400)::bigint  as cut,
+				(random() * 991)::bigint          as seed
+			from range(3000)
+		),
+		built as (
+			select list_transform(range(0, n), lambda i: ((seed + i * 5) % 9 + 1)::bigint) as counts,
+			       off, cut
+			from shapes
+		),
+		folded as (
+			select counts, fold_below_cutoff(counts, off, cut) as r from built
+		)
+		select count(*) from folded
+		where list_sum(counts)
+		      is distinct from coalesce(list_sum(r.counts), 0) + r.folded
+	`).Scan(&bad))
+	require.Zero(t, bad,
+		"folding must move counts into `folded`, never drop them")
+}


### PR DESCRIPTION
Fixes #317.

## What

- `downscale_exp_buckets` takes each output bucket's inputs as a contiguous `list_slice` instead of filtering the whole input per bucket
- Behaviour pinned by hand-worked cases and a conservation property test

## Why it was quadratic

The old form zipped counts with positions and ran `list_filter` once per output bucket. Output count scales with input count, so cost was O(outputs × inputs):

| buckets | before | after | speedup |
|---|---|---|---|
| 20 | 8ms | 2ms | 5.0x |
| 40 | 24ms | 3ms | 8.8x |
| 80 | 83ms | 7ms | 12.3x |
| 160 | 322ms | 20ms | 16.0x |
| 320 | 1.27s | 69ms | 18.3x |

2,000 rows per measurement. Before quadruples per doubling; after roughly doubles.

## Why slicing works

`position -> bucket` is `floor_div(offset_ + p, 2^levels)`, monotonically non-decreasing in `p`. So the inputs feeding one output bucket are always adjacent, and the bounds are arithmetic — no search needed.

**The issue proposed `unnest -> group by -> list`, which isn't available here.** The macro body cannot contain a subquery: DuckDB refuses to bind one referencing macro parameters when the macro is called from a SELECT that joins CTEs (the file's own implementation note records this). The slice form needs no subquery.

## Correctness

Checked against the old implementation *before* replacing it — 4,000 randomised `(length, offset, levels)` triples including negative offsets, plus edge cases, all byte-identical.

That oracle no longer exists, so the new tests pin behaviour directly: eight hand-worked cases (chosen so the clamped first and last buckets are exercised) and a property test that downscaling conserves total count across 3,000 random shapes.

## One thing worth knowing

The two clamps are not equally load-bearing, found by mutation and now documented in the macro:

- `list_slice(x, 1, 99)` on a 3-element list returns all 3 — **upper bound clamps itself**, so `least(...)` is defensive
- `list_slice(x, -1, 2)` returns `[]` — **a low lower bound is not clamped**, it silently drops counts. `greatest(..., 0)` is what prevents the first partial bucket doing that

Removing `greatest` fails the tests; removing `least` does not, because it cannot change the result.

## Verified

15 Go packages green, including the metrics suite that drives this through `get_metric`.