### PR TITLE
Tidy the test suite: one setup helper, one shared read-only database, and parallelism where it is safe

### DIFF
--- a/desktopexporter/internal/store/attributes/attributes_test.go
+++ b/desktopexporter/internal/store/attributes/attributes_test.go
@@ -84,6 +84,7 @@ func search(t *testing.T, s *store.Store, ctx context.Context, term string) []ma
 // The question the feature exists to answer: a value seen in the UI, traced
 // back to the keys that hold it -- across signals, in one call.
 func TestSearchFindsKeysByValue(t *testing.T) {
+	t.Parallel()
 	s, ctx := setup(t)
 	got := search(t, s, ctx, "checkout")
 
@@ -111,6 +112,7 @@ func TestSearchFindsKeysByValue(t *testing.T) {
 }
 
 func TestSearchMatchesKeyNamesToo(t *testing.T) {
+	t.Parallel()
 	s, ctx := setup(t)
 	// "status" appears in no value, only in a key name.
 	got := search(t, s, ctx, "status")
@@ -119,11 +121,13 @@ func TestSearchMatchesKeyNamesToo(t *testing.T) {
 }
 
 func TestSearchIsCaseInsensitive(t *testing.T) {
+	t.Parallel()
 	s, ctx := setup(t)
 	assert.ElementsMatch(t, search(t, s, ctx, "CHECKOUT"), search(t, s, ctx, "checkout"))
 }
 
 func TestSearchEmptyAndNoMatch(t *testing.T) {
+	t.Parallel()
 	s, ctx := setup(t)
 	assert.Empty(t, search(t, s, ctx, ""), "an empty term is not a request for everything")
 	assert.Empty(t, search(t, s, ctx, "   "))
@@ -134,6 +138,7 @@ func TestSearchEmptyAndNoMatch(t *testing.T) {
 // escaping, typing % returns the entire dictionary, which looks like a bug and
 // is a slow one.
 func TestSearchEscapesLikeWildcards(t *testing.T) {
+	t.Parallel()
 	s, ctx := setup(t)
 	assert.Empty(t, search(t, s, ctx, "%"), "%% must be a literal, not a wildcard")
 	assert.Empty(t, search(t, s, ctx, "_"))
@@ -143,6 +148,7 @@ func TestSearchEscapesLikeWildcards(t *testing.T) {
 // Samples are bounded, or a broad term returns the dictionary through the back
 // door.
 func TestSearchBoundsSampleValues(t *testing.T) {
+	t.Parallel()
 	s, ctx := setup(t)
 	got := search(t, s, ctx, "/")
 

--- a/desktopexporter/internal/store/attributes/attributes_test.go
+++ b/desktopexporter/internal/store/attributes/attributes_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/attributes"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/logs"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/spans"
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/storetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.uber.org/zap"
 )
 
 type match struct {
@@ -29,10 +29,7 @@ type match struct {
 
 func setup(t *testing.T) (*store.Store, context.Context) {
 	t.Helper()
-	ctx := context.Background()
-	s, err := store.NewStore(ctx, "", zap.NewNop())
-	require.NoError(t, err)
-	t.Cleanup(func() { s.Close() })
+	s, ctx := storetest.New(t)
 
 	td := ptrace.NewTraces()
 	rs := td.ResourceSpans().AppendEmpty()

--- a/desktopexporter/internal/store/ingest/appender_test.go
+++ b/desktopexporter/internal/store/ingest/appender_test.go
@@ -1,7 +1,6 @@
 package ingest_test
 
 import (
-	"context"
 	"database/sql"
 	"database/sql/driver"
 	"errors"
@@ -9,12 +8,12 @@ import (
 
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/ingest"
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/storetest"
 	"github.com/duckdb/duckdb-go/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	"go.uber.org/zap"
 )
 
 // readStore runs a query under the store's read lock and returns its result.
@@ -30,19 +29,10 @@ func readStore[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error)
 	return out, err
 }
 
-func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
-	t.Helper()
-	ctx := context.Background()
-	s, err := store.NewStore(ctx, "", zap.NewNop())
-	require.NoError(t, err)
-	return s, ctx, func() { s.Close() }
-}
-
 // TestNewAppenders_ErrorPath verifies that when appender creation fails partway through,
 // we close any appenders already created before returning the error (no leak).
 func TestNewAppenders_ErrorPath(t *testing.T) {
-	s, _, teardown := setupStore(t)
-	defer teardown()
+	s, _ := storetest.New(t)
 
 	tables := []string{"attributes", "nonexistent_table"}
 	var appenders map[string]*duckdb.Appender
@@ -86,8 +76,7 @@ func TestNewAppenders_ErrorPath(t *testing.T) {
 // load-bearing here rather than incidental: without it the appender's own flush
 // would fail the FK, which is itself a check that the two halves agree.
 func TestFlushAppenders_MakesDataVisible(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	// Build the dictionary side the way logs.Ingest does, so the ids the
 	// appender writes are the ids the dictionary rows were keyed by.

--- a/desktopexporter/internal/store/ingest/appender_test.go
+++ b/desktopexporter/internal/store/ingest/appender_test.go
@@ -32,6 +32,7 @@ func readStore[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error)
 // TestNewAppenders_ErrorPath verifies that when appender creation fails partway through,
 // we close any appenders already created before returning the error (no leak).
 func TestNewAppenders_ErrorPath(t *testing.T) {
+	t.Parallel()
 	s, _ := storetest.New(t)
 
 	tables := []string{"attributes", "nonexistent_table"}
@@ -76,6 +77,7 @@ func TestNewAppenders_ErrorPath(t *testing.T) {
 // load-bearing here rather than incidental: without it the appender's own flush
 // would fail the FK, which is itself a check that the two halves agree.
 func TestFlushAppenders_MakesDataVisible(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	// Build the dictionary side the way logs.Ingest does, so the ids the
@@ -188,6 +190,7 @@ func TestFlushAppenders_MakesDataVisible(t *testing.T) {
 // TestFlushAppenders_CloseAppenders_NilEmptySafe verifies that FlushAppenders and
 // CloseAppenders do not panic when given nil or empty inputs (documented as safe).
 func TestFlushAppenders_CloseAppenders_NilEmptySafe(t *testing.T) {
+	t.Parallel()
 	assert.NotPanics(t, func() { ingest.FlushAppenders(nil, nil) })
 	assert.NotPanics(t, func() { ingest.FlushAppenders(nil, []string{"x"}) })
 	assert.NotPanics(t, func() { ingest.FlushAppenders(map[string]*duckdb.Appender{}, nil) })

--- a/desktopexporter/internal/store/ingest/attribute_memo_test.go
+++ b/desktopexporter/internal/store/ingest/attribute_memo_test.go
@@ -19,6 +19,15 @@ func mapOf(build func(m pcommon.Map)) pcommon.Map {
 // stands in front of a pure function, so for every input the cached answer must
 // be the answer the derivation would have given. Each case is asked twice --
 // once cold, once warm -- because only the second is served by the memo.
+// The tests in this file are deliberately not parallel.
+//
+// The memo is one process-global table with global hit and miss counters, so
+// a test that asserts "89 misses and 17,711 hits" is asserting about the whole
+// process. Any other test ingesting at the same time moves those numbers, and
+// so does another memo test calling ResetAttributeMemo halfway through this
+// one. Go runs every non-parallel test to completion before the parallel ones
+// resume, which is what keeps these six isolated -- so leaving t.Parallel()
+// off is load-bearing here, not an omission.
 func TestAttributeMemoAgreesWithDerivation(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/desktopexporter/internal/store/ingest/dictionary_test.go
+++ b/desktopexporter/internal/store/ingest/dictionary_test.go
@@ -25,6 +25,7 @@ func attrMap(kv map[string]string) pcommon.Map {
 // The whole model rests on this: the same content must produce the same id
 // across batches and process restarts, with no database round trip.
 func TestAttributeIDIsContentDerived(t *testing.T) {
+	t.Parallel()
 	a := ingest.AttributeID("http.method", "GET", "string", ingest.ScopeSpan)
 	b := ingest.AttributeID("http.method", "GET", "string", ingest.ScopeSpan)
 	assert.Equal(t, a, b, "same content must give the same id")
@@ -41,6 +42,7 @@ func TestAttributeIDIsContentDerived(t *testing.T) {
 // same, and a value containing the separator could impersonate a different
 // split of the same bytes.
 func TestHashFramingIsUnambiguous(t *testing.T) {
+	t.Parallel()
 	assert.NotEqual(t,
 		ingest.AttributeID("ab", "c", "string", ingest.ScopeSpan),
 		ingest.AttributeID("a", "bc", "string", ingest.ScopeSpan))
@@ -56,6 +58,7 @@ func TestHashFramingIsUnambiguous(t *testing.T) {
 // makes scope dedupe work at all (ScopeID still hashes this array; resources
 // no longer do, see the ResourceID tests below).
 func TestAttributeSetIsOrderIndependent(t *testing.T) {
+	t.Parallel()
 	one := pcommon.NewMap()
 	one.PutStr("b", "2")
 	one.PutStr("a", "1")
@@ -86,6 +89,7 @@ func TestAttributeSetIsOrderIndependent(t *testing.T) {
 // service.instance.id, must land on different resource ids -- otherwise two
 // running processes collapse into one resource.
 func TestResourceIdentityIncludesInstanceID(t *testing.T) {
+	t.Parallel()
 	a := attrMap(map[string]string{"service.name": "checkout", "service.instance.id": "i-1"})
 	b := attrMap(map[string]string{"service.name": "checkout", "service.instance.id": "i-2"})
 	assert.NotEqual(t, ingest.ResourceID(a), ingest.ResourceID(b),
@@ -95,6 +99,7 @@ func TestResourceIdentityIncludesInstanceID(t *testing.T) {
 // service.namespace scopes service.name, per the spec's own pairing, so it
 // has to participate too.
 func TestResourceIdentityIncludesNamespace(t *testing.T) {
+	t.Parallel()
 	a := attrMap(map[string]string{"service.namespace": "ns-a", "service.name": "checkout", "service.instance.id": "i-1"})
 	b := attrMap(map[string]string{"service.namespace": "ns-b", "service.name": "checkout", "service.instance.id": "i-1"})
 	assert.NotEqual(t, ingest.ResourceID(a), ingest.ResourceID(b))
@@ -105,6 +110,7 @@ func TestResourceIdentityIncludesNamespace(t *testing.T) {
 // used to fail: telemetry.sdk.* arriving mid-stream minted a new resource for
 // the same running process.
 func TestResourceIdentityIgnoresNonIdentifyingAttributes(t *testing.T) {
+	t.Parallel()
 	a := attrMap(map[string]string{"service.name": "checkout", "service.instance.id": "i-1", "region": "us-east-1"})
 	b := attrMap(map[string]string{
 		"service.name": "checkout", "service.instance.id": "i-1",
@@ -121,6 +127,7 @@ func TestResourceIdentityIgnoresNonIdentifyingAttributes(t *testing.T) {
 // hash differently under a fallback that used the rest of the attribute set
 // to compensate for the missing field.
 func TestResourceIdentityAbsentInstanceIDCollapses(t *testing.T) {
+	t.Parallel()
 	a := attrMap(map[string]string{"service.name": "checkout", "region": "us-east-1"})
 	b := attrMap(map[string]string{
 		"service.name": "checkout", "pod": "checkout-7f9c", "telemetry.sdk.name": "opentelemetry",
@@ -131,6 +138,7 @@ func TestResourceIdentityAbsentInstanceIDCollapses(t *testing.T) {
 
 // Two scopes with identical (empty) attributes are still different scopes.
 func TestScopeIdentityIncludesNameAndVersion(t *testing.T) {
+	t.Parallel()
 	var none []struct{}
 	_ = none
 	empty := pcommon.NewMap()
@@ -156,6 +164,7 @@ func newStore(t *testing.T) *store.Store {
 // duplicate anything -- that is the whole point of content-derived ids plus
 // `on conflict do nothing`.
 func TestFlushIsIdempotent(t *testing.T) {
+	t.Parallel()
 	s := newStore(t)
 	ctx := context.Background()
 
@@ -201,6 +210,7 @@ func TestFlushIsIdempotent(t *testing.T) {
 // calls out as undetectable: a later batch would trust the cache, skip the
 // insert, and leave an owner's array pointing at a row that was never there.
 func TestFailedFlushDoesNotMarkAsFlushed(t *testing.T) {
+	t.Parallel()
 	s := newStore(t)
 	ctx := context.Background()
 
@@ -226,6 +236,7 @@ func TestFailedFlushDoesNotMarkAsFlushed(t *testing.T) {
 // enforces this -- DuckDB cannot FK into a LIST -- so it is checked rather than
 // assumed.
 func TestFlushedArraysReferenceRealAttributes(t *testing.T) {
+	t.Parallel()
 	s := newStore(t)
 	ctx := context.Background()
 
@@ -257,6 +268,7 @@ func TestFlushedArraysReferenceRealAttributes(t *testing.T) {
 // independent reimplementation, so this catches a bug in the Go hashing itself
 // rather than only storage corruption.
 func TestStoredIDsMatchTheSQLMacro(t *testing.T) {
+	t.Parallel()
 	s := newStore(t)
 	ctx := context.Background()
 

--- a/desktopexporter/internal/store/logs/logs_test.go
+++ b/desktopexporter/internal/store/logs/logs_test.go
@@ -262,6 +262,7 @@ func attrMap(attrs []attrKeyValue) map[string]string {
 
 // TestLogOrdering verifies that logs are returned newest-first by effective time (timestamp or observedTimestamp).
 func TestLogOrdering(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
@@ -282,6 +283,7 @@ func TestLogOrdering(t *testing.T) {
 
 // TestEmptyLogs verifies handling of empty log lists and empty store.
 func TestEmptyLogs(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	err := s.WithConn(func(conn driver.Conn) error {
@@ -303,6 +305,7 @@ func TestEmptyLogs(t *testing.T) {
 // that decides. Asserting that they survive Clear is the new contract, not a
 // dropped assertion. See spans.TestClearTraces for the same shape.
 func TestClearLogs(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
@@ -347,6 +350,7 @@ func TestClearLogs(t *testing.T) {
 
 // TestLogSuite runs a comprehensive suite on the same three-log dataset.
 func TestLogSuite(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
@@ -516,6 +520,7 @@ func getLogAttributeDefs(t *testing.T, s *store.Store, ctx context.Context, star
 // rather than nothing. (2) has no such escape -- those keys exist only outside
 // the window.
 func TestGetLogAttributes(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
@@ -572,6 +577,7 @@ func TestGetLogAttributes(t *testing.T) {
 
 // TestDeleteLogsByIDs verifies that multiple logs can be deleted by their IDs.
 func TestDeleteLogsByIDs(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
@@ -596,6 +602,7 @@ func TestDeleteLogsByIDs(t *testing.T) {
 
 // TestDeleteLogsByIDs_Empty verifies that deleting with an empty list is a no-op.
 func TestDeleteLogsByIDs_Empty(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	err := s.WithDBWrite(func(db *sql.DB) error {
@@ -611,6 +618,7 @@ func TestDeleteLogsByIDs_Empty(t *testing.T) {
 // the interval ingests consistently. Sized from the constant: this said 250
 // against an interval that had been raised to 500.
 func TestIngestLogs_LargeBatchStaysConsistent(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
@@ -649,6 +657,7 @@ func TestIngestLogs_LargeBatchStaysConsistent(t *testing.T) {
 }
 
 func TestIngest_CanceledContext(t *testing.T) {
+	t.Parallel()
 	s, _ := storetest.New(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -661,6 +670,7 @@ func TestIngest_CanceledContext(t *testing.T) {
 }
 
 func TestIngest_CanceledDuringIngest(t *testing.T) {
+	t.Parallel()
 	s, _ := storetest.New(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -680,6 +690,7 @@ func TestIngest_CanceledDuringIngest(t *testing.T) {
 
 // TestSearchLogs tests logs.Search with various query types.
 func TestSearchLogs(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
@@ -1100,6 +1111,7 @@ func TestSearchLogs(t *testing.T) {
 // on the standard fixture which stamps service.name = test-service on
 // the resource for every record.
 func TestLogs_ServiceNameDenormStaysConsistent(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()

--- a/desktopexporter/internal/store/logs/logs_test.go
+++ b/desktopexporter/internal/store/logs/logs_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/ingest"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/logs"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/search"
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/storetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
-	"go.uber.org/zap"
 )
 
 // readStore runs a query under the store's read lock and returns its result.
@@ -34,14 +34,6 @@ func readStore[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error)
 		return err
 	})
 	return out, err
-}
-
-func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
-	t.Helper()
-	ctx := context.Background()
-	s, err := store.NewStore(ctx, "", zap.NewNop())
-	require.NoError(t, err)
-	return s, ctx, func() { s.Close() }
 }
 
 func countRows(t *testing.T, s *store.Store, ctx context.Context, query string, args ...any) int {
@@ -270,8 +262,7 @@ func attrMap(attrs []attrKeyValue) map[string]string {
 
 // TestLogOrdering verifies that logs are returned newest-first by effective time (timestamp or observedTimestamp).
 func TestLogOrdering(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
 	ldata := createTestLogsPdata(baseTime)
@@ -291,8 +282,7 @@ func TestLogOrdering(t *testing.T) {
 
 // TestEmptyLogs verifies handling of empty log lists and empty store.
 func TestEmptyLogs(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	err := s.WithConn(func(conn driver.Conn) error {
 		return logs.Ingest(ctx, conn, plog.NewLogs(), s.FlushedIDs())
@@ -313,8 +303,7 @@ func TestEmptyLogs(t *testing.T) {
 // that decides. Asserting that they survive Clear is the new contract, not a
 // dropped assertion. See spans.TestClearTraces for the same shape.
 func TestClearLogs(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
 	ldata := createTestLogsPdata(baseTime)
@@ -358,8 +347,7 @@ func TestClearLogs(t *testing.T) {
 
 // TestLogSuite runs a comprehensive suite on the same three-log dataset.
 func TestLogSuite(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
 	ldata := createTestLogsPdata(baseTime)
@@ -528,8 +516,7 @@ func getLogAttributeDefs(t *testing.T, s *store.Store, ctx context.Context, star
 // rather than nothing. (2) has no such escape -- those keys exist only outside
 // the window.
 func TestGetLogAttributes(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
 	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
@@ -585,8 +572,7 @@ func TestGetLogAttributes(t *testing.T) {
 
 // TestDeleteLogsByIDs verifies that multiple logs can be deleted by their IDs.
 func TestDeleteLogsByIDs(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
 	ldata := createTestLogsPdata(baseTime)
@@ -610,8 +596,7 @@ func TestDeleteLogsByIDs(t *testing.T) {
 
 // TestDeleteLogsByIDs_Empty verifies that deleting with an empty list is a no-op.
 func TestDeleteLogsByIDs_Empty(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	err := s.WithDBWrite(func(db *sql.DB) error {
 		return logs.DeleteLogsByIDs(ctx, db, []any{})
@@ -626,8 +611,7 @@ func TestDeleteLogsByIDs_Empty(t *testing.T) {
 // the interval ingests consistently. Sized from the constant: this said 250
 // against an interval that had been raised to 500.
 func TestIngestLogs_LargeBatchStaysConsistent(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
 	const batchSize = logs.FlushInterval + 1
@@ -665,8 +649,7 @@ func TestIngestLogs_LargeBatchStaysConsistent(t *testing.T) {
 }
 
 func TestIngest_CanceledContext(t *testing.T) {
-	s, _, teardown := setupStore(t)
-	defer teardown()
+	s, _ := storetest.New(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -678,8 +661,7 @@ func TestIngest_CanceledContext(t *testing.T) {
 }
 
 func TestIngest_CanceledDuringIngest(t *testing.T) {
-	s, _, teardown := setupStore(t)
-	defer teardown()
+	s, _ := storetest.New(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	ldata := createTestLogsPdataN(time.Now().UnixNano(), 100)
@@ -698,8 +680,7 @@ func TestIngest_CanceledDuringIngest(t *testing.T) {
 
 // TestSearchLogs tests logs.Search with various query types.
 func TestSearchLogs(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
 	ldata := createTestLogsPdata(baseTime)
@@ -1119,8 +1100,7 @@ func TestSearchLogs(t *testing.T) {
 // on the standard fixture which stamps service.name = test-service on
 // the resource for every record.
 func TestLogs_ServiceNameDenormStaysConsistent(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
 	err := s.WithConn(func(conn driver.Conn) error {

--- a/desktopexporter/internal/store/metrics/metrics_test.go
+++ b/desktopexporter/internal/store/metrics/metrics_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/ingest"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/metrics"
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/storetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.uber.org/zap"
 )
 
 const maxNano = 1<<63 - 1
@@ -49,14 +49,6 @@ func readStore[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error)
 		return err
 	})
 	return out, err
-}
-
-func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
-	t.Helper()
-	ctx := context.Background()
-	s, err := store.NewStore(ctx, "", zap.NewNop())
-	require.NoError(t, err)
-	return s, ctx, func() { s.Close() }
 }
 
 func countRows(t *testing.T, s *store.Store, ctx context.Context, query string, args ...any) int {
@@ -274,8 +266,7 @@ func getMetricFullByName(t *testing.T, s *store.Store, ctx context.Context, name
 
 // TestMetricSuite runs tests on ingested metrics using SearchMetrics (DB-generated JSON).
 func TestMetricSuite(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	err := s.WithConn(func(conn driver.Conn) error {
 		return metrics.Ingest(ctx, conn, createTestMetricsPdata(), s.FlushedIDs())
@@ -724,8 +715,7 @@ func deleteByIdentity(t *testing.T, ctx context.Context, s *store.Store, name, u
 // is gone and (b) nothing else was touched.
 func TestDeleteMetricStream(t *testing.T) {
 	t.Run("removes a single Gauge by name+unit+scope+service", func(t *testing.T) {
-		s, ctx, teardown := setupStore(t)
-		defer teardown()
+		s, ctx := storetest.New(t)
 
 		err := s.WithConn(func(conn driver.Conn) error {
 			return metrics.Ingest(ctx, conn, createTestMetricsPdata(), s.FlushedIDs())
@@ -754,8 +744,7 @@ func TestDeleteMetricStream(t *testing.T) {
 	})
 
 	t.Run("collapses multiple ingestions of the same logical metric", func(t *testing.T) {
-		s, ctx, teardown := setupStore(t)
-		defer teardown()
+		s, ctx := storetest.New(t)
 
 		// Three independent batches => three metric_ingests rows for the
 		// same logical Gauge, all sharing one metric_streams row.
@@ -791,8 +780,7 @@ func TestDeleteMetricStream(t *testing.T) {
 	})
 
 	t.Run("unit discriminates same-name metrics", func(t *testing.T) {
-		s, ctx, teardown := setupStore(t)
-		defer teardown()
+		s, ctx := storetest.New(t)
 
 		md := pmetric.NewMetrics()
 		rm := md.ResourceMetrics().AppendEmpty()
@@ -829,8 +817,7 @@ func TestDeleteMetricStream(t *testing.T) {
 	})
 
 	t.Run("service.name discriminates same-name metrics from different services", func(t *testing.T) {
-		s, ctx, teardown := setupStore(t)
-		defer teardown()
+		s, ctx := storetest.New(t)
 
 		md := pmetric.NewMetrics()
 		for _, svc := range []string{"svc-a", "svc-b"} {
@@ -866,8 +853,7 @@ func TestDeleteMetricStream(t *testing.T) {
 	})
 
 	t.Run("is_monotonic discriminates Sum metrics", func(t *testing.T) {
-		s, ctx, teardown := setupStore(t)
-		defer teardown()
+		s, ctx := storetest.New(t)
 
 		md := pmetric.NewMetrics()
 		rm := md.ResourceMetrics().AppendEmpty()
@@ -907,8 +893,7 @@ func TestDeleteMetricStream(t *testing.T) {
 	})
 
 	t.Run("no-match identity is a no-op", func(t *testing.T) {
-		s, ctx, teardown := setupStore(t)
-		defer teardown()
+		s, ctx := storetest.New(t)
 
 		err := s.WithConn(func(conn driver.Conn) error {
 			return metrics.Ingest(ctx, conn, createTestMetricsPdata(), s.FlushedIDs())
@@ -925,8 +910,7 @@ func TestDeleteMetricStream(t *testing.T) {
 	})
 
 	t.Run("cascade removes attributes, exemplars, datapoints", func(t *testing.T) {
-		s, ctx, teardown := setupStore(t)
-		defer teardown()
+		s, ctx := storetest.New(t)
 
 		err := s.WithConn(func(conn driver.Conn) error {
 			return metrics.Ingest(ctx, conn, createTestMetricsPdata(), s.FlushedIDs())
@@ -1021,8 +1005,7 @@ func TestDeleteMetricStream(t *testing.T) {
 // This test is the find-or-insert mirror of the cascade-delete test:
 // together they pin down the two halves of "identity is canonical."
 func TestMetricStreams_FindOrInsertIdempotent(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	const batches = 5
 	for i := 0; i < batches; i++ {
@@ -1107,8 +1090,7 @@ func TestMetricStreams_DistinctIdentitiesStayDistinct(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			s, ctx, teardown := setupStore(t)
-			defer teardown()
+			s, ctx := storetest.New(t)
 
 			err := s.WithConn(func(conn driver.Conn) error {
 				return metrics.Ingest(ctx, conn, mk(t, func(pmetric.Metric, pcommon.InstrumentationScope, pcommon.Resource) {}), s.FlushedIDs())
@@ -1136,8 +1118,7 @@ func TestMetricStreams_DistinctIdentitiesStayDistinct(t *testing.T) {
 // inconsistent service names for the same identity), this test will
 // catch it.
 func TestMetricStreams_ServiceNameDenormStaysConsistent(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	err := s.WithConn(func(conn driver.Conn) error {
 		return metrics.Ingest(ctx, conn, createTestMetricsPdata(), s.FlushedIDs())
@@ -1162,8 +1143,7 @@ func TestMetricStreams_ServiceNameDenormStaysConsistent(t *testing.T) {
 
 // TestEmptyMetrics verifies empty metric list and empty store.
 func TestEmptyMetrics(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	err := s.WithConn(func(conn driver.Conn) error {
 		return metrics.Ingest(ctx, conn, pmetric.NewMetrics(), s.FlushedIDs())
@@ -1176,8 +1156,7 @@ func TestEmptyMetrics(t *testing.T) {
 
 // TestClearMetrics verifies that all metrics can be cleared, including child rows.
 func TestClearMetrics(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	err := s.WithConn(func(conn driver.Conn) error {
 		return metrics.Ingest(ctx, conn, createTestMetricsPdata(), s.FlushedIDs())
@@ -1215,8 +1194,7 @@ func TestClearMetrics(t *testing.T) {
 }
 
 func TestExpHistogramZeroThresholdRoundTrip(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	ts := time.Unix(1700000000, 0)
 	md := pmetric.NewMetrics()
@@ -1448,8 +1426,7 @@ func findMetricID(t *testing.T, s *store.Store, ctx context.Context, name string
 // which is unobservable by design. Sized from the constant so it cannot stop
 // being a large batch when the constant moves.
 func TestIngestMetrics_LargeBatchStaysConsistent(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	const batchSize = metrics.FlushInterval + 1
 	err := s.WithConn(func(conn driver.Conn) error {
@@ -1491,8 +1468,7 @@ func TestIngestMetrics_LargeBatchStaysConsistent(t *testing.T) {
 }
 
 func TestIngest_CanceledContext(t *testing.T) {
-	s, _, teardown := setupStore(t)
-	defer teardown()
+	s, _ := storetest.New(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -1504,8 +1480,7 @@ func TestIngest_CanceledContext(t *testing.T) {
 }
 
 func TestIngest_CanceledDuringIngest(t *testing.T) {
-	s, _, teardown := setupStore(t)
-	defer teardown()
+	s, _ := storetest.New(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -1525,8 +1500,7 @@ func TestIngest_CanceledDuringIngest(t *testing.T) {
 // by drawer cards: stream id, series count, scalar last value, last seen.
 func TestSearchSummaries_CardFields(t *testing.T) {
 	t.Run("Gauge", func(t *testing.T) {
-		s, ctx, teardown := setupStore(t)
-		defer teardown()
+		s, ctx := storetest.New(t)
 
 		ts := time.Unix(1700000000, 0)
 		md := pmetric.NewMetrics()
@@ -1560,8 +1534,7 @@ func TestSearchSummaries_CardFields(t *testing.T) {
 	})
 
 	t.Run("HistogramOmitsLastValue", func(t *testing.T) {
-		s, ctx, teardown := setupStore(t)
-		defer teardown()
+		s, ctx := storetest.New(t)
 
 		bounds := []float64{1.0, 2.0}
 		ts := time.Unix(1700000000, 0)
@@ -1590,8 +1563,7 @@ func TestSearchSummaries_CardFields(t *testing.T) {
 // first makes it one array-overlap scan (39.2ms -> 7.7ms on the reference
 // capture), so the coverage gap is now just a gap.
 func TestMetricSearch_DatapointAndExemplarLabels(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
 		return metrics.Ingest(ctx, conn, createTestMetricsPdata(), s.FlushedIDs())
@@ -1770,8 +1742,7 @@ func buildTwoReplicaMetrics(t *testing.T) pmetric.Metrics {
 // rows and two series. Collapsing replicas that actually identified
 // themselves would be a worse bug than the one this whole change fixes.
 func TestMetricSeries_SplitByResource(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
 		return metrics.Ingest(ctx, conn, buildTwoReplicaMetrics(t), s.FlushedIDs())
@@ -1834,8 +1805,7 @@ func TestMetricSeries_SplitByResource(t *testing.T) {
 // fallback is gone. Absent means absent: the telemetry never claimed these
 // were different instances, so we do not either.
 func TestMetricSeries_ResourceOnlyDiffersByHostNameCollapses(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	md := pmetric.NewMetrics()
 	base := time.Now().UnixNano()
@@ -1889,8 +1859,7 @@ func TestMetricSeries_ResourceOnlyDiffersByHostNameCollapses(t *testing.T) {
 // content-derived id from (stream, resource, labels) is the same every time the
 // same series arrives.
 func TestMetricSeries_IDsAreStableAcrossReingest(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	seriesIDs := func() []string {
 		var out []string
@@ -1998,8 +1967,7 @@ func buildInstanceMetrics(t *testing.T, extra map[string]string, base int64) pme
 // test asserted two as the "correct" half of the split, back when a resource
 // id still carried the attribute set as identity. It no longer does.
 func TestMetricSeries_SurvivesResourceEnrichment(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Now().UnixNano()
 	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
@@ -2071,8 +2039,7 @@ func TestMetricSeries_SurvivesResourceEnrichment(t *testing.T) {
 //	folded           = buckets 0 and 1 = 5 + 7 = 12
 //	result           = [3] at offset 2, zeroCount 1 + 2 + 12 = 15
 func TestExpHistogramMerge_FoldsBucketsBelowMergedZeroThreshold(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Now().Add(-time.Minute)
 	fixture := makeExpHistogramFixtureT("http.duration", pmetric.AggregationTemporalityDelta, []expHistTestDP{
@@ -2140,8 +2107,7 @@ func TestExpHistogramMerge_FoldsBucketsBelowMergedZeroThreshold(t *testing.T) {
 // The bug needed a reduction to appear at all, which is why no existing test
 // saw it: they either request no reduction or never look at the labels.
 func TestGetMetric_MergedSeriesKeepTheirLabels(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 	// Two series, told apart only by their labels, each with two datapoints
@@ -2210,8 +2176,7 @@ func TestGetMetric_MergedSeriesKeepTheirLabels(t *testing.T) {
 // skip it -- the mean of nothing is not nought. Emitting 0 would bake one
 // view's reading into all three.
 func TestGetMetric_ScalarViewBuckets(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 	// A counter climbing by one a minute, with a five-minute silence in the
@@ -2335,8 +2300,7 @@ func TestGetMetric_ScalarViewBuckets(t *testing.T) {
 // with samples but no rate draws nothing -- and derives both from it, so the
 // overlay, the badges and the line cannot disagree.
 func TestGetMetric_RateSlopeAndStats(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 	// A counter climbing a minute at a time with a five-minute silence: the
@@ -2458,8 +2422,7 @@ func TestGetMetric_RateSlopeAndStats(t *testing.T) {
 // each datapoint against its predecessor in the series, then buckets); this
 // pins the histogram merge to the same rule.
 func TestCumulativeHistogramMerge_DifferencesAcrossBuckets(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 	bounds := []float64{10, 20, 30}
@@ -2556,8 +2519,7 @@ func TestCumulativeHistogramMerge_DifferencesAcrossBuckets(t *testing.T) {
 // than its own buckets held. Nothing downstream can reconcile that, because the
 // count badge and the quantiles read different fields of the same row.
 func TestCumulativeHistogramMerge_ResetIsConsistentAcrossFields(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 	bounds := []float64{10, 20, 30}
@@ -2622,8 +2584,7 @@ func TestCumulativeHistogramMerge_ResetIsConsistentAcrossFields(t *testing.T) {
 // Absolute boundaries are right for a chart and wrong for a summary, which is
 // why one bucket is a different request rather than a smaller number of them.
 func TestGetMetric_WindowSummaryIsOneBucket(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	// 10:20 to 12:00 -- a 100 minute span, which the ladder serves with the
 	// 1 hour rung, so absolute flooring splits it across 10:00, 11:00 and 12:00.
@@ -2693,8 +2654,7 @@ func TestGetMetric_WindowSummaryIsOneBucket(t *testing.T) {
 // another. Measured on a 21-series histogram: three checked series arrived with
 // no datapoints, and three that were shipped theirs were never drawn.
 func TestGetMetric_DatapointLimitMatchesResponseOrder(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 	bounds := []float64{10, 20, 30}
@@ -2766,8 +2726,7 @@ func TestGetMetric_DatapointLimitMatchesResponseOrder(t *testing.T) {
 // exporter that changed its histogram configuration mid-window, which is a real
 // finding for anyone debugging one, looked like an idle period.
 func TestGetMetric_BoundsMismatchIsReported(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 	attrs := map[string]string{"pod": "a"}
@@ -2851,8 +2810,7 @@ func TestGetMetric_BoundsMismatchIsReported(t *testing.T) {
 // ladder rung: a reader can name a 1-minute boundary and cannot name a
 // 30.5-second one.
 func TestGetMetric_ViewGridRespectsCadence(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 	// Once a minute for twenty minutes, with no gaps: every bucket the grid
@@ -2956,8 +2914,7 @@ func TestGetMetric_ViewGridRespectsCadence(t *testing.T) {
 // visibly full of data -- reading as series that had stopped reporting rather
 // than ones this response did not carry.
 func TestGetMetric_CountsDescribeTheWindow(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 	var dps []sumTestDP
@@ -3076,8 +3033,7 @@ func TestGetMetric_CountsDescribeTheWindow(t *testing.T) {
 // returned six different responses in six tries, differing in which datapoints
 // the M4 election kept.
 func TestGetMetric_Deterministic(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 	var dps []sumTestDP
@@ -3199,8 +3155,7 @@ func TestGetMetric_Deterministic(t *testing.T) {
 // aggregate folds them. Narrowing that reached the aggregates would turn "all"
 // into "all of the checked ones", which is wrong and looks plausible.
 func TestGetMetric_DatapointNarrowing(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 	var dps []sumTestDP
@@ -3316,8 +3271,7 @@ func TestGetMetric_DatapointNarrowing(t *testing.T) {
 // average is pooled over every sample rather than averaged over per-series
 // averages.
 func TestGetMetric_ScalarPoolAggregate(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 	// Deliberately lopsided: "dense" reports ten times a minute at value 1,
@@ -3454,8 +3408,7 @@ func TestGetMetric_ScalarPoolAggregate(t *testing.T) {
 // because a sparkline's whole job is to show that something happened, and a
 // mean over a wide bucket is exactly what hides a spike.
 func TestGetMetric_Sparkline(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 	// Two hundred minutes of a quiet delta counter with a single one-minute
@@ -3560,8 +3513,7 @@ func TestGetMetric_Sparkline(t *testing.T) {
 // That implementation is gone -- the store does the merging now -- and this
 // test exists so the behaviour did not leave with it.
 func TestExpHistogramMerge_RescalesBeforeSumming(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 	fixture := makeExpHistogramFixtureT("rescale.duration", pmetric.AggregationTemporalityDelta, []expHistTestDP{
@@ -3640,8 +3592,7 @@ func TestExpHistogramMerge_RescalesBeforeSumming(t *testing.T) {
 //
 // Also ported from the deleted TypeScript merge.
 func TestExpHistogramMerge_CumulativeSubtractsAcrossAScaleChange(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 	fixture := makeExpHistogramFixtureT("cumulative.duration", pmetric.AggregationTemporalityCumulative, []expHistTestDP{
@@ -3702,8 +3653,7 @@ func TestExpHistogramMerge_CumulativeSubtractsAcrossAScaleChange(t *testing.T) {
 //
 // Empty means all, which is what every caller predating the parameter sends.
 func TestGetMetric_SeriesFilter(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Now().Add(-time.Minute)
 	var dps []expHistTestDP
@@ -3770,8 +3720,7 @@ func TestGetMetric_SeriesFilter(t *testing.T) {
 //
 // Empty means none, so a caller drawing no overlays does not pay for them.
 func TestGetMetric_Quantiles(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Now().Add(-time.Minute)
 	fixture := makeExpHistogramFixtureT("q.duration", pmetric.AggregationTemporalityDelta, []expHistTestDP{{
@@ -3833,8 +3782,7 @@ func TestGetMetric_Quantiles(t *testing.T) {
 //
 // Totals: A has 60 observations, B has 10, so the aggregate must report 70.
 func TestGetMetric_CrossSeriesAggregate(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Now().Add(-time.Minute)
 	fixture := makeExpHistogramFixtureT("agg.duration", pmetric.AggregationTemporalityDelta, []expHistTestDP{
@@ -3912,8 +3860,7 @@ func TestGetMetric_CrossSeriesAggregate(t *testing.T) {
 // and it is why this test reaches back before 1970 rather than only checking a
 // present-day offset.
 func TestGetMetric_TimezoneAlignedBuckets(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	// Two datapoints either side of midnight UTC. Under a -5h offset they fall
 	// on the same local day; under UTC they straddle two.
@@ -3985,8 +3932,7 @@ func TestGetMetric_TimezoneAlignedBuckets(t *testing.T) {
 // window must keep dividing itself, so its buckets stay anchored where the
 // caller put them.
 func TestGetMetric_FitToDataSpansTheData(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	// Ten minutes of datapoints a minute apart, inside a window that spans
 	// decades. That ratio is the whole point: at 8 target buckets the requested
@@ -4079,8 +4025,7 @@ func TestGetMetric_FitToDataSpansTheData(t *testing.T) {
 // lands on exactly 10s: 60s / 6 admits 10s and refuses 5s. Pinning the width is
 // what lets the assertion be "on the grid" rather than "self-consistent".
 func TestGetMetric_MergedRowsCarryTheirBucket(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	// 13:00:00 UTC is a whole minute, so it is already on the 10s grid and the
 	// expected bucket starts are base, base+10s, base+20s exactly.
@@ -4180,8 +4125,7 @@ func TestGetMetric_MergedRowsCarryTheirBucket(t *testing.T) {
 // arguments -- it runs the same query and keeps one field, and this is what
 // stops those two drifting.
 func TestGetMetricAggregate(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Now().Add(-time.Minute)
 	var dps []expHistTestDP
@@ -4333,8 +4277,7 @@ func mapKeys(m map[string]any) []string {
 // to the whole window puts the two readings below on different local days, so a
 // day bucket splits a day that did not end.
 func TestGetMetric_BucketsFollowTheZoneAcrossDST(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	// Both readings fall on local Sunday 25 October 2026 in London: the first
 	// half an hour into it while BST is still in force, the second half an hour
@@ -4420,8 +4363,7 @@ func TestGetMetric_BucketsFollowTheZoneAcrossDST(t *testing.T) {
 // directly visible here and nowhere else. A mutant reverting the election's
 // zone conversion survives the scalar test; this one is built to kill it.
 func TestGetMetric_HistogramMergeFollowsTheZoneAcrossDST(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	// The same three moments as the scalar test: two on London's 25-hour local
 	// Sunday -- one while BST holds, one after the clocks went back -- and one
@@ -4497,8 +4439,7 @@ func TestGetMetric_HistogramMergeFollowsTheZoneAcrossDST(t *testing.T) {
 // settings rather than anything this query controls. A stream sampling every
 // datapoint defeated the reduction outright: every row came back.
 func TestGetMetric_ExemplarsAreCappedPerBucket(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
 	// One bucket's worth of readings, every one of them carrying an exemplar.
@@ -4565,8 +4506,7 @@ func TestGetMetric_ExemplarsAreCappedPerBucket(t *testing.T) {
 // not limit. The list is capped and the true count travels beside it, so a
 // client can say "5 of 60" rather than silently showing five.
 func TestGetMetric_ExemplarListIsCappedAndCounted(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
 	const perDatapoint = 60
@@ -4624,8 +4564,7 @@ func TestGetMetric_ExemplarListIsCappedAndCounted(t *testing.T) {
 // returned nothing, and time order hands them whichever happened first. Both
 // caps now rank from either extreme, so what survives spans the range.
 func TestGetMetric_ExemplarSelectionKeepsBothExtremes(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
 	md := pmetric.NewMetrics()
@@ -4693,8 +4632,7 @@ func TestGetMetric_ExemplarSelectionKeepsBothExtremes(t *testing.T) {
 // which two does it keep? The ones whose exemplars reach lowest and highest,
 // not the two that happened first.
 func TestGetMetric_ExemplarCarriersAreTheExtremeOnes(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
 	md := pmetric.NewMetrics()
@@ -4792,8 +4730,7 @@ func TestGetMetric_ExemplarCarriersAreTheExtremeOnes(t *testing.T) {
 // start of each column, slow ones after, which is the shape of a latency spike
 // and the reason someone clicks a heatmap in the first place.
 func TestGetMetric_ColumnWindowMergesTheWholeColumn(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
 	// Enough readings that the heatmap's target is what sets its width. Fewer and
@@ -4934,8 +4871,7 @@ func TestGetMetric_ColumnWindowMergesTheWholeColumn(t *testing.T) {
 // change mid-flight gets a second row, not a collision, because OTel only
 // makes fixed bounds a practice, never a promise.
 func TestHistogramBoundsAreStoredOnce(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
 	boundsA := []float64{1, 5, 10}
@@ -5024,8 +4960,7 @@ func TestHistogramBoundsAreStoredOnce(t *testing.T) {
 // ever "optimised" into a count over metric_series, which agrees on an
 // unbounded window and diverges exactly where it matters.
 func TestSeriesCountsAreWindowAndLifetime(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
 	// Twelve series on the stream; only three of them report in the first
@@ -5084,8 +5019,7 @@ func TestSeriesCountsAreWindowAndLifetime(t *testing.T) {
 // Every existing histogram fixture supplies at least one bound, which is why
 // the whole suite passed while the crash was reachable from any real demo.
 func TestIngest_SingleBucketHistogram(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 	fixture := makeHistogramFixtureT("single.bucket", pmetric.AggregationTemporalityDelta, []histTestDP{{
@@ -5143,8 +5077,7 @@ func TestIngest_NilArraysReachingTheAppender(t *testing.T) {
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 
 	t.Run("histogram with no buckets", func(t *testing.T) {
-		s, ctx, teardown := setupStore(t)
-		defer teardown()
+		s, ctx := storetest.New(t)
 
 		md := pmetric.NewMetrics()
 		rm := md.ResourceMetrics().AppendEmpty()
@@ -5164,8 +5097,7 @@ func TestIngest_NilArraysReachingTheAppender(t *testing.T) {
 	})
 
 	t.Run("exponential histogram with no negative buckets", func(t *testing.T) {
-		s, ctx, teardown := setupStore(t)
-		defer teardown()
+		s, ctx := storetest.New(t)
 
 		md := pmetric.NewMetrics()
 		rm := md.ResourceMetrics().AppendEmpty()
@@ -5202,8 +5134,7 @@ func TestIngest_NilArraysReachingTheAppender(t *testing.T) {
 // allowlist is the only thing keeping it out and a later edit could widen it
 // without anyone noticing.
 func TestMetricMetadataRoundTrip(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	md := pmetric.NewMetrics()
 	rm := md.ResourceMetrics().AppendEmpty()

--- a/desktopexporter/internal/store/metrics/metrics_test.go
+++ b/desktopexporter/internal/store/metrics/metrics_test.go
@@ -266,6 +266,7 @@ func getMetricFullByName(t *testing.T, s *store.Store, ctx context.Context, name
 
 // TestMetricSuite runs tests on ingested metrics using SearchMetrics (DB-generated JSON).
 func TestMetricSuite(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	err := s.WithConn(func(conn driver.Conn) error {
@@ -714,6 +715,7 @@ func deleteByIdentity(t *testing.T, ctx context.Context, s *store.Store, name, u
 // DeleteMetricStream, and checks that (a) every row backing that stream
 // is gone and (b) nothing else was touched.
 func TestDeleteMetricStream(t *testing.T) {
+	t.Parallel()
 	t.Run("removes a single Gauge by name+unit+scope+service", func(t *testing.T) {
 		s, ctx := storetest.New(t)
 
@@ -1005,6 +1007,7 @@ func TestDeleteMetricStream(t *testing.T) {
 // This test is the find-or-insert mirror of the cascade-delete test:
 // together they pin down the two halves of "identity is canonical."
 func TestMetricStreams_FindOrInsertIdempotent(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	const batches = 5
@@ -1050,6 +1053,7 @@ func TestMetricStreams_FindOrInsertIdempotent(t *testing.T) {
 // assert each change yields a fresh stream so a future "be permissive"
 // regression won't silently merge two semantically distinct streams.
 func TestMetricStreams_DistinctIdentitiesStayDistinct(t *testing.T) {
+	t.Parallel()
 	mk := func(t *testing.T, mutate func(m pmetric.Metric, scope pcommon.InstrumentationScope, res pcommon.Resource)) pmetric.Metrics {
 		t.Helper()
 		md := pmetric.NewMetrics()
@@ -1118,6 +1122,7 @@ func TestMetricStreams_DistinctIdentitiesStayDistinct(t *testing.T) {
 // inconsistent service names for the same identity), this test will
 // catch it.
 func TestMetricStreams_ServiceNameDenormStaysConsistent(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	err := s.WithConn(func(conn driver.Conn) error {
@@ -1143,6 +1148,7 @@ func TestMetricStreams_ServiceNameDenormStaysConsistent(t *testing.T) {
 
 // TestEmptyMetrics verifies empty metric list and empty store.
 func TestEmptyMetrics(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	err := s.WithConn(func(conn driver.Conn) error {
@@ -1156,6 +1162,7 @@ func TestEmptyMetrics(t *testing.T) {
 
 // TestClearMetrics verifies that all metrics can be cleared, including child rows.
 func TestClearMetrics(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	err := s.WithConn(func(conn driver.Conn) error {
@@ -1194,6 +1201,7 @@ func TestClearMetrics(t *testing.T) {
 }
 
 func TestExpHistogramZeroThresholdRoundTrip(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	ts := time.Unix(1700000000, 0)
@@ -1426,6 +1434,7 @@ func findMetricID(t *testing.T, s *store.Store, ctx context.Context, name string
 // which is unobservable by design. Sized from the constant so it cannot stop
 // being a large batch when the constant moves.
 func TestIngestMetrics_LargeBatchStaysConsistent(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	const batchSize = metrics.FlushInterval + 1
@@ -1468,6 +1477,7 @@ func TestIngestMetrics_LargeBatchStaysConsistent(t *testing.T) {
 }
 
 func TestIngest_CanceledContext(t *testing.T) {
+	t.Parallel()
 	s, _ := storetest.New(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1480,6 +1490,7 @@ func TestIngest_CanceledContext(t *testing.T) {
 }
 
 func TestIngest_CanceledDuringIngest(t *testing.T) {
+	t.Parallel()
 	s, _ := storetest.New(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1499,6 +1510,7 @@ func TestIngest_CanceledDuringIngest(t *testing.T) {
 // TestSearchSummaries_CardFields verifies the slim summary projection used
 // by drawer cards: stream id, series count, scalar last value, last seen.
 func TestSearchSummaries_CardFields(t *testing.T) {
+	t.Parallel()
 	t.Run("Gauge", func(t *testing.T) {
 		s, ctx := storetest.New(t)
 
@@ -1563,6 +1575,7 @@ func TestSearchSummaries_CardFields(t *testing.T) {
 // first makes it one array-overlap scan (39.2ms -> 7.7ms on the reference
 // capture), so the coverage gap is now just a gap.
 func TestMetricSearch_DatapointAndExemplarLabels(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
@@ -1742,6 +1755,7 @@ func buildTwoReplicaMetrics(t *testing.T) pmetric.Metrics {
 // rows and two series. Collapsing replicas that actually identified
 // themselves would be a worse bug than the one this whole change fixes.
 func TestMetricSeries_SplitByResource(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
@@ -1805,6 +1819,7 @@ func TestMetricSeries_SplitByResource(t *testing.T) {
 // fallback is gone. Absent means absent: the telemetry never claimed these
 // were different instances, so we do not either.
 func TestMetricSeries_ResourceOnlyDiffersByHostNameCollapses(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	md := pmetric.NewMetrics()
@@ -1859,6 +1874,7 @@ func TestMetricSeries_ResourceOnlyDiffersByHostNameCollapses(t *testing.T) {
 // content-derived id from (stream, resource, labels) is the same every time the
 // same series arrives.
 func TestMetricSeries_IDsAreStableAcrossReingest(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	seriesIDs := func() []string {
@@ -1967,6 +1983,7 @@ func buildInstanceMetrics(t *testing.T, extra map[string]string, base int64) pme
 // test asserted two as the "correct" half of the split, back when a resource
 // id still carried the attribute set as identity. It no longer does.
 func TestMetricSeries_SurvivesResourceEnrichment(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Now().UnixNano()
@@ -2039,6 +2056,7 @@ func TestMetricSeries_SurvivesResourceEnrichment(t *testing.T) {
 //	folded           = buckets 0 and 1 = 5 + 7 = 12
 //	result           = [3] at offset 2, zeroCount 1 + 2 + 12 = 15
 func TestExpHistogramMerge_FoldsBucketsBelowMergedZeroThreshold(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Now().Add(-time.Minute)
@@ -2107,6 +2125,7 @@ func TestExpHistogramMerge_FoldsBucketsBelowMergedZeroThreshold(t *testing.T) {
 // The bug needed a reduction to appear at all, which is why no existing test
 // saw it: they either request no reduction or never look at the labels.
 func TestGetMetric_MergedSeriesKeepTheirLabels(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
@@ -2176,6 +2195,7 @@ func TestGetMetric_MergedSeriesKeepTheirLabels(t *testing.T) {
 // skip it -- the mean of nothing is not nought. Emitting 0 would bake one
 // view's reading into all three.
 func TestGetMetric_ScalarViewBuckets(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
@@ -2300,6 +2320,7 @@ func TestGetMetric_ScalarViewBuckets(t *testing.T) {
 // with samples but no rate draws nothing -- and derives both from it, so the
 // overlay, the badges and the line cannot disagree.
 func TestGetMetric_RateSlopeAndStats(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
@@ -2422,6 +2443,7 @@ func TestGetMetric_RateSlopeAndStats(t *testing.T) {
 // each datapoint against its predecessor in the series, then buckets); this
 // pins the histogram merge to the same rule.
 func TestCumulativeHistogramMerge_DifferencesAcrossBuckets(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
@@ -2519,6 +2541,7 @@ func TestCumulativeHistogramMerge_DifferencesAcrossBuckets(t *testing.T) {
 // than its own buckets held. Nothing downstream can reconcile that, because the
 // count badge and the quantiles read different fields of the same row.
 func TestCumulativeHistogramMerge_ResetIsConsistentAcrossFields(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
@@ -2584,6 +2607,7 @@ func TestCumulativeHistogramMerge_ResetIsConsistentAcrossFields(t *testing.T) {
 // Absolute boundaries are right for a chart and wrong for a summary, which is
 // why one bucket is a different request rather than a smaller number of them.
 func TestGetMetric_WindowSummaryIsOneBucket(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	// 10:20 to 12:00 -- a 100 minute span, which the ladder serves with the
@@ -2654,6 +2678,7 @@ func TestGetMetric_WindowSummaryIsOneBucket(t *testing.T) {
 // another. Measured on a 21-series histogram: three checked series arrived with
 // no datapoints, and three that were shipped theirs were never drawn.
 func TestGetMetric_DatapointLimitMatchesResponseOrder(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
@@ -2726,6 +2751,7 @@ func TestGetMetric_DatapointLimitMatchesResponseOrder(t *testing.T) {
 // exporter that changed its histogram configuration mid-window, which is a real
 // finding for anyone debugging one, looked like an idle period.
 func TestGetMetric_BoundsMismatchIsReported(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
@@ -2810,6 +2836,7 @@ func TestGetMetric_BoundsMismatchIsReported(t *testing.T) {
 // ladder rung: a reader can name a 1-minute boundary and cannot name a
 // 30.5-second one.
 func TestGetMetric_ViewGridRespectsCadence(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
@@ -2914,6 +2941,7 @@ func TestGetMetric_ViewGridRespectsCadence(t *testing.T) {
 // visibly full of data -- reading as series that had stopped reporting rather
 // than ones this response did not carry.
 func TestGetMetric_CountsDescribeTheWindow(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
@@ -3033,6 +3061,7 @@ func TestGetMetric_CountsDescribeTheWindow(t *testing.T) {
 // returned six different responses in six tries, differing in which datapoints
 // the M4 election kept.
 func TestGetMetric_Deterministic(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
@@ -3155,6 +3184,7 @@ func TestGetMetric_Deterministic(t *testing.T) {
 // aggregate folds them. Narrowing that reached the aggregates would turn "all"
 // into "all of the checked ones", which is wrong and looks plausible.
 func TestGetMetric_DatapointNarrowing(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
@@ -3271,6 +3301,7 @@ func TestGetMetric_DatapointNarrowing(t *testing.T) {
 // average is pooled over every sample rather than averaged over per-series
 // averages.
 func TestGetMetric_ScalarPoolAggregate(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
@@ -3408,6 +3439,7 @@ func TestGetMetric_ScalarPoolAggregate(t *testing.T) {
 // because a sparkline's whole job is to show that something happened, and a
 // mean over a wide bucket is exactly what hides a spike.
 func TestGetMetric_Sparkline(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
@@ -3513,6 +3545,7 @@ func TestGetMetric_Sparkline(t *testing.T) {
 // That implementation is gone -- the store does the merging now -- and this
 // test exists so the behaviour did not leave with it.
 func TestExpHistogramMerge_RescalesBeforeSumming(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
@@ -3592,6 +3625,7 @@ func TestExpHistogramMerge_RescalesBeforeSumming(t *testing.T) {
 //
 // Also ported from the deleted TypeScript merge.
 func TestExpHistogramMerge_CumulativeSubtractsAcrossAScaleChange(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
@@ -3653,6 +3687,7 @@ func TestExpHistogramMerge_CumulativeSubtractsAcrossAScaleChange(t *testing.T) {
 //
 // Empty means all, which is what every caller predating the parameter sends.
 func TestGetMetric_SeriesFilter(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Now().Add(-time.Minute)
@@ -3720,6 +3755,7 @@ func TestGetMetric_SeriesFilter(t *testing.T) {
 //
 // Empty means none, so a caller drawing no overlays does not pay for them.
 func TestGetMetric_Quantiles(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Now().Add(-time.Minute)
@@ -3782,6 +3818,7 @@ func TestGetMetric_Quantiles(t *testing.T) {
 //
 // Totals: A has 60 observations, B has 10, so the aggregate must report 70.
 func TestGetMetric_CrossSeriesAggregate(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Now().Add(-time.Minute)
@@ -3860,6 +3897,7 @@ func TestGetMetric_CrossSeriesAggregate(t *testing.T) {
 // and it is why this test reaches back before 1970 rather than only checking a
 // present-day offset.
 func TestGetMetric_TimezoneAlignedBuckets(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	// Two datapoints either side of midnight UTC. Under a -5h offset they fall
@@ -3932,6 +3970,7 @@ func TestGetMetric_TimezoneAlignedBuckets(t *testing.T) {
 // window must keep dividing itself, so its buckets stay anchored where the
 // caller put them.
 func TestGetMetric_FitToDataSpansTheData(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	// Ten minutes of datapoints a minute apart, inside a window that spans
@@ -4025,6 +4064,7 @@ func TestGetMetric_FitToDataSpansTheData(t *testing.T) {
 // lands on exactly 10s: 60s / 6 admits 10s and refuses 5s. Pinning the width is
 // what lets the assertion be "on the grid" rather than "self-consistent".
 func TestGetMetric_MergedRowsCarryTheirBucket(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	// 13:00:00 UTC is a whole minute, so it is already on the 10s grid and the
@@ -4125,6 +4165,7 @@ func TestGetMetric_MergedRowsCarryTheirBucket(t *testing.T) {
 // arguments -- it runs the same query and keeps one field, and this is what
 // stops those two drifting.
 func TestGetMetricAggregate(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Now().Add(-time.Minute)
@@ -4277,6 +4318,7 @@ func mapKeys(m map[string]any) []string {
 // to the whole window puts the two readings below on different local days, so a
 // day bucket splits a day that did not end.
 func TestGetMetric_BucketsFollowTheZoneAcrossDST(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	// Both readings fall on local Sunday 25 October 2026 in London: the first
@@ -4363,6 +4405,7 @@ func TestGetMetric_BucketsFollowTheZoneAcrossDST(t *testing.T) {
 // directly visible here and nowhere else. A mutant reverting the election's
 // zone conversion survives the scalar test; this one is built to kill it.
 func TestGetMetric_HistogramMergeFollowsTheZoneAcrossDST(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	// The same three moments as the scalar test: two on London's 25-hour local
@@ -4439,6 +4482,7 @@ func TestGetMetric_HistogramMergeFollowsTheZoneAcrossDST(t *testing.T) {
 // settings rather than anything this query controls. A stream sampling every
 // datapoint defeated the reduction outright: every row came back.
 func TestGetMetric_ExemplarsAreCappedPerBucket(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
@@ -4506,6 +4550,7 @@ func TestGetMetric_ExemplarsAreCappedPerBucket(t *testing.T) {
 // not limit. The list is capped and the true count travels beside it, so a
 // client can say "5 of 60" rather than silently showing five.
 func TestGetMetric_ExemplarListIsCappedAndCounted(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
@@ -4564,6 +4609,7 @@ func TestGetMetric_ExemplarListIsCappedAndCounted(t *testing.T) {
 // returned nothing, and time order hands them whichever happened first. Both
 // caps now rank from either extreme, so what survives spans the range.
 func TestGetMetric_ExemplarSelectionKeepsBothExtremes(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
@@ -4632,6 +4678,7 @@ func TestGetMetric_ExemplarSelectionKeepsBothExtremes(t *testing.T) {
 // which two does it keep? The ones whose exemplars reach lowest and highest,
 // not the two that happened first.
 func TestGetMetric_ExemplarCarriersAreTheExtremeOnes(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
@@ -4730,6 +4777,7 @@ func TestGetMetric_ExemplarCarriersAreTheExtremeOnes(t *testing.T) {
 // start of each column, slow ones after, which is the shape of a latency spike
 // and the reason someone clicks a heatmap in the first place.
 func TestGetMetric_ColumnWindowMergesTheWholeColumn(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
@@ -4871,6 +4919,7 @@ func TestGetMetric_ColumnWindowMergesTheWholeColumn(t *testing.T) {
 // change mid-flight gets a second row, not a collision, because OTel only
 // makes fixed bounds a practice, never a promise.
 func TestHistogramBoundsAreStoredOnce(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
@@ -4960,6 +5009,7 @@ func TestHistogramBoundsAreStoredOnce(t *testing.T) {
 // ever "optimised" into a count over metric_series, which agrees on an
 // unbounded window and diverges exactly where it matters.
 func TestSeriesCountsAreWindowAndLifetime(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
@@ -5019,6 +5069,7 @@ func TestSeriesCountsAreWindowAndLifetime(t *testing.T) {
 // Every existing histogram fixture supplies at least one bound, which is why
 // the whole suite passed while the crash was reachable from any real demo.
 func TestIngest_SingleBucketHistogram(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
@@ -5074,6 +5125,7 @@ func TestIngest_SingleBucketHistogram(t *testing.T) {
 // stops absorbing nil, this fails next to the code that would need the same
 // normalisation AddBounds now does.
 func TestIngest_NilArraysReachingTheAppender(t *testing.T) {
+	t.Parallel()
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
 
 	t.Run("histogram with no buckets", func(t *testing.T) {
@@ -5134,6 +5186,7 @@ func TestIngest_NilArraysReachingTheAppender(t *testing.T) {
 // allowlist is the only thing keeping it out and a later edit could widen it
 // without anyone noticing.
 func TestMetricMetadataRoundTrip(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	md := pmetric.NewMetrics()

--- a/desktopexporter/internal/store/metrics/sdk_cumulative_test.go
+++ b/desktopexporter/internal/store/metrics/sdk_cumulative_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/metrics"
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/storetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -114,8 +115,7 @@ func TestCumulativeMergeAgainstTheOtelSDK(t *testing.T) {
 	// send exactly this on exit.
 	require.GreaterOrEqual(t, len(sink.batches), 2, "one batch per collection")
 
-	s, storeCtx, teardown := setupStore(t)
-	defer teardown()
+	s, storeCtx := storetest.New(t)
 	for _, md := range sink.batches {
 		require.NoError(t, s.WithConn(func(conn driver.Conn) error {
 			return metrics.Ingest(storeCtx, conn, md, s.FlushedIDs())

--- a/desktopexporter/internal/store/metrics/sdk_cumulative_test.go
+++ b/desktopexporter/internal/store/metrics/sdk_cumulative_test.go
@@ -60,6 +60,7 @@ func (c *collector) Export(_ context.Context, req pmetricotlp.ExportRequest) (pm
 // second collection's values, and only those, are what a merge across the window
 // must report.
 func TestCumulativeMergeAgainstTheOtelSDK(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")

--- a/desktopexporter/internal/store/queries/cumulative_merge_test.go
+++ b/desktopexporter/internal/store/queries/cumulative_merge_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/queries"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -121,13 +120,7 @@ func literal(c []int64) string {
 // TestCumulativeMergeMatchesReference drives random cumulative pairs through
 // the SQL macros and the Go reference and requires them to agree.
 func TestCumulativeMergeMatchesReference(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	defer db.Close()
-	for _, stmt := range queries.Macros() {
-		_, err := db.Exec(stmt.SQL)
-		require.NoErrorf(t, err, "%s", stmt.Name)
-	}
+	db := macroDB(t)
 
 	rng := rand.New(rand.NewSource(20260811))
 	cases, resets := 0, 0

--- a/desktopexporter/internal/store/queries/ddl_exec_test.go
+++ b/desktopexporter/internal/store/queries/ddl_exec_test.go
@@ -1,7 +1,6 @@
 package queries_test
 
 import (
-	"database/sql"
 	"strings"
 	"testing"
 
@@ -13,9 +12,7 @@ import (
 // Every DDL statement must actually execute. Compiling proves only that the
 // strings are valid Go.
 func TestAllDDLExecutes(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	defer db.Close()
+	db := freshDB(t)
 
 	for _, stmt := range queries.Types() {
 		db.Exec(stmt.SQL) // "already exists" is fine
@@ -36,17 +33,9 @@ func TestAllDDLExecutes(t *testing.T) {
 // The wire format keys resources and scopes by seq, so the sequence defaults
 // have to actually fire on insert.
 func TestSequencesAssignShortKeys(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	defer db.Close()
+	db := freshDB(t)
 
-	for _, group := range [][]queries.Statement{queries.Types(), queries.Tables()} {
-		for _, stmt := range group {
-			db.Exec(stmt.SQL)
-		}
-	}
-
-	_, err = db.Exec(`insert into attributes values
+	_, err := db.Exec(`insert into attributes values
 		('11111111-1111-1111-1111-111111111111','service.name','checkout','string','resource')`)
 	require.NoError(t, err)
 

--- a/desktopexporter/internal/store/queries/downscale_test.go
+++ b/desktopexporter/internal/store/queries/downscale_test.go
@@ -1,11 +1,9 @@
 package queries_test
 
 import (
-	"database/sql"
 	"fmt"
 	"testing"
 
-	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/queries"
 	_ "github.com/duckdb/duckdb-go/v2"
 	"github.com/stretchr/testify/require"
 )
@@ -27,16 +25,7 @@ import (
 // which is why several cases below start at an offset that does not divide
 // evenly.
 func TestDownscaleExpBuckets(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	defer db.Close()
-	for _, stmt := range queries.Types() {
-		db.Exec(stmt.SQL)
-	}
-	for _, stmt := range queries.Macros() {
-		_, err := db.Exec(stmt.SQL)
-		require.NoErrorf(t, err, "%s", stmt.Name)
-	}
+	db := macroDB(t)
 
 	cases := []struct {
 		name   string
@@ -123,16 +112,7 @@ func TestDownscaleExpBuckets(t *testing.T) {
 // class of bounds error that hand-written cases can miss -- a slice that skips
 // an input or counts one twice changes the sum.
 func TestDownscaleConservesTotal(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	defer db.Close()
-	for _, stmt := range queries.Types() {
-		db.Exec(stmt.SQL)
-	}
-	for _, stmt := range queries.Macros() {
-		_, err := db.Exec(stmt.SQL)
-		require.NoErrorf(t, err, "%s", stmt.Name)
-	}
+	db := macroDB(t)
 
 	var bad int
 	require.NoError(t, db.QueryRow(`

--- a/desktopexporter/internal/store/queries/duckdb_json_test.go
+++ b/desktopexporter/internal/store/queries/duckdb_json_test.go
@@ -12,7 +12,7 @@ import (
 // ::varchar cast without scientific notation. DuckDB's `/` operator returns
 // DOUBLE even for bigint operands; we use `//` (integer division) instead.
 func TestBucketStartTypePrecision(t *testing.T) {
-	db := setupMacroDB(t)
+	db := macroDB(t)
 
 	rows, err := db.Query(`
 		with params as (

--- a/desktopexporter/internal/store/queries/duckdb_list_semantics_test.go
+++ b/desktopexporter/internal/store/queries/duckdb_list_semantics_test.go
@@ -1,10 +1,8 @@
 package queries_test
 
 import (
-	"database/sql"
 	"testing"
 
-	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/queries"
 	_ "github.com/duckdb/duckdb-go/v2"
 	"github.com/stretchr/testify/require"
 )
@@ -25,9 +23,7 @@ import (
 // an explanation rather than somewhere downstream as a wrong histogram. If it
 // ever fails, read the two macros below before touching this file.
 func TestListSliceBoundsAreAsymmetric(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	defer db.Close()
+	db := macroDB(t)
 
 	q := func(sqlText string) string {
 		var got string
@@ -57,16 +53,7 @@ func TestListSliceBoundsAreAsymmetric(t *testing.T) {
 // `cutoff < offset_` branch catches everything below, so this is the test that
 // notices if that branch is ever relaxed.
 func TestFoldBelowCutoffConservesCounts(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	defer db.Close()
-	for _, stmt := range queries.Types() {
-		db.Exec(stmt.SQL)
-	}
-	for _, stmt := range queries.Macros() {
-		_, err := db.Exec(stmt.SQL)
-		require.NoErrorf(t, err, "%s", stmt.Name)
-	}
+	db := macroDB(t)
 
 	var bad int
 	require.NoError(t, db.QueryRow(`

--- a/desktopexporter/internal/store/queries/harness_test.go
+++ b/desktopexporter/internal/store/queries/harness_test.go
@@ -1,0 +1,95 @@
+package queries_test
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/queries"
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+// One DuckDB for the tests in this package that only read.
+//
+// Most tests here evaluate a macro against literal arguments -- downscaling a
+// bucket array, slicing a list, folding counts. They never write a row, so the
+// database they run against is a constant: types and macros installed, tables
+// empty. Building that per test was thirteen copies of the same preamble, and
+// the copies had already drifted -- some loaded Types before Macros, some
+// discarded the error from Types, and setupMacroDB installed macros but not
+// types, which is why the files needing both hand-rolled it instead of calling
+// it.
+//
+// The split is by what a test does to the database, not by what it costs.
+// Sharing is safe for the readers because DuckDB evaluating a scalar macro
+// touches nothing another test can observe. It is not safe for the two tests
+// that write -- see freshDB.
+var sharedDB *sql.DB
+
+func TestMain(m *testing.M) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "opening shared duckdb:", err)
+		os.Exit(1)
+	}
+	if err := install(db); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	sharedDB = db
+	code := m.Run()
+	_ = db.Close()
+	os.Exit(code)
+}
+
+// install puts the schema on a connection: types first, since macros and
+// tables both refer to them, then macros, then tables.
+func install(db *sql.DB) error {
+	// Types are created with plain CREATE TYPE and there is no IF NOT EXISTS
+	// for it, so a redundant one is an "already exists" error rather than a
+	// real failure. Every other statement here is checked.
+	for _, stmt := range queries.Types() {
+		db.Exec(stmt.SQL)
+	}
+	for _, stmt := range queries.Macros() {
+		if _, err := db.Exec(stmt.SQL); err != nil {
+			return fmt.Errorf("creating macro %s: %w", stmt.Name, err)
+		}
+	}
+	for _, stmt := range queries.Tables() {
+		if _, err := db.Exec(stmt.SQL); err != nil {
+			return fmt.Errorf("creating table %s: %w", stmt.Name, err)
+		}
+	}
+	return nil
+}
+
+// macroDB is the shared database, for tests that only evaluate expressions.
+//
+// Do not write to it. If a test needs to insert a row or create a table, it
+// needs freshDB instead: a stray row here is visible to every other test in
+// the package and to none of their assertions.
+func macroDB(t *testing.T) *sql.DB {
+	t.Helper()
+	return sharedDB
+}
+
+// freshDB is a private database for a test that writes.
+//
+// Two tests in this package do: one inserts into attributes and resources to
+// exercise the orphan sweep, the other creates a table called `t`. Both would
+// be visible to unrelated tests on the shared handle, and `t` would collide
+// outright with a second test doing the same.
+func freshDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("opening duckdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := install(db); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}

--- a/desktopexporter/internal/store/queries/otlp_coverage_test.go
+++ b/desktopexporter/internal/store/queries/otlp_coverage_test.go
@@ -1,13 +1,11 @@
 package queries_test
 
 import (
-	"database/sql"
 	"reflect"
 	"sort"
 	"strings"
 	"testing"
 
-	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/queries"
 	_ "github.com/duckdb/duckdb-go/v2"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -30,23 +28,14 @@ import (
 // wrong in a way that looks fine.
 //
 // Two choices worth stating. Columns come from duckdb_columns() against a
-// schema this test actually creates, not from parsing the .sql files, so a
+// schema that was really executed -- the harness creates it and fails the
+// package if any table does not build -- not from parsing the .sql files, so a
 // column that fails to materialise cannot pass. And fields are matched by
 // name, which is loose -- a column named for a field it does not really hold
 // would satisfy this. It catches absence, which is the failure that happened
 // twice, not misuse.
 func TestSchemaCoversOTLP(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	defer db.Close()
-
-	for _, stmt := range queries.Types() {
-		db.Exec(stmt.SQL) // "already exists" is fine
-	}
-	for _, stmt := range queries.Tables() {
-		_, err := db.Exec(stmt.SQL)
-		require.NoErrorf(t, err, "%s", stmt.Name)
-	}
+	db := macroDB(t)
 
 	columns := func(table string) map[string]bool {
 		rows, err := db.Query(

--- a/desktopexporter/internal/store/queries/schema_test.go
+++ b/desktopexporter/internal/store/queries/schema_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/queries"
-	"github.com/duckdb/duckdb-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,23 +14,6 @@ import (
 // setupMacroDB stands up a fresh in-memory DuckDB and applies all macro
 // creation queries. Tests that only need the macros (no tables/indexes) use
 // this rather than store.NewStore to avoid an import cycle (store -> schema).
-func setupMacroDB(t *testing.T) *sql.DB {
-	t.Helper()
-
-	connector, err := duckdb.NewConnector("", nil)
-	require.NoError(t, err, "duckdb connector should open")
-	t.Cleanup(func() { _ = connector.Close() })
-
-	db := sql.OpenDB(connector)
-	t.Cleanup(func() { _ = db.Close() })
-
-	for i, q := range queries.Macros() {
-		_, err := db.Exec(q.SQL)
-		require.NoErrorf(t, err, "creating macro %d should succeed", i)
-	}
-	return db
-}
-
 // scalarFloat runs a query that returns one numeric column and returns the
 // value as a float64. The bool indicates whether the result was non-NULL.
 func scalarFloat(t *testing.T, db *sql.DB, query string) (float64, bool) {
@@ -42,7 +24,7 @@ func scalarFloat(t *testing.T, db *sql.DB, query string) (float64, bool) {
 }
 
 func TestMacros_InterpolationKernels(t *testing.T) {
-	db := setupMacroDB(t)
+	db := macroDB(t)
 
 	cases := []struct {
 		name  string
@@ -90,7 +72,7 @@ func TestMacros_InterpolationKernels(t *testing.T) {
 }
 
 func TestMacros_HistogramQuantile(t *testing.T) {
-	db := setupMacroDB(t)
+	db := macroDB(t)
 
 	cases := []struct {
 		name  string
@@ -124,7 +106,7 @@ func TestMacros_HistogramQuantile(t *testing.T) {
 }
 
 func TestMacros_ExpHistogramQuantile(t *testing.T) {
-	db := setupMacroDB(t)
+	db := macroDB(t)
 
 	cases := []struct {
 		name  string
@@ -180,7 +162,7 @@ func TestMacros_ExpHistogramQuantile(t *testing.T) {
 }
 
 func TestMacros_NullSafety(t *testing.T) {
-	db := setupMacroDB(t)
+	db := macroDB(t)
 
 	cases := []struct {
 		name  string
@@ -208,7 +190,7 @@ func TestMacros_NullSafety(t *testing.T) {
 }
 
 func TestMacros_BucketBuilderShapes(t *testing.T) {
-	db := setupMacroDB(t)
+	db := macroDB(t)
 
 	// Float bucket bounds. Each row asserts one struct field of one element
 	// in the list returned by a builder.
@@ -294,7 +276,7 @@ func TestMacros_BucketBuilderShapes(t *testing.T) {
 }
 
 func TestMacros_FloorDiv(t *testing.T) {
-	db := setupMacroDB(t)
+	db := macroDB(t)
 
 	// The whole point of this macro vs. SQL's `/` is correct rounding for
 	// negative numerators. Cases cover:
@@ -330,7 +312,7 @@ func TestMacros_FloorDiv(t *testing.T) {
 }
 
 func TestMacros_DownscaleExpBuckets(t *testing.T) {
-	db := setupMacroDB(t)
+	db := macroDB(t)
 
 	// Each case names the input and the expected output struct, then we probe
 	// individual fields (offset, len(counts), and specific counts entries) via
@@ -466,7 +448,7 @@ func TestMacros_DownscaleExpBuckets(t *testing.T) {
 }
 
 func TestMacros_FoldBelowCutoff(t *testing.T) {
-	db := setupMacroDB(t)
+	db := macroDB(t)
 
 	// Each subtest probes one field of the returned struct against an
 	// expected int64. The triple {counts, offset, folded} fully describes
@@ -637,7 +619,7 @@ func TestMacros_FoldBelowCutoff(t *testing.T) {
 }
 
 func TestMacros_PadLeftToOffset(t *testing.T) {
-	db := setupMacroDB(t)
+	db := macroDB(t)
 
 	// Each subtest probes a single position of the result via [] indexing,
 	// matching the BucketBuilderShapes / DownscaleExpBuckets style.
@@ -748,7 +730,7 @@ func TestMacros_PadLeftToOffset(t *testing.T) {
 }
 
 func TestMacros_SumBucketVectors(t *testing.T) {
-	db := setupMacroDB(t)
+	db := macroDB(t)
 
 	// Probe individual elements of the returned list via [] indexing -- same
 	// pattern TestMacros_BucketBuilderShapes uses to avoid the complexity of
@@ -834,7 +816,7 @@ func TestMacros_Idempotent(t *testing.T) {
 	// "already exists" errors. This is the protection against the historical
 	// DuckDB quirk where some CREATE statements weren't idempotent and had
 	// to be tolerated at the bootstrap layer.
-	db := setupMacroDB(t)
+	db := macroDB(t)
 	for i, q := range queries.Macros() {
 		_, err := db.Exec(q.SQL)
 		require.NoErrorf(t, err, "re-running macro %d should succeed", i)
@@ -850,13 +832,7 @@ func TestMacros_Idempotent(t *testing.T) {
 // across the full scale range: the bucket at the cutoff must be wholly at or
 // below the threshold, and the next one must not be.
 func TestMacros_ExpZeroCutoff(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	defer db.Close()
-	for _, stmt := range queries.Macros() {
-		_, err := db.Exec(stmt.SQL)
-		require.NoErrorf(t, err, "%s", stmt.Name)
-	}
+	db := macroDB(t)
 
 	thresholds := []float64{1e-9, 0.001, 0.5, 1, 1.5, 2, 3.7, 6.25, 1024}
 	for scale := -5; scale <= 12; scale++ {
@@ -883,13 +859,7 @@ func TestMacros_ExpZeroCutoff(t *testing.T) {
 // No zero region means nothing to fold, and fold_below_cutoff reads NULL as
 // "fold nothing".
 func TestMacros_ExpZeroCutoffWithoutAZeroRegion(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	defer db.Close()
-	for _, stmt := range queries.Macros() {
-		_, err := db.Exec(stmt.SQL)
-		require.NoErrorf(t, err, "%s", stmt.Name)
-	}
+	db := macroDB(t)
 
 	for _, threshold := range []any{0.0, -1.0, nil} {
 		var cutoff sql.NullInt64
@@ -903,13 +873,7 @@ func TestMacros_ExpZeroCutoffWithoutAZeroRegion(t *testing.T) {
 // is a subtraction and you cannot subtract two minima to get the minimum of the
 // activity between them -- so the range is rebuilt from the buckets instead.
 func TestMacros_BucketExtents(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	defer db.Close()
-	for _, stmt := range queries.Macros() {
-		_, err := db.Exec(stmt.SQL)
-		require.NoErrorf(t, err, "%s", stmt.Name)
-	}
+	db := macroDB(t)
 
 	for _, tc := range []struct {
 		name     string
@@ -979,7 +943,7 @@ func TestMacros_BucketExtents(t *testing.T) {
 // is chosen first. The p50 cases here are what would regress if that reasoning
 // were wrong.
 func TestMacros_QuantileSkipsEmptyBuckets(t *testing.T) {
-	db := setupMacroDB(t)
+	db := macroDB(t)
 
 	cases := []struct {
 		name  string
@@ -1036,7 +1000,7 @@ func TestMacros_QuantileSkipsEmptyBuckets(t *testing.T) {
 // Surfaced by opening the app: every explicit-bounds histogram returned
 // "JSON RPC internal error".
 func TestMacros_DiffBucketVectorsUnsignedReset(t *testing.T) {
-	db := setupMacroDB(t)
+	db := macroDB(t)
 
 	t.Run("reset returns null, not an error", func(t *testing.T) {
 		var got sql.NullString

--- a/desktopexporter/internal/store/queries/uuid_list_test.go
+++ b/desktopexporter/internal/store/queries/uuid_list_test.go
@@ -1,10 +1,8 @@
 package queries_test
 
 import (
-	"database/sql"
 	"testing"
 
-	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/queries"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,14 +20,8 @@ import (
 // must delete, and a malformed id must raise rather than report a successful
 // no-op.
 func TestUUIDListRejectsMalformedIDs(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	defer db.Close()
-	for _, stmt := range queries.Macros() {
-		_, err := db.Exec(stmt.SQL)
-		require.NoErrorf(t, err, "%s", stmt.Name)
-	}
-	_, err = db.Exec(`create table t (id uuid)`)
+	db := freshDB(t)
+	_, err := db.Exec(`create table t (id uuid)`)
 	require.NoError(t, err)
 	_, err = db.Exec(`insert into t values ('720cea1f-6c57-2438-d9b1-098fa86ecc3b')`)
 	require.NoError(t, err)
@@ -59,13 +51,7 @@ func TestUUIDListRejectsMalformedIDs(t *testing.T) {
 // characters, so the truncation never fires and a macro that returned the body
 // untouched would pass every end-to-end check.
 func TestBodyPreviewTruncates(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	defer db.Close()
-	for _, stmt := range queries.Macros() {
-		_, err := db.Exec(stmt.SQL)
-		require.NoErrorf(t, err, "%s", stmt.Name)
-	}
+	db := macroDB(t)
 
 	var long, short int
 	var emptyOK, nullOK bool

--- a/desktopexporter/internal/store/spans/ingest_dedupe_test.go
+++ b/desktopexporter/internal/store/spans/ingest_dedupe_test.go
@@ -19,6 +19,7 @@ import (
 // The dedupe claim, end to end: many spans sharing a resource must produce one
 // resource row and one set of dictionary entries, not one copy per span.
 func TestIngestDedupesAcrossSpans(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s, err := store.NewStore(ctx, "", zap.NewNop())
 	require.NoError(t, err)

--- a/desktopexporter/internal/store/spans/spans_test.go
+++ b/desktopexporter/internal/store/spans/spans_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/ingest"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/search"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/spans"
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/storetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.uber.org/zap"
 )
 
 // readStore runs a query under the store's read lock and returns its result.
@@ -34,14 +34,6 @@ func readStore[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error)
 		return err
 	})
 	return out, err
-}
-
-func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
-	t.Helper()
-	ctx := context.Background()
-	s, err := store.NewStore(ctx, "", zap.NewNop())
-	require.NoError(t, err)
-	return s, ctx, func() { s.Close() }
 }
 
 func countRows(t *testing.T, s *store.Store, ctx context.Context, query string, args ...any) int {
@@ -179,8 +171,7 @@ type rootSpanJSON struct {
 
 // TestTraceSummaryOrdering verifies that trace summaries are ordered by start time (newest first).
 func TestTraceSummaryOrdering(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
 	traces, trace1Hex, trace2Hex, trace3Hex := buildTracesForSummaryOrdering(baseTime)
@@ -212,8 +203,7 @@ func TestTraceSummaryOrdering(t *testing.T) {
 
 // TestTraceNotFound verifies error handling for non-existent trace IDs.
 func TestTraceNotFound(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	_, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
 		return spans.SearchSpans(ctx, db, "00000000-0000-0000-0000-000000000000", nil)
@@ -224,8 +214,7 @@ func TestTraceNotFound(t *testing.T) {
 
 // TestEmptySpans verifies handling of empty span lists and empty stores.
 func TestEmptySpans(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	err := s.WithConn(func(conn driver.Conn) error {
 		return spans.Ingest(ctx, conn, ptrace.NewTraces(), s.FlushedIDs())
@@ -247,8 +236,7 @@ func TestEmptySpans(t *testing.T) {
 // asserting they *survive* is the point, not an omission. ingest.SweepOrphans
 // is the only thing that may delete them.
 func TestClearTraces(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	traces := createTestTracePdata()
 	err := s.WithConn(func(conn driver.Conn) error {
@@ -334,8 +322,7 @@ func spanDataFromSearchSpans(t *testing.T, raw json.RawMessage, i int) (name, sp
 
 // TestTraceSuite runs a comprehensive suite of tests on a single trace.
 func TestTraceSuite(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	traces := createTestTracePdata()
 	testTraceID := "00000000000000000000000000000099"
@@ -439,8 +426,7 @@ func TestTraceSuite(t *testing.T) {
 
 // TestSearchTraces tests SearchTraces with various query types.
 func TestSearchTraces(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	traces := createTestTracePdata()
 	testTraceID := "00000000000000000000000000000099"
@@ -1108,8 +1094,7 @@ func TestSearchTraces(t *testing.T) {
 // the constant was raised from 50 to 500 the hardcoded 51 quietly stopped
 // being a large batch at all.
 func TestIngestSpans_LargeBatchStaysConsistent(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	const batchSize = spans.FlushInterval + 1
 	traces := createTestTracesPdataN(batchSize)
@@ -1173,8 +1158,7 @@ func TestIngestSpans_LargeBatchStaysConsistent(t *testing.T) {
 }
 
 func TestIngest_CanceledContext(t *testing.T) {
-	s, _, teardown := setupStore(t)
-	defer teardown()
+	s, _ := storetest.New(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -1186,8 +1170,7 @@ func TestIngest_CanceledContext(t *testing.T) {
 }
 
 func TestIngest_CanceledDuringIngest(t *testing.T) {
-	s, _, teardown := setupStore(t)
-	defer teardown()
+	s, _ := storetest.New(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	traces := createTestTracesPdataN(100)
@@ -1206,8 +1189,7 @@ func TestIngest_CanceledDuringIngest(t *testing.T) {
 
 // TestDeleteSpansByIDs verifies that multiple spans can be deleted by their SpanIDs, including child rows.
 func TestDeleteSpansByIDs(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	traces := createTestTracePdata()
 	err := s.WithConn(func(conn driver.Conn) error {
@@ -1283,8 +1265,7 @@ func TestDeleteSpansByIDs(t *testing.T) {
 
 // TestDeleteSpansByIDs_Empty verifies that deleting with an empty list is a no-op.
 func TestDeleteSpansByIDs_Empty(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	err := s.WithDBWrite(func(db *sql.DB) error {
 		return spans.DeleteSpansByIDs(ctx, db, []any{})
@@ -1294,8 +1275,7 @@ func TestDeleteSpansByIDs_Empty(t *testing.T) {
 
 // TestSearchSpansWith32CharHexTraceID verifies that SearchSpans finds a trace when given the 32-char hex form (no hyphens).
 func TestSearchSpansWith32CharHexTraceID(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	traces := createTestTracePdata()
 	err := s.WithConn(func(conn driver.Conn) error {
@@ -1313,8 +1293,7 @@ func TestSearchSpansWith32CharHexTraceID(t *testing.T) {
 
 // TestDeleteSpansByTraceIDs verifies that spans for multiple traces are deleted, including child rows.
 func TestDeleteSpansByTraceIDs(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	traces := createTestTracePdata()
 	testTraceID := "00000000000000000000000000000099"
@@ -1358,8 +1337,7 @@ func TestDeleteSpansByTraceIDs(t *testing.T) {
 
 // TestDeleteSpansByTraceIDs_Empty verifies that deleting with an empty list is a no-op.
 func TestDeleteSpansByTraceIDs_Empty(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	err := s.WithDBWrite(func(db *sql.DB) error {
 		return spans.DeleteSpansByTraceIDs(ctx, db, []any{})
@@ -1624,8 +1602,7 @@ func createTestTracePdata() ptrace.Traces {
 // path forgot to write the column, or the resource attribute row was
 // dropped, both of which would silently break service filtering.
 func TestSpans_ServiceNameDenormStaysConsistent(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
 	traces, _, _, _ := buildTracesForSummaryOrdering(baseTime)
@@ -1679,8 +1656,7 @@ func TestSpans_ServiceNameDenormStaysConsistent(t *testing.T) {
 // spans rather than part of resource or scope identity: the same scope emitted
 // through two pipelines stamping different urls is still one scope.
 func TestSchemaURLsAreStored(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	const resURL = "https://opentelemetry.io/schemas/1.27.0"
 	const scopeURL = "https://opentelemetry.io/schemas/1.24.0"
@@ -1724,8 +1700,7 @@ func TestSchemaURLsAreStored(t *testing.T) {
 // Unreachable spans were previously dropped in silence, which renders the
 // trace short with nothing saying so. unplacedSpanCount reports them.
 func TestSearchSpansReportsUnplacedSpans(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC).UnixNano()
 	add := func(tr ptrace.Traces, traceHex, spanHex, parentHex string, offset int64) {
@@ -1884,8 +1859,7 @@ func TestSearchSpansReportsUnplacedSpans(t *testing.T) {
 // the wire, which means surviving the recursive walk's explicit column list
 // and the JSON macro -- the two places this was actually missing.
 func TestSpanAndLinkFlagsRoundTrip(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	const (
 		traceIDHex = "000000000000000000000000000000aa"

--- a/desktopexporter/internal/store/spans/spans_test.go
+++ b/desktopexporter/internal/store/spans/spans_test.go
@@ -171,6 +171,7 @@ type rootSpanJSON struct {
 
 // TestTraceSummaryOrdering verifies that trace summaries are ordered by start time (newest first).
 func TestTraceSummaryOrdering(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
@@ -203,6 +204,7 @@ func TestTraceSummaryOrdering(t *testing.T) {
 
 // TestTraceNotFound verifies error handling for non-existent trace IDs.
 func TestTraceNotFound(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	_, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
@@ -214,6 +216,7 @@ func TestTraceNotFound(t *testing.T) {
 
 // TestEmptySpans verifies handling of empty span lists and empty stores.
 func TestEmptySpans(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	err := s.WithConn(func(conn driver.Conn) error {
@@ -236,6 +239,7 @@ func TestEmptySpans(t *testing.T) {
 // asserting they *survive* is the point, not an omission. ingest.SweepOrphans
 // is the only thing that may delete them.
 func TestClearTraces(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	traces := createTestTracePdata()
@@ -322,6 +326,7 @@ func spanDataFromSearchSpans(t *testing.T, raw json.RawMessage, i int) (name, sp
 
 // TestTraceSuite runs a comprehensive suite of tests on a single trace.
 func TestTraceSuite(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	traces := createTestTracePdata()
@@ -426,6 +431,7 @@ func TestTraceSuite(t *testing.T) {
 
 // TestSearchTraces tests SearchTraces with various query types.
 func TestSearchTraces(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	traces := createTestTracePdata()
@@ -1094,6 +1100,7 @@ func TestSearchTraces(t *testing.T) {
 // the constant was raised from 50 to 500 the hardcoded 51 quietly stopped
 // being a large batch at all.
 func TestIngestSpans_LargeBatchStaysConsistent(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	const batchSize = spans.FlushInterval + 1
@@ -1158,6 +1165,7 @@ func TestIngestSpans_LargeBatchStaysConsistent(t *testing.T) {
 }
 
 func TestIngest_CanceledContext(t *testing.T) {
+	t.Parallel()
 	s, _ := storetest.New(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1170,6 +1178,7 @@ func TestIngest_CanceledContext(t *testing.T) {
 }
 
 func TestIngest_CanceledDuringIngest(t *testing.T) {
+	t.Parallel()
 	s, _ := storetest.New(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1189,6 +1198,7 @@ func TestIngest_CanceledDuringIngest(t *testing.T) {
 
 // TestDeleteSpansByIDs verifies that multiple spans can be deleted by their SpanIDs, including child rows.
 func TestDeleteSpansByIDs(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	traces := createTestTracePdata()
@@ -1265,6 +1275,7 @@ func TestDeleteSpansByIDs(t *testing.T) {
 
 // TestDeleteSpansByIDs_Empty verifies that deleting with an empty list is a no-op.
 func TestDeleteSpansByIDs_Empty(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	err := s.WithDBWrite(func(db *sql.DB) error {
@@ -1275,6 +1286,7 @@ func TestDeleteSpansByIDs_Empty(t *testing.T) {
 
 // TestSearchSpansWith32CharHexTraceID verifies that SearchSpans finds a trace when given the 32-char hex form (no hyphens).
 func TestSearchSpansWith32CharHexTraceID(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	traces := createTestTracePdata()
@@ -1293,6 +1305,7 @@ func TestSearchSpansWith32CharHexTraceID(t *testing.T) {
 
 // TestDeleteSpansByTraceIDs verifies that spans for multiple traces are deleted, including child rows.
 func TestDeleteSpansByTraceIDs(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	traces := createTestTracePdata()
@@ -1337,6 +1350,7 @@ func TestDeleteSpansByTraceIDs(t *testing.T) {
 
 // TestDeleteSpansByTraceIDs_Empty verifies that deleting with an empty list is a no-op.
 func TestDeleteSpansByTraceIDs_Empty(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	err := s.WithDBWrite(func(db *sql.DB) error {
@@ -1602,6 +1616,7 @@ func createTestTracePdata() ptrace.Traces {
 // path forgot to write the column, or the resource attribute row was
 // dropped, both of which would silently break service filtering.
 func TestSpans_ServiceNameDenormStaysConsistent(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
@@ -1656,6 +1671,7 @@ func TestSpans_ServiceNameDenormStaysConsistent(t *testing.T) {
 // spans rather than part of resource or scope identity: the same scope emitted
 // through two pipelines stamping different urls is still one scope.
 func TestSchemaURLsAreStored(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	const resURL = "https://opentelemetry.io/schemas/1.27.0"
@@ -1700,6 +1716,7 @@ func TestSchemaURLsAreStored(t *testing.T) {
 // Unreachable spans were previously dropped in silence, which renders the
 // trace short with nothing saying so. unplacedSpanCount reports them.
 func TestSearchSpansReportsUnplacedSpans(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC).UnixNano()
@@ -1859,6 +1876,7 @@ func TestSearchSpansReportsUnplacedSpans(t *testing.T) {
 // the wire, which means surviving the recursive walk's explicit column list
 // and the JSON macro -- the two places this was actually missing.
 func TestSpanAndLinkFlagsRoundTrip(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	const (

--- a/desktopexporter/internal/store/spans/sql_golden_test.go
+++ b/desktopexporter/internal/store/spans/sql_golden_test.go
@@ -89,6 +89,7 @@ func TestSearchSpansSQLGolden(t *testing.T) {
 // the text. A golden file would look identical either way, since the id is not
 // in it -- which is the point.
 func TestSearchSpansSQLBindsTraceID(t *testing.T) {
+	t.Parallel()
 	query, args, err := searchSpansSQL("00000000000000000000000000000099", nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, args)

--- a/desktopexporter/internal/store/spans/sql_injection_test.go
+++ b/desktopexporter/internal/store/spans/sql_injection_test.go
@@ -38,6 +38,7 @@ var injectionPayloads = []string{
 // rendered, not re-parsed, so a fragment containing template syntax cannot
 // cause a second round of expansion.
 func TestSearchSpansSQLBindsHostileInput(t *testing.T) {
+	t.Parallel()
 	for _, payload := range injectionPayloads {
 		t.Run(payload, func(t *testing.T) {
 			// A non-equality operator so the query keeps the value comparison

--- a/desktopexporter/internal/store/stats/stats_test.go
+++ b/desktopexporter/internal/store/stats/stats_test.go
@@ -103,6 +103,7 @@ func getStats(t *testing.T, s *store.Store, ctx context.Context) statsJSON {
 }
 
 func TestGetStats_Empty(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	result := getStats(t, s, ctx)
@@ -123,6 +124,7 @@ func TestGetStats_Empty(t *testing.T) {
 }
 
 func TestGetStats_WithTraces(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
@@ -146,6 +148,7 @@ func TestGetStats_WithTraces(t *testing.T) {
 }
 
 func TestGetStats_WithLogs(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
@@ -166,6 +169,7 @@ func TestGetStats_WithLogs(t *testing.T) {
 }
 
 func TestGetStats_WithMetrics(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	m := buildTestMetrics()
@@ -185,6 +189,7 @@ func TestGetStats_WithMetrics(t *testing.T) {
 }
 
 func TestGetStats_AllSignals(t *testing.T) {
+	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()

--- a/desktopexporter/internal/store/stats/stats_test.go
+++ b/desktopexporter/internal/store/stats/stats_test.go
@@ -15,13 +15,13 @@ import (
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/metrics"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/spans"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/stats"
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/storetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.uber.org/zap"
 )
 
 // readStore runs a query under the store's read lock and returns its result.
@@ -35,14 +35,6 @@ func readStore[T any](s *store.Store, fn func(db *sql.DB) (T, error)) (T, error)
 		return err
 	})
 	return out, err
-}
-
-func setupStore(t *testing.T) (*store.Store, context.Context, func()) {
-	t.Helper()
-	ctx := context.Background()
-	s, err := store.NewStore(ctx, "", zap.NewNop())
-	require.NoError(t, err)
-	return s, ctx, func() { s.Close() }
 }
 
 func mustDecodeTraceID(s string) [16]byte {
@@ -111,8 +103,7 @@ func getStats(t *testing.T, s *store.Store, ctx context.Context) statsJSON {
 }
 
 func TestGetStats_Empty(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	result := getStats(t, s, ctx)
 
@@ -132,8 +123,7 @@ func TestGetStats_Empty(t *testing.T) {
 }
 
 func TestGetStats_WithTraces(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
 	tr := buildTestTraces(baseTime)
@@ -156,8 +146,7 @@ func TestGetStats_WithTraces(t *testing.T) {
 }
 
 func TestGetStats_WithLogs(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
 	lg := buildTestLogs(baseTime)
@@ -177,8 +166,7 @@ func TestGetStats_WithLogs(t *testing.T) {
 }
 
 func TestGetStats_WithMetrics(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	m := buildTestMetrics()
 
@@ -197,8 +185,7 @@ func TestGetStats_WithMetrics(t *testing.T) {
 }
 
 func TestGetStats_AllSignals(t *testing.T) {
-	s, ctx, teardown := setupStore(t)
-	defer teardown()
+	s, ctx := storetest.New(t)
 
 	baseTime := time.Now().UnixNano()
 

--- a/desktopexporter/internal/store/storetest/storetest.go
+++ b/desktopexporter/internal/store/storetest/storetest.go
@@ -1,0 +1,45 @@
+// Package storetest builds stores for tests.
+//
+// Every test package under store/ needs the same thing to start: an in-memory
+// store, a context, and a guarantee it gets closed. That was six identical
+// copies of the same six lines, one per package, which is the kind of
+// duplication that stays invisible until one copy needs to change.
+//
+// The store package's own tests are not among the callers and cannot be. Its
+// tests are an internal test package (`package store`), so importing a helper
+// that imports store would be an import cycle. Its copy stays where it is on
+// purpose -- it is not an oversight to tidy away.
+package storetest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// New returns an in-memory store and a context for it. The store is closed
+// when the test and its subtests finish.
+//
+// Cleanup is registered rather than returned. The teardown func it replaces
+// was correct but had to be deferred by hand at all 99 call sites, and a
+// forgotten defer leaks a DuckDB instance for the rest of the run without
+// failing anything.
+//
+// Each call builds its own database. That is what lets these tests run in
+// parallel, and it is not merely an optimisation they tolerate: many of them
+// assert over whole-table state -- "there are exactly five metrics", "the
+// stream table is empty after delete" -- which is only meaningful when nothing
+// else is writing to the same database.
+func New(t *testing.T) (*store.Store, context.Context) {
+	t.Helper()
+
+	ctx := context.Background()
+	s, err := store.NewStore(ctx, "", zap.NewNop())
+	require.NoError(t, err)
+	t.Cleanup(func() { s.Close() })
+
+	return s, ctx
+}


### PR DESCRIPTION
Three commits on the test suite. No assertion changes — every test still checks what it checked.

## Share one database among the query tests that only read from it

- Most tests in `store/queries` evaluate a macro against literal arguments and never write a row, so the database they run against is a constant
- That was 13 copies of the same preamble, and the copies had drifted: some loaded `Types` before `Macros`, some discarded its error by accident rather than on purpose, and `setupMacroDB` installed macros but *not* types — which is why the files needing both hand-rolled it instead of calling it. Four of those copies were recent and mine
- One `TestMain` installs types, macros and tables once; `macroDB` hands out the shared handle
- The split is by what a test does to the database, not by what it costs. Three keep their own: `TestAllDDLExecutes` asserts every `CREATE` succeeds, true only against a virgin database; `TestSequencesAssignShortKeys` asserts `min(seq)`/`max(seq)` across the whole `resources` table; `TestUUIDListRejectsMalformedIDs` creates a table called `t` that would outlive it
- Checked, not assumed: breaking `downscale_exp_buckets` still fails 20 assertions on the shared handle, and deleting `metric_ingests.metadata_ids` still fails the OTLP coverage test

## Give the store test packages one setup helper instead of six

- Five packages carried byte-identical `setupStore` helpers; the sixth differed only in a package qualifier
- `storetest.New` replaces them. Cleanup is registered rather than returned — the teardown func was correct but had to be deferred by hand at all 99 call sites, and a forgotten defer leaks a DuckDB for the rest of the run without failing anything
- The `store` package keeps its copy and that is not an oversight: its tests are an internal test package, so importing a helper that imports `store` would be an import cycle. The reason is written next to the helper

## Run the store tests in parallel, except where a global forbids it

- Each test builds its own database, so the only thing making them run one at a time was that nobody had said otherwise. **25.5s to 13.5s wall**
- Six tests in `attribute_memo_test.go` deliberately do not. The memo is one process-global table with global hit/miss counters, so a test asserting "89 misses, 17,711 hits" is asserting about the whole process. Go runs every non-parallel test to completion before the parallel ones resume, which is what keeps those six isolated
- Found by running the suite, not reading it: a first pass marked all 119 parallel and failed **10 out of 10** under `-shuffle=on`. The audit beforehand had only grepped test files, and the memo lives in the non-test source
- Golden SQL tests stay serial — they write files under `-update-golden` and already run in milliseconds

## Evidence

- 15 consecutive full-suite runs under `-shuffle=on`, 3 under `-race`, 3 under `GOMAXPROCS=2 -p 2 -parallel 2` to match a two-core runner — all clean
- Re-verified after rebasing onto #399: 10 more shuffled runs and another `-race` run, all clean
- Peak RSS 686MB to 1.27GB, against the 7–16GB a GitHub runner has
