### PR TITLE
Ask SQL for the aggregate instead of the whole metric

### DIFF
--- a/desktopexporter/internal/store/metrics/metrics.go
+++ b/desktopexporter/internal/store/metrics/metrics.go
@@ -812,12 +812,18 @@ func SearchSummaries(ctx context.Context, db *sql.DB, startTime, endTime int64, 
 // this decision; the store obeys it. The window actually used comes back in the
 // response, so nobody has to infer it from bucketed timestamps.
 func GetMetric(ctx context.Context, db *sql.DB, streamID string, startTime, endTime int64, targetBuckets int64, seriesIDs []string, quantiles []float64, tzOffsetNs int64, fitToData bool, viewBuckets int64, sparklineBuckets int64, selectedSeriesIDs []string, tzName string, datapointSeriesIDs []string, datapointSeriesLimit int64) (json.RawMessage, error) {
+	return getMetric(ctx, db, getMetricParams{}, streamID, startTime, endTime, targetBuckets, seriesIDs, quantiles, tzOffsetNs, fitToData, viewBuckets, sparklineBuckets, selectedSeriesIDs, tzName, datapointSeriesIDs, datapointSeriesLimit)
+}
+
+// getMetric runs the query in whichever shape params asks for. Both shapes take
+// the same arguments and the same CTEs; only the projection differs.
+func getMetric(ctx context.Context, db *sql.DB, params getMetricParams, streamID string, startTime, endTime int64, targetBuckets int64, seriesIDs []string, quantiles []float64, tzOffsetNs int64, fitToData bool, viewBuckets int64, sparklineBuckets int64, selectedSeriesIDs []string, tzName string, datapointSeriesIDs []string, datapointSeriesLimit int64) (json.RawMessage, error) {
 	// Everything filters by stream_id.
 	// matched_ingests is "ingests for this stream that produced at least
 	// one datapoint in the time window." All identity columns the JSON
 	// projection needs come from the metric_streams row directly via
 	// the stream CTE.
-	query, err := queries.Render(queries.GetMetric, nil)
+	query, err := queries.Render(queries.GetMetric, params)
 	if err != nil {
 		return nil, err
 	}
@@ -897,38 +903,29 @@ func GetMetric(ctx context.Context, db *sql.DB, streamID string, startTime, endT
 // The rule the two share: narrowing decides what is *sent*, never what is
 // *aggregated*.
 func GetMetricAggregate(ctx context.Context, db *sql.DB, streamID string, startTime, endTime int64, targetBuckets int64, seriesIDs []string, quantiles []float64, tzOffsetNs int64, fitToData bool, viewBuckets int64, selectedSeriesIDs []string, tzName string) (json.RawMessage, error) {
-	// 0 sparkline buckets: this call keeps only the aggregate envelopes and drops
-	// the timeseries the sparklines hang off, so computing them would be work
-	// whose entire output is discarded a few lines below.
-	// An empty datapoint list, not nil: this call keeps only the aggregate
-	// envelopes and discards the timeseries, so naming no series ships no
-	// datapoints. nil would mean "not narrowing", which with no limit ships
-	// every one of them for nothing.
-	raw, err := GetMetric(ctx, db, streamID, startTime, endTime, targetBuckets, seriesIDs, quantiles, tzOffsetNs, fitToData, viewBuckets, 0, selectedSeriesIDs, tzName, []string{}, 0)
+	// Ask SQL for the aggregate shape rather than the whole metric.
+	//
+	// This used to call GetMetric and then unmarshal its response in Go to
+	// keep two fields. That was the store's only place parsing JSON on the way
+	// back out -- everywhere else a query's JSON is passed through untouched --
+	// and it made a legend toggle pay for the entire metric.
+	//
+	// The saving is not the discarded bytes, it is the plan. DuckDB prunes the
+	// CTEs a projection never reads, so dropping `timeseries` drops the
+	// per-series pipelines feeding it. Measured on a 21-series histogram:
+	// 314ms -> 150ms, of which planning 212ms -> 67ms.
+	//
+	// 0 sparkline buckets and an empty datapoint list are still passed, so a
+	// caller reading this does not have to work out that the pruning already
+	// covers them.
+	raw, err := getMetric(ctx, db, getMetricParams{AggregateOnly: true},
+		streamID, startTime, endTime, targetBuckets, seriesIDs, quantiles,
+		tzOffsetNs, fitToData, viewBuckets, 0, selectedSeriesIDs, tzName,
+		[]string{}, 0)
 	if err != nil {
 		return nil, err
 	}
-	var envelope struct {
-		Aggregate       json.RawMessage `json:"aggregate"`
-		ScalarAggregate json.RawMessage `json:"scalarAggregate"`
-	}
-	if err := json.Unmarshal(raw, &envelope); err != nil {
-		return nil, fmt.Errorf("GetMetricAggregate: %w: %w", ErrMetricsStoreInternal, err)
-	}
-	// Both fields travel, each null-able on its own: a scalar metric has no
-	// histogram merge and a histogram has no scalar pools, and the caller should
-	// not have to ask twice to find out which it got.
-	out, err := json.Marshal(struct {
-		Aggregate       json.RawMessage `json:"aggregate"`
-		ScalarAggregate json.RawMessage `json:"scalarAggregate"`
-	}{
-		Aggregate:       nullIfAbsent(envelope.Aggregate),
-		ScalarAggregate: nullIfAbsent(envelope.ScalarAggregate),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("GetMetricAggregate: %w: %w", ErrMetricsStoreInternal, err)
-	}
-	return out, nil
+	return raw, nil
 }
 
 // nullIfAbsent keeps json.Marshal from writing a bare `null` field as invalid
@@ -1334,6 +1331,20 @@ func boolValueToIdentityString(v driver.Value, metricType string) string {
 
 // searchSummariesParams are the fragments SearchSummaries assembles into
 // queries/metrics/search_summaries.sql.
+// getMetricParams selects which shape of response the projection builds.
+//
+// The CTE definitions are identical either way; only the final json_object
+// changes. DuckDB prunes whatever the projection does not read, so asking for
+// less is not merely a smaller payload -- it is a smaller plan. Measured on a
+// 21-series histogram: the full projection plans in 212ms and runs in 314ms,
+// the aggregate-only one in 67ms and 150ms.
+type getMetricParams struct {
+	// AggregateOnly emits just the cross-series aggregates, which is all
+	// GetMetricAggregate returns. It drops `timeseries` -- the field that
+	// carries the per-series pipelines and most of the planning cost.
+	AggregateOnly bool
+}
+
 type searchSummariesParams struct {
 	// CTEs is the search_params CTE holding the time bounds.
 	CTEs string

--- a/desktopexporter/internal/store/metrics/metrics.go
+++ b/desktopexporter/internal/store/metrics/metrics.go
@@ -918,7 +918,7 @@ func GetMetricAggregate(ctx context.Context, db *sql.DB, streamID string, startT
 	// 0 sparkline buckets and an empty datapoint list are still passed, so a
 	// caller reading this does not have to work out that the pruning already
 	// covers them.
-	raw, err := getMetric(ctx, db, getMetricParams{AggregateOnly: true},
+	raw, err := getMetric(ctx, db, aggregateShapeFor(ctx, db, streamID),
 		streamID, startTime, endTime, targetBuckets, seriesIDs, quantiles,
 		tzOffsetNs, fitToData, viewBuckets, 0, selectedSeriesIDs, tzName,
 		[]string{}, 0)
@@ -1343,6 +1343,42 @@ type getMetricParams struct {
 	// GetMetricAggregate returns. It drops `timeseries` -- the field that
 	// carries the per-series pipelines and most of the planning cost.
 	AggregateOnly bool
+
+	// NoHistogramMerge and NoScalarPools drop a chain whose output is already
+	// known to be empty for this metric's shape, so the planner never builds
+	// it. scalar_dps admits Gauge and Sum only, so a histogram's pools are
+	// always []; the histogram merge needs bucket vectors, so a scalar's
+	// aggregate is always null.
+	//
+	// Only worth setting alongside AggregateOnly. In the full projection
+	// `timeseries` reaches into both chains anyway -- measured, dropping
+	// scalarAggregate there saved nothing -- so the pruning has no room to
+	// work until the per-series fields are gone.
+	NoHistogramMerge bool
+	NoScalarPools    bool
+}
+
+// aggregateShapeFor decides which chains a metric's aggregate can possibly
+// need. A primary-key lookup on metric_streams, measured at 0.09ms, against
+// 120ms saved on a scalar metric.
+func aggregateShapeFor(ctx context.Context, db *sql.DB, streamID string) getMetricParams {
+	p := getMetricParams{AggregateOnly: true}
+	var metricType string
+	err := db.QueryRowContext(ctx,
+		`select metric_type from metric_streams where id = ?::uuid`, streamID).Scan(&metricType)
+	if err != nil {
+		// Unknown shape: ask for both, which is what this call did before the
+		// pruning existed. A stream id that does not resolve fails in the main
+		// query with ErrStreamIDNotFound, and that is the error worth showing.
+		return p
+	}
+	switch metricType {
+	case "Histogram", "ExponentialHistogram":
+		p.NoScalarPools = true
+	case "Gauge", "Sum":
+		p.NoHistogramMerge = true
+	}
+	return p
 }
 
 type searchSummariesParams struct {

--- a/desktopexporter/internal/store/metrics/metrics.go
+++ b/desktopexporter/internal/store/metrics/metrics.go
@@ -928,15 +928,6 @@ func GetMetricAggregate(ctx context.Context, db *sql.DB, streamID string, startT
 	return raw, nil
 }
 
-// nullIfAbsent keeps json.Marshal from writing a bare `null` field as invalid
-// empty bytes when the source key was missing rather than JSON null.
-func nullIfAbsent(raw json.RawMessage) json.RawMessage {
-	if len(raw) == 0 {
-		return json.RawMessage("null")
-	}
-	return raw
-}
-
 // GetMetricAttributes returns every metric-side attribute name/scope/type this
 // store knows about. The time range is accepted and ignored -- see the note on
 // spans.GetTraceAttributes.
@@ -1329,8 +1320,6 @@ func boolValueToIdentityString(v driver.Value, metricType string) string {
 	return ""
 }
 
-// searchSummariesParams are the fragments SearchSummaries assembles into
-// queries/metrics/search_summaries.sql.
 // getMetricParams selects which shape of response the projection builds.
 //
 // The CTE definitions are identical either way; only the final json_object
@@ -1381,6 +1370,8 @@ func aggregateShapeFor(ctx context.Context, db *sql.DB, streamID string) getMetr
 	return p
 }
 
+// searchSummariesParams are the fragments SearchSummaries assembles into
+// queries/metrics/search_summaries.sql.
 type searchSummariesParams struct {
 	// CTEs is the search_params CTE holding the time bounds.
 	CTEs string

--- a/desktopexporter/internal/store/metrics/metrics_test.go
+++ b/desktopexporter/internal/store/metrics/metrics_test.go
@@ -4252,6 +4252,75 @@ func TestGetMetricAggregate(t *testing.T) {
 		"an empty selection aggregates no series")
 
 	assert.Positive(t, allCount, "nil selection aggregates every series")
+
+	// The envelope carries these two fields and nothing else.
+	//
+	// It is built by SQL now rather than assembled in Go, so a stray field in
+	// the projection would travel silently: the caller reads the two it knows
+	// about and never notices the rest. That matters more than the bytes --
+	// the projection is what the planner prunes from, so a field nobody reads
+	// still drags its whole CTE chain into the plan.
+	assert.ElementsMatch(t, []string{"aggregate", "scalarAggregate"},
+		mapKeys(envelope),
+		"the aggregate call must project exactly its envelope")
+
+	// A scalar is the mirror image, and the reason the shape is chosen per
+	// metric: no histogram merge to report, but real pools.
+	t.Run("scalar metric reports pools and no merge", func(t *testing.T) {
+		var sums []sumTestDP
+		for i := 0; i < 4; i++ {
+			sums = append(sums, sumTestDP{
+				timestamp: base.Add(time.Duration(i) * time.Second),
+				value:     float64(10 * (i + 1)),
+				attrs:     map[string]string{"route": "/scalar"},
+			})
+		}
+		require.NoError(t, s.WithConn(func(conn driver.Conn) error {
+			return metrics.Ingest(ctx, conn,
+				makeSumFixtureT("agg.scalar", pmetric.AggregationTemporalityCumulative, sums),
+				s.FlushedIDs())
+		}))
+		scalarID := findMetricID(t, s, ctx, "agg.scalar")
+
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return metrics.GetMetricAggregate(ctx, db, scalarID, 0, end, 1, nil, nil, 0, false, 4, nil, "")
+		})
+		require.NoError(t, err)
+		var env map[string]any
+		require.NoError(t, json.Unmarshal(raw, &env))
+
+		assert.ElementsMatch(t, []string{"aggregate", "scalarAggregate"}, mapKeys(env))
+		// Null, not empty: a Sum has no bucket vectors, so there is no merge to
+		// report, and the client tells that apart from "merged to nothing".
+		assert.Nil(t, env["aggregate"], "a scalar has no histogram merge")
+		pools, _ := env["scalarAggregate"].(map[string]any)
+		require.NotNil(t, pools)
+		assert.NotEmpty(t, pools["all"], "a scalar contributes an All pool")
+	})
+
+	// The full projection keeps every field, which the shared template makes
+	// worth asserting: one stray conditional would truncate the real response
+	// and every test above would still pass, because none of them read it.
+	t.Run("the full projection is unaffected", func(t *testing.T) {
+		m := getMetricFullByName(t, s, ctx, "agg.only")
+		for _, k := range []string{
+			"id", "name", "description", "unit", "metricType", "resource",
+			"scope", "timeseries", "aggregate", "scalarAggregate",
+			"lastSeenNs", "datapointCount", "window",
+		} {
+			assert.Containsf(t, m, k, "getMetric must still emit %q", k)
+		}
+	})
+}
+
+// mapKeys is the sorted key set of a decoded JSON object.
+func mapKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // TestGetMetric_BucketsFollowTheZoneAcrossDST pins bucketing to the viewer's

--- a/desktopexporter/internal/store/queries/metrics/get_metric.sql
+++ b/desktopexporter/internal/store/queries/metrics/get_metric.sql
@@ -1604,6 +1604,7 @@
 		-- ErrStreamIDNotFound. The representative-sourced fields are
 		-- coalesced so the wire shape stays non-null either way.
 		select cast(json_object(
+{{- if not .AggregateOnly}}
 			'id', s.id, 'name', s.name, 'description', coalesce(r.description, ''), 'unit', s.unit,
 			-- The metric's own metadata map, from the same representative ingest
 			-- description comes from: both are per-batch and neither is identity.
@@ -1624,6 +1625,7 @@
 				            'attributes', json('[]'), 'droppedAttributesCount', 0)
 			),
 			'timeseries', coalesce((select timeseries from timeseries_agg), json('[]')),
+{{- end}}
 			-- Null rather than [] when there is nothing to aggregate, so the
 			-- client can tell "no histogram merge happened" from "merged to
 			-- nothing".
@@ -1636,7 +1638,7 @@
 			'scalarAggregate', json_object(
 				'selected', coalesce((select selected from scalar_pools_json), json('[]')),
 				'all', coalesce((select all_series from scalar_pools_json), json('[]'))
-			),
+			){{if not .AggregateOnly}},
 			-- How many datapoints the window actually holds, as opposed to how
 			-- many came back. Equal today; the moment the server reduces what it
 			-- returns, the difference is what the UI needs in order to say so.
@@ -1674,6 +1676,7 @@
 				'endNs', case when (select fit_to_data from input)
 					then (select max_ts from data_extent)::varchar end
 			)
+{{- end}}
 		) as varchar) as metric
 		from stream s left join representative r on true
 	

--- a/desktopexporter/internal/store/queries/metrics/get_metric.sql
+++ b/desktopexporter/internal/store/queries/metrics/get_metric.sql
@@ -1629,16 +1629,19 @@
 			-- Null rather than [] when there is nothing to aggregate, so the
 			-- client can tell "no histogram merge happened" from "merged to
 			-- nothing".
-			'aggregate', (select aggregate from aggregate_agg),
+			'aggregate', {{if .NoHistogramMerge}}null{{else}}(select aggregate from aggregate_agg){{end}},
 			-- The cross-series lines for a scalar metric, in the same bucket shape
 			-- the per-series views use. `selected` is empty when nothing is
 			-- checked, which the chart reads as "draw All alone" rather than as an
 			-- error. Both are present for histograms too and are empty there --
 			-- scalar_dps is Gauge and Sum only, so nothing reaches the fold.
-			'scalarAggregate', json_object(
+			'scalarAggregate', {{if .NoScalarPools}}json_object(
+				'selected', json('[]'),
+				'all', json('[]')
+			){{else}}json_object(
 				'selected', coalesce((select selected from scalar_pools_json), json('[]')),
 				'all', coalesce((select all_series from scalar_pools_json), json('[]'))
-			){{if not .AggregateOnly}},
+			){{end}}{{if not .AggregateOnly}},
 			-- How many datapoints the window actually holds, as opposed to how
 			-- many came back. Equal today; the moment the server reduces what it
 			-- returns, the difference is what the UI needs in order to say so.


### PR DESCRIPTION
The first half of the metric query work. Legend toggles.

## What

- `GetMetricAggregate` renders an aggregate-only projection instead of calling `GetMetric` and unmarshalling its response in Go
- The projection also drops the aggregate chain a metric's shape cannot produce

## Why it is faster

DuckDB prunes CTEs the projection never reads, so asking for less is a smaller *plan*, not just a smaller payload. The CTE bodies are unchanged; only the final `json_object` is conditional, using the template mechanism `search_spans.sql` already uses.

Planning is worth attacking because it does not scale with data. Re-profiled on this branch, plan time is flat across a 7,560x change in stored datapoints — 155.5ms against a database holding **one** and 158.0ms against one holding 7,560 — while execution over the same range goes 34.6ms to 116.2ms.

| metric | before | after |
|---|---|---|
| Gauge, 21 series | ~176ms | **24ms** |
| Histogram, 21 series | ~235ms | **114ms** |

The gauge gains most: the histogram merge is the longer chain and a gauge could never use it. `scalar_dps` admits Gauge and Sum only, so a histogram's pools are always `[]`; the merge needs bucket vectors, so a scalar's aggregate is always null. Both were planned and executed to produce nothing.

The two commits only pay together — in the full projection `timeseries` reaches into both chains, so dropping `scalarAggregate` there measured at zero saving.

## Also fixes a rule violation

`metrics.go:915` was the store's only place unmarshalling JSON on the way back out; everywhere else a query's JSON passes through untouched. Gone — the store now has none. `nullIfAbsent` went with it, having lost its only caller.

## Verified

- Responses equal to the previous implementation for both metric shapes across four selection sizes; `getMetric` untouched
- Equality is float-tolerant deliberately: DuckDB sums doubles in a parallelism-dependent order, so two consecutive calls to an **unmodified** server already differ in a sum's last digits
- Metric shape comes from a `metric_streams` lookup measured at 0.09ms; an unresolvable id asks for both chains, as before
- Three tests pin the new behaviour, each mutation-checked: the envelope carries exactly `aggregate` and `scalarAggregate`; a scalar reports null merge with populated pools and a histogram the inverse; the full projection still emits every field
- 15 Go packages green

## Related

Not a fix for #354, but the server half of its premise: "a legend toggle should refetch only the aggregate" is what this makes cheap.
