### PR TITLE
Stop one bad row costing the whole batch

### DIFF
--- a/desktopexporter/exporter.go
+++ b/desktopexporter/exporter.go
@@ -152,13 +152,15 @@ func (e *desktopExporter) pushLogs(ctx context.Context, source plog.Logs) error 
 // error, no dropped_items, nothing. unit names what was counted, since a
 // metrics batch is measured in datapoints but refused a metric at a time.
 func (e *desktopExporter) reportRejected(signal, unit string, items int, r ingest.Rejected) {
-	if r.Count == 0 {
+	if r.Count() == 0 {
 		return
 	}
 	e.logger.Warn("store refused part of a batch",
 		zap.String("signal", signal),
-		zap.Int("rejected", r.Count),
+		zap.Int("rejected", r.Count()),
 		zap.Int("batch_"+unit, items),
-		zap.NamedError("reason", r.Reason),
+		// Every distinct reason, because a batch can be refused for more than
+		// one and naming only the first would hide the others.
+		zap.Any("reasons", r.Reasons()),
 	)
 }

--- a/desktopexporter/exporter.go
+++ b/desktopexporter/exporter.go
@@ -10,7 +10,10 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
+	"go.uber.org/zap"
+
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store"
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/ingest"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/logs"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/metrics"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/spans"
@@ -33,6 +36,10 @@ type storeHost interface {
 type desktopExporter struct {
 	tel *telemetry.Telemetry
 
+	// logger reports rows the store refused. Those are not errors -- the batch
+	// landed without them -- so nothing else would ever mention them.
+	logger *zap.Logger
+
 	// store is resolved in Start and never changes afterwards. The collector
 	// guarantees extensions are started first, so by the time the pipeline
 	// calls the push functions this is non-nil.
@@ -44,7 +51,11 @@ func newDesktopExporter(cfg *Config, settings component.TelemetrySettings) (*des
 	if err != nil {
 		return nil, err
 	}
-	return &desktopExporter{tel: tel}, nil
+	logger := settings.Logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &desktopExporter{tel: tel, logger: logger}, nil
 }
 
 // Start resolves the shared store from the collector's extensions. Exactly one
@@ -89,11 +100,16 @@ func (e *desktopExporter) pushTraces(ctx context.Context, source ptrace.Traces) 
 	ctx, cancel := withIngestTimeout(ctx)
 	defer cancel()
 
-	ctx, end := e.tel.Ingest(ctx, "traces", source.SpanCount())
+	items := source.SpanCount()
+	ctx, end := e.tel.Ingest(ctx, "traces", items)
+	var rejected ingest.Rejected
 	err := e.store.WithConn(func(conn driver.Conn) error {
-		return spans.Ingest(ctx, conn, source, e.store.FlushedIDs())
+		var iErr error
+		rejected, iErr = spans.IngestReport(ctx, conn, source, e.store.FlushedIDs())
+		return iErr
 	})
 	end(err)
+	e.reportRejected("traces", "spans", items, rejected)
 	return err
 }
 
@@ -101,11 +117,16 @@ func (e *desktopExporter) pushMetrics(ctx context.Context, source pmetric.Metric
 	ctx, cancel := withIngestTimeout(ctx)
 	defer cancel()
 
-	ctx, end := e.tel.Ingest(ctx, "metrics", source.DataPointCount())
+	items := source.DataPointCount()
+	ctx, end := e.tel.Ingest(ctx, "metrics", items)
+	var rejected ingest.Rejected
 	err := e.store.WithConn(func(conn driver.Conn) error {
-		return metrics.Ingest(ctx, conn, source, e.store.FlushedIDs())
+		var iErr error
+		rejected, iErr = metrics.IngestReport(ctx, conn, source, e.store.FlushedIDs())
+		return iErr
 	})
 	end(err)
+	e.reportRejected("metrics", "metrics", items, rejected)
 	return err
 }
 
@@ -113,10 +134,31 @@ func (e *desktopExporter) pushLogs(ctx context.Context, source plog.Logs) error 
 	ctx, cancel := withIngestTimeout(ctx)
 	defer cancel()
 
-	ctx, end := e.tel.Ingest(ctx, "logs", source.LogRecordCount())
+	items := source.LogRecordCount()
+	ctx, end := e.tel.Ingest(ctx, "logs", items)
+	var rejected ingest.Rejected
 	err := e.store.WithConn(func(conn driver.Conn) error {
-		return logs.Ingest(ctx, conn, source, e.store.FlushedIDs())
+		var iErr error
+		rejected, iErr = logs.IngestReport(ctx, conn, source, e.store.FlushedIDs())
+		return iErr
 	})
 	end(err)
+	e.reportRejected("logs", "records", items, rejected)
 	return err
+}
+
+// reportRejected logs rows the store would not take. The batch itself
+// succeeded, so without this the sender sees telemetry silently missing: no
+// error, no dropped_items, nothing. unit names what was counted, since a
+// metrics batch is measured in datapoints but refused a metric at a time.
+func (e *desktopExporter) reportRejected(signal, unit string, items int, r ingest.Rejected) {
+	if r.Count == 0 {
+		return
+	}
+	e.logger.Warn("store refused part of a batch",
+		zap.String("signal", signal),
+		zap.Int("rejected", r.Count),
+		zap.Int("batch_"+unit, items),
+		zap.NamedError("reason", r.Reason),
+	)
 }

--- a/desktopexporter/internal/store/ingest/appender.go
+++ b/desktopexporter/internal/store/ingest/appender.go
@@ -40,16 +40,28 @@ func FlushAppenders(appenders map[string]*duckdb.Appender, tables []string) erro
 	return nil
 }
 
-// CloseAppenders closes appenders in the order of tables, so close order is deterministic.
+// CloseAppenders closes every appender in reverse order of tables, matching
+// FlushAppenders so parents are written before dependents, and returns the
+// first failure.
+//
+// Every appender is closed even after one fails, because Close is also what
+// destroys the appender and releases its buffered chunk -- skipping the rest
+// would leak. Only the first error is returned, though. Ingest runs in a
+// transaction, so the first failure aborts it and every appender closed
+// afterwards reports the same derived "Current transaction is aborted (please
+// ROLLBACK)" rather than a fault of its own. Joining those buried the real
+// cause under two copies of a message telling the reader to do something the
+// caller already does.
+//
 // Safe to call with nil map or nil/empty tables.
 func CloseAppenders(appenders map[string]*duckdb.Appender, tables []string) error {
-	var errs []error
+	var firstErr error
 	for i := len(tables) - 1; i >= 0; i-- {
 		if a := appenders[tables[i]]; a != nil {
-			if err := a.Close(); err != nil {
-				errs = append(errs, err)
+			if err := a.Close(); err != nil && firstErr == nil {
+				firstErr = err
 			}
 		}
 	}
-	return errors.Join(errs...)
+	return firstErr
 }

--- a/desktopexporter/internal/store/ingest/appender.go
+++ b/desktopexporter/internal/store/ingest/appender.go
@@ -12,8 +12,8 @@ var (
 	ErrIngestInternal = errors.New("ingest internal error")
 )
 
-// NewAppenders creates one appender per table name, keyed by table name.
-// Caller must call CloseAppenders(appenders, tables) when done so appenders are closed in creation order.
+// NewAppenders opens one appender per table, keyed by name. Caller must
+// CloseAppenders.
 func NewAppenders(conn driver.Conn, tables []string) (map[string]*duckdb.Appender, error) {
 	out := make(map[string]*duckdb.Appender, len(tables))
 	for _, table := range tables {
@@ -27,8 +27,8 @@ func NewAppenders(conn driver.Conn, tables []string) (map[string]*duckdb.Appende
 	return out, nil
 }
 
-// FlushAppenders flushes appenders in reverse order of tables (parents before dependents)
-// so FK references exist when rows are written. Safe to call with nil map or nil/empty tables.
+// FlushAppenders flushes in reverse table order, so parents land before the
+// rows referencing them.
 func FlushAppenders(appenders map[string]*duckdb.Appender, tables []string) error {
 	for i := len(tables) - 1; i >= 0; i-- {
 		if a := appenders[tables[i]]; a != nil {
@@ -40,20 +40,9 @@ func FlushAppenders(appenders map[string]*duckdb.Appender, tables []string) erro
 	return nil
 }
 
-// CloseAppenders closes every appender in reverse order of tables, matching
-// FlushAppenders so parents are written before dependents, and returns the
-// first failure.
-//
-// Every appender is closed even after one fails, because Close is also what
-// destroys the appender and releases its buffered chunk -- skipping the rest
-// would leak. Only the first error is returned, though. Ingest runs in a
-// transaction, so the first failure aborts it and every appender closed
-// afterwards reports the same derived "Current transaction is aborted (please
-// ROLLBACK)" rather than a fault of its own. Joining those buried the real
-// cause under two copies of a message telling the reader to do something the
-// caller already does.
-//
-// Safe to call with nil map or nil/empty tables.
+// CloseAppenders closes every appender in reverse table order and returns the
+// first error. It keeps closing after a failure because Close releases each
+// buffered chunk; later errors only report that the transaction is aborted.
 func CloseAppenders(appenders map[string]*duckdb.Appender, tables []string) error {
 	var firstErr error
 	for i := len(tables) - 1; i >= 0; i-- {

--- a/desktopexporter/internal/store/ingest/bisect.go
+++ b/desktopexporter/internal/store/ingest/bisect.go
@@ -5,97 +5,38 @@ import (
 	"errors"
 )
 
-// ErrNotRowFault marks a failure that no individual row caused, so bisection
-// must surface it rather than search for a culprit.
-//
-// # Why this has to be said explicitly
-//
-// BisectingWrite is a search, and it rests on one assumption: remove the guilty
-// item and the rest succeeds. That is true of a duplicate key and false of a
-// fault belonging to the operation itself, which fails identically for every
-// subset. Given one of those, the search does not report it -- it halves all
-// the way down, finds every single-row window failing, and returns "every row
-// was rejected" with a nil error. The same shape as `git bisect` handed a test
-// script that fails on every commit: it does not conclude the script is broken,
-// it names an innocent commit with total confidence.
-//
-// The stakes are highest for the checks that exist to be loud. The pass
-// mismatch guards in spans, logs and metrics fire when the two passes disagree
-// about how many items exist -- a bug in our own code, whose whole purpose is
-// to fail noisily instead of pairing every owner past that point with another
-// owner's attributes. Run through an unguarded bisection, that alarm becomes a
-// silent tally, and resilience machinery ends up eating the one error it was
-// most important to hear.
-//
-// Wrap with %w. Anything not wrapped is still treated as row-specific and
-// isolated, which is the right default for a fault we do not recognise.
+// ErrNotRowFault marks a failure no single row caused. BisectingWrite surfaces
+// these instead of searching: they fail identically for every subset, so
+// narrowing would blame each row in turn and return no error at all. Wrap with %w.
 var ErrNotRowFault = errors.New("not attributable to any single row")
 
-// Rejected reports how many items an ingest could not write.
-//
-// A non-zero count is not an error. The batch succeeded; some items in it did
-// not, and the caller is told how many so it can say so rather than leaving the
-// sender to guess why its telemetry never appeared.
+// Rejected reports items an ingest could not write. A non-zero Count is not an
+// error: the batch landed without them.
 type Rejected struct {
 	Count int
-	// Reason is the store's message for the first item rejected. They are
-	// usually all the same fault, and one concrete message beats a bare count:
-	// "duplicate key" tells a sender that it is reusing ids.
+	// Reason is why the first one was refused, so a sender can act on it.
 	Reason error
 }
 
-// BisectingWrite writes as many of total items as it can, isolating the ones it
-// cannot.
+// BisectingWrite writes as many of total items as it can, retrying a failed
+// attempt in narrowing halves until each bad item is alone.
 //
-// # The problem it solves
+// A failed append discards its whole buffer, so without this one bad row costs
+// the entire batch. k bad items in n costs O(k log n) attempts; k of zero is a
+// single attempt, making this purely an error path.
 //
-// The appender path is all-or-nothing by construction. A constraint violation
-// is only detected when the appender flushes, and a failed flush discards its
-// entire buffer -- "appended and not yet flushed data has been invalidated".
-// So a single unwritable row used to cost the whole batch: 599 good spans
-// dropped because the 600th reused an id.
-//
-// # How
-//
-// Stop trusting a failure to be about the whole batch. Try all of it; if that
-// fails, try each half; recurse. n items containing k bad ones costs O(k log n)
-// attempts and lands the other n-k, while the common case -- k is zero -- is a
-// single attempt with no overhead whatsoever. This is purely an error path.
-//
-// Bisection rather than a row-by-row INSERT fallback because it reuses the
-// append path exactly as written, with no second copy of any column list to
-// drift out of sync, and because it does not care *why* an item failed.
-// Anything item-specific is isolated the same way. A fault that is not
-// item-specific -- a full disk -- fails every half down to single items and
-// surfaces as their rejection reason, which is the information the old code
-// returned anyway, minus the loss of everything alongside it.
-//
-// # The contract attempt must honour
-//
-// attempt(lo, hi) writes items [lo, hi) and must be atomic: on failure it has
-// to leave nothing behind, or the next attempt inherits rows it did not write.
-// In practice that means running inside InTransaction. Each attempt is its own
-// top-level transaction because DuckDB has neither nested transactions nor
-// SAVEPOINT, so a failed half cannot be unwound inside an enclosing one.
-//
-// # Why an ordinal range and not a set of ids
-//
-// Ranges are what bisection halves, and a set of ids cannot express "the second
-// half". Ordinals also keep two occurrences of a duplicated id separable, so
-// the first can be written and the second rejected -- which an id-keyed skip
-// set could not do. And an ordinal is an int, which is what lets this stay
-// signal-agnostic: it knows nothing of spans, logs, metrics or columns.
+// attempt(lo, hi) writes items [lo, hi) and must be atomic, or a failed try
+// leaves rows the next one did not write. Ranges rather than ids because
+// bisection halves ranges, and because two occurrences of one duplicated id
+// stay separable.
 func BisectingWrite(ctx context.Context, total int, attempt func(lo, hi int) error) (Rejected, error) {
 	var rejected Rejected
 
 	if total == 0 {
-		// Still attempt once. An empty batch has to behave exactly as it did
-		// before, including whatever the write path does with no rows.
 		return rejected, attempt(0, 0)
 	}
 
-	// Iterative rather than recursive so a pathological batch cannot exhaust
-	// the stack. Ranges still to try, taken newest-first.
+	// Iterative so a huge batch cannot exhaust the stack.
 	type window struct{ lo, hi int }
 	todo := []window{{0, total}}
 
@@ -112,21 +53,14 @@ func BisectingWrite(ctx context.Context, total int, attempt func(lo, hi int) err
 			continue
 		}
 
-		// A fault no row caused fails every half identically, so narrowing
-		// would blame each row in turn and report none of it as an error.
+		// Fails the same for every subset, so searching would blame innocents.
 		if errors.Is(err, ErrNotRowFault) {
 			return rejected, err
 		}
 
 		if w.hi-w.lo == 1 {
-			// Narrowed to one item and it still will not go in. This is the
-			// row the batch was being thrown away for.
-			//
-			// Unless the context just went away underneath it: a cancelled
-			// attempt says nothing about the row it happened to be carrying,
-			// and recording it would report a rejection for work that was
-			// never really tried. The loop head catches this too, but only
-			// after the count has already been taken.
+			// Narrowed to one item that still will not go in -- unless we were
+			// cancelled, which says nothing about the row it was carrying.
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return rejected, ctxErr
 			}
@@ -137,10 +71,9 @@ func BisectingWrite(ctx context.Context, total int, attempt func(lo, hi int) err
 			continue
 		}
 
+		// High half pushed first so the low half pops first, keeping items in
+		// order: the first occurrence of a duplicated id is the one that lands.
 		mid := w.lo + (w.hi-w.lo)/2
-		// High half pushed first so the low half is popped first, keeping
-		// items in their original order. That makes "the first occurrence of a
-		// duplicated id is the one that survives" true rather than incidental.
 		todo = append(todo, window{mid, w.hi}, window{w.lo, mid})
 	}
 

--- a/desktopexporter/internal/store/ingest/bisect.go
+++ b/desktopexporter/internal/store/ingest/bisect.go
@@ -1,0 +1,104 @@
+package ingest
+
+import "context"
+
+// Rejected reports how many items an ingest could not write.
+//
+// A non-zero count is not an error. The batch succeeded; some items in it did
+// not, and the caller is told how many so it can say so rather than leaving the
+// sender to guess why its telemetry never appeared.
+type Rejected struct {
+	Count int
+	// Reason is the store's message for the first item rejected. They are
+	// usually all the same fault, and one concrete message beats a bare count:
+	// "duplicate key" tells a sender that it is reusing ids.
+	Reason error
+}
+
+// BisectingWrite writes as many of total items as it can, isolating the ones it
+// cannot.
+//
+// # The problem it solves
+//
+// The appender path is all-or-nothing by construction. A constraint violation
+// is only detected when the appender flushes, and a failed flush discards its
+// entire buffer -- "appended and not yet flushed data has been invalidated".
+// So a single unwritable row used to cost the whole batch: 599 good spans
+// dropped because the 600th reused an id.
+//
+// # How
+//
+// Stop trusting a failure to be about the whole batch. Try all of it; if that
+// fails, try each half; recurse. n items containing k bad ones costs O(k log n)
+// attempts and lands the other n-k, while the common case -- k is zero -- is a
+// single attempt with no overhead whatsoever. This is purely an error path.
+//
+// Bisection rather than a row-by-row INSERT fallback because it reuses the
+// append path exactly as written, with no second copy of any column list to
+// drift out of sync, and because it does not care *why* an item failed.
+// Anything item-specific is isolated the same way. A fault that is not
+// item-specific -- a full disk -- fails every half down to single items and
+// surfaces as their rejection reason, which is the information the old code
+// returned anyway, minus the loss of everything alongside it.
+//
+// # The contract attempt must honour
+//
+// attempt(lo, hi) writes items [lo, hi) and must be atomic: on failure it has
+// to leave nothing behind, or the next attempt inherits rows it did not write.
+// In practice that means running inside InTransaction. Each attempt is its own
+// top-level transaction because DuckDB has neither nested transactions nor
+// SAVEPOINT, so a failed half cannot be unwound inside an enclosing one.
+//
+// # Why an ordinal range and not a set of ids
+//
+// Ranges are what bisection halves, and a set of ids cannot express "the second
+// half". Ordinals also keep two occurrences of a duplicated id separable, so
+// the first can be written and the second rejected -- which an id-keyed skip
+// set could not do. And an ordinal is an int, which is what lets this stay
+// signal-agnostic: it knows nothing of spans, logs, metrics or columns.
+func BisectingWrite(ctx context.Context, total int, attempt func(lo, hi int) error) (Rejected, error) {
+	var rejected Rejected
+
+	if total == 0 {
+		// Still attempt once. An empty batch has to behave exactly as it did
+		// before, including whatever the write path does with no rows.
+		return rejected, attempt(0, 0)
+	}
+
+	// Iterative rather than recursive so a pathological batch cannot exhaust
+	// the stack. Ranges still to try, taken newest-first.
+	type window struct{ lo, hi int }
+	todo := []window{{0, total}}
+
+	for len(todo) > 0 {
+		w := todo[len(todo)-1]
+		todo = todo[:len(todo)-1]
+
+		if err := ctx.Err(); err != nil {
+			return rejected, err
+		}
+
+		err := attempt(w.lo, w.hi)
+		if err == nil {
+			continue
+		}
+
+		if w.hi-w.lo == 1 {
+			// Narrowed to one item and it still will not go in. This is the
+			// row the batch was being thrown away for.
+			rejected.Count++
+			if rejected.Reason == nil {
+				rejected.Reason = err
+			}
+			continue
+		}
+
+		mid := w.lo + (w.hi-w.lo)/2
+		// High half pushed first so the low half is popped first, keeping
+		// items in their original order. That makes "the first occurrence of a
+		// duplicated id is the one that survives" true rather than incidental.
+		todo = append(todo, window{mid, w.hi}, window{w.lo, mid})
+	}
+
+	return rejected, nil
+}

--- a/desktopexporter/internal/store/ingest/bisect.go
+++ b/desktopexporter/internal/store/ingest/bisect.go
@@ -1,6 +1,35 @@
 package ingest
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// ErrNotRowFault marks a failure that no individual row caused, so bisection
+// must surface it rather than search for a culprit.
+//
+// # Why this has to be said explicitly
+//
+// BisectingWrite is a search, and it rests on one assumption: remove the guilty
+// item and the rest succeeds. That is true of a duplicate key and false of a
+// fault belonging to the operation itself, which fails identically for every
+// subset. Given one of those, the search does not report it -- it halves all
+// the way down, finds every single-row window failing, and returns "every row
+// was rejected" with a nil error. The same shape as `git bisect` handed a test
+// script that fails on every commit: it does not conclude the script is broken,
+// it names an innocent commit with total confidence.
+//
+// The stakes are highest for the checks that exist to be loud. The pass
+// mismatch guards in spans, logs and metrics fire when the two passes disagree
+// about how many items exist -- a bug in our own code, whose whole purpose is
+// to fail noisily instead of pairing every owner past that point with another
+// owner's attributes. Run through an unguarded bisection, that alarm becomes a
+// silent tally, and resilience machinery ends up eating the one error it was
+// most important to hear.
+//
+// Wrap with %w. Anything not wrapped is still treated as row-specific and
+// isolated, which is the right default for a fault we do not recognise.
+var ErrNotRowFault = errors.New("not attributable to any single row")
 
 // Rejected reports how many items an ingest could not write.
 //
@@ -83,9 +112,24 @@ func BisectingWrite(ctx context.Context, total int, attempt func(lo, hi int) err
 			continue
 		}
 
+		// A fault no row caused fails every half identically, so narrowing
+		// would blame each row in turn and report none of it as an error.
+		if errors.Is(err, ErrNotRowFault) {
+			return rejected, err
+		}
+
 		if w.hi-w.lo == 1 {
 			// Narrowed to one item and it still will not go in. This is the
 			// row the batch was being thrown away for.
+			//
+			// Unless the context just went away underneath it: a cancelled
+			// attempt says nothing about the row it happened to be carrying,
+			// and recording it would report a rejection for work that was
+			// never really tried. The loop head catches this too, but only
+			// after the count has already been taken.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return rejected, ctxErr
+			}
 			rejected.Count++
 			if rejected.Reason == nil {
 				rejected.Reason = err

--- a/desktopexporter/internal/store/ingest/bisect.go
+++ b/desktopexporter/internal/store/ingest/bisect.go
@@ -3,6 +3,8 @@ package ingest
 import (
 	"context"
 	"errors"
+	"maps"
+	"slices"
 )
 
 // ErrNotRowFault marks a failure no single row caused. BisectingWrite surfaces
@@ -10,12 +12,47 @@ import (
 // narrowing would blame each row in turn and return no error at all. Wrap with %w.
 var ErrNotRowFault = errors.New("not attributable to any single row")
 
-// Rejected reports items an ingest could not write. A non-zero Count is not an
-// error: the batch landed without them.
+// Rejection is one item an ingest would not write, identified by its ordinal in
+// the batch walk so the caller can find the payload again.
+type Rejection struct {
+	Ordinal int
+	Reason  error
+}
+
+// Rejected reports the items an ingest could not write, in walk order. A
+// non-empty Rejected is not an error: the batch landed without them.
+//
+// Both ways an item can be refused end up here, and only here. Rows skipped
+// before the write because the store already holds them, and rows bisection
+// discovered by failing, are the same kind of fact about the same batch, so a
+// caller counting or reporting them should not have to know which path found
+// it. Keeping two tallies meant the count came from one place and the reason
+// from another, and a batch refused for two different reasons described itself
+// with whichever one happened to be asked.
 type Rejected struct {
-	Count int
-	// Reason is why the first one was refused, so a sender can act on it.
-	Reason error
+	Items []Rejection
+}
+
+// Count is how many items were refused.
+func (r Rejected) Count() int { return len(r.Items) }
+
+// Reason is why the first refused item was refused, for a one-line summary.
+// Nil when nothing was refused.
+func (r Rejected) Reason() error {
+	if len(r.Items) == 0 {
+		return nil
+	}
+	return r.Items[0].Reason
+}
+
+// Reasons counts the distinct reasons, so a caller can say "412 already stored,
+// 1 constraint violation" rather than picking one and dropping the rest.
+func (r Rejected) Reasons() map[string]int {
+	out := map[string]int{}
+	for _, item := range r.Items {
+		out[item.Reason.Error()]++
+	}
+	return out
 }
 
 // BisectingWrite writes as many of total items as it can, retrying a failed
@@ -29,11 +66,26 @@ type Rejected struct {
 // leaves rows the next one did not write. Ranges rather than ids because
 // bisection halves ranges, and because two occurrences of one duplicated id
 // stay separable.
-func BisectingWrite(ctx context.Context, total int, attempt func(lo, hi int) error) (Rejected, error) {
-	var rejected Rejected
+// preRejected names items the caller already knows it will not write, keyed by
+// ordinal. They are recorded here rather than added by the caller afterwards so
+// that every rejection is built in one place and lands in walk order. attempt
+// is expected to skip them, which makes a range of nothing but pre-rejected
+// items succeed trivially -- so bisection never blames them either.
+func BisectingWrite(ctx context.Context, total int, preRejected map[int]error, attempt func(lo, hi int) error) (Rejected, error) {
+	discovered := make(map[int]error, len(preRejected))
+	maps.Copy(discovered, preRejected)
+
+	collect := func() Rejected {
+		ordinals := slices.Sorted(maps.Keys(discovered))
+		out := Rejected{Items: make([]Rejection, 0, len(ordinals))}
+		for _, o := range ordinals {
+			out.Items = append(out.Items, Rejection{Ordinal: o, Reason: discovered[o]})
+		}
+		return out
+	}
 
 	if total == 0 {
-		return rejected, attempt(0, 0)
+		return collect(), attempt(0, 0)
 	}
 
 	// Iterative so a huge batch cannot exhaust the stack.
@@ -45,7 +97,7 @@ func BisectingWrite(ctx context.Context, total int, attempt func(lo, hi int) err
 		todo = todo[:len(todo)-1]
 
 		if err := ctx.Err(); err != nil {
-			return rejected, err
+			return collect(), err
 		}
 
 		err := attempt(w.lo, w.hi)
@@ -55,19 +107,16 @@ func BisectingWrite(ctx context.Context, total int, attempt func(lo, hi int) err
 
 		// Fails the same for every subset, so searching would blame innocents.
 		if errors.Is(err, ErrNotRowFault) {
-			return rejected, err
+			return collect(), err
 		}
 
 		if w.hi-w.lo == 1 {
 			// Narrowed to one item that still will not go in -- unless we were
 			// cancelled, which says nothing about the row it was carrying.
 			if ctxErr := ctx.Err(); ctxErr != nil {
-				return rejected, ctxErr
+				return collect(), ctxErr
 			}
-			rejected.Count++
-			if rejected.Reason == nil {
-				rejected.Reason = err
-			}
+			discovered[w.lo] = err
 			continue
 		}
 
@@ -77,5 +126,5 @@ func BisectingWrite(ctx context.Context, total int, attempt func(lo, hi int) err
 		todo = append(todo, window{mid, w.hi}, window{w.lo, mid})
 	}
 
-	return rejected, nil
+	return collect(), nil
 }

--- a/desktopexporter/internal/store/ingest/bisect_test.go
+++ b/desktopexporter/internal/store/ingest/bisect_test.go
@@ -1,0 +1,115 @@
+package ingest_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/ingest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// attemptOver returns an attempt func that fails whenever its range contains
+// any of bad, which is how a row-specific fault actually behaves.
+func attemptOver(bad map[int]bool, attempts *int) func(lo, hi int) error {
+	return func(lo, hi int) error {
+		*attempts++
+		for i := lo; i < hi; i++ {
+			if bad[i] {
+				return fmt.Errorf("row %d is bad", i)
+			}
+		}
+		return nil
+	}
+}
+
+func TestBisectingWrite_CleanBatchCostsOneAttempt(t *testing.T) {
+	t.Parallel()
+	var attempts int
+	rep, err := ingest.BisectingWrite(t.Context(), 600, attemptOver(map[int]bool{}, &attempts))
+	require.NoError(t, err)
+	assert.Zero(t, rep.Count)
+	assert.Equal(t, 1, attempts, "the common case must not pay for the error path")
+}
+
+func TestBisectingWrite_IsolatesBadRows(t *testing.T) {
+	t.Parallel()
+	bad := map[int]bool{7: true, 293: true, 599: true}
+	var attempts int
+	rep, err := ingest.BisectingWrite(t.Context(), 600, attemptOver(bad, &attempts))
+	require.NoError(t, err, "row faults are reported, not returned")
+	assert.Equal(t, 3, rep.Count)
+	require.Error(t, rep.Reason)
+	assert.Less(t, attempts, 100, "should be O(k log n), nowhere near one attempt per row")
+}
+
+// A fault no row caused must come back as an error rather than being reported
+// as "every row was rejected".
+//
+// Without the sentinel this is the silent-corruption case: the guard that
+// exists to fail loudly fires identically in every half, bisection blames each
+// row in turn, and the call returns nil.
+func TestBisectingWrite_SurfacesFaultsNoRowCaused(t *testing.T) {
+	t.Parallel()
+	structural := fmt.Errorf("%w: pass mismatch (spans 4/5)", ingest.ErrNotRowFault)
+
+	var attempts int
+	rep, err := ingest.BisectingWrite(t.Context(), 600, func(lo, hi int) error {
+		attempts++
+		return structural
+	})
+
+	require.Error(t, err, "a structural fault must not be swallowed")
+	assert.ErrorIs(t, err, ingest.ErrNotRowFault)
+	assert.Contains(t, err.Error(), "pass mismatch", "the diagnosis must survive")
+	assert.Zero(t, rep.Count, "no row caused this, so no row should be blamed")
+	assert.Equal(t, 1, attempts, "it fails the same for every subset; do not search")
+}
+
+// Cancellation is not a property of whichever row the search happened to be
+// holding, so it must not be recorded as that row's rejection.
+func TestBisectingWrite_CancellationIsNotARejection(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// The cancel has to land on a single-row window specifically. Anywhere
+	// wider and the loop head catches it on the next pass; it is only at width
+	// one that the code is about to write the failure down as a rejection.
+	rep, err := ingest.BisectingWrite(ctx, 8, func(lo, hi int) error {
+		if hi-lo == 1 {
+			cancel()
+			return errors.New("interrupted")
+		}
+		return errors.New("force a split")
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Zero(t, rep.Count, "a cancelled attempt says nothing about its rows")
+}
+
+func TestBisectingWrite_EmptyBatchStillAttemptsOnce(t *testing.T) {
+	t.Parallel()
+	var attempts int
+	rep, err := ingest.BisectingWrite(t.Context(), 0, attemptOver(map[int]bool{}, &attempts))
+	require.NoError(t, err)
+	assert.Zero(t, rep.Count)
+	assert.Equal(t, 1, attempts)
+}
+
+// The first occurrence of a repeated identity is the one that survives, which
+// depends on ranges being attempted in order rather than incidentally.
+func TestBisectingWrite_AttemptsRangesInOrder(t *testing.T) {
+	t.Parallel()
+	var order []int
+	_, err := ingest.BisectingWrite(t.Context(), 4, func(lo, hi int) error {
+		if hi-lo == 1 {
+			order = append(order, lo)
+			return nil
+		}
+		return errors.New("force a split")
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []int{0, 1, 2, 3}, order)
+}

--- a/desktopexporter/internal/store/ingest/bisect_test.go
+++ b/desktopexporter/internal/store/ingest/bisect_test.go
@@ -28,9 +28,9 @@ func attemptOver(bad map[int]bool, attempts *int) func(lo, hi int) error {
 func TestBisectingWrite_CleanBatchCostsOneAttempt(t *testing.T) {
 	t.Parallel()
 	var attempts int
-	rep, err := ingest.BisectingWrite(t.Context(), 600, attemptOver(map[int]bool{}, &attempts))
+	rep, err := ingest.BisectingWrite(t.Context(), 600, nil, attemptOver(map[int]bool{}, &attempts))
 	require.NoError(t, err)
-	assert.Zero(t, rep.Count)
+	assert.Zero(t, rep.Count())
 	assert.Equal(t, 1, attempts, "the common case must not pay for the error path")
 }
 
@@ -38,10 +38,10 @@ func TestBisectingWrite_IsolatesBadRows(t *testing.T) {
 	t.Parallel()
 	bad := map[int]bool{7: true, 293: true, 599: true}
 	var attempts int
-	rep, err := ingest.BisectingWrite(t.Context(), 600, attemptOver(bad, &attempts))
+	rep, err := ingest.BisectingWrite(t.Context(), 600, nil, attemptOver(bad, &attempts))
 	require.NoError(t, err, "row faults are reported, not returned")
-	assert.Equal(t, 3, rep.Count)
-	require.Error(t, rep.Reason)
+	assert.Equal(t, 3, rep.Count())
+	require.Error(t, rep.Reason())
 	assert.Less(t, attempts, 100, "should be O(k log n), nowhere near one attempt per row")
 }
 
@@ -56,7 +56,7 @@ func TestBisectingWrite_SurfacesFaultsNoRowCaused(t *testing.T) {
 	structural := fmt.Errorf("%w: pass mismatch (spans 4/5)", ingest.ErrNotRowFault)
 
 	var attempts int
-	rep, err := ingest.BisectingWrite(t.Context(), 600, func(lo, hi int) error {
+	rep, err := ingest.BisectingWrite(t.Context(), 600, nil, func(lo, hi int) error {
 		attempts++
 		return structural
 	})
@@ -64,7 +64,7 @@ func TestBisectingWrite_SurfacesFaultsNoRowCaused(t *testing.T) {
 	require.Error(t, err, "a structural fault must not be swallowed")
 	assert.ErrorIs(t, err, ingest.ErrNotRowFault)
 	assert.Contains(t, err.Error(), "pass mismatch", "the diagnosis must survive")
-	assert.Zero(t, rep.Count, "no row caused this, so no row should be blamed")
+	assert.Zero(t, rep.Count(), "no row caused this, so no row should be blamed")
 	assert.Equal(t, 1, attempts, "it fails the same for every subset; do not search")
 }
 
@@ -77,7 +77,7 @@ func TestBisectingWrite_CancellationIsNotARejection(t *testing.T) {
 	// The cancel has to land on a single-row window specifically. Anywhere
 	// wider and the loop head catches it on the next pass; it is only at width
 	// one that the code is about to write the failure down as a rejection.
-	rep, err := ingest.BisectingWrite(ctx, 8, func(lo, hi int) error {
+	rep, err := ingest.BisectingWrite(ctx, 8, nil, func(lo, hi int) error {
 		if hi-lo == 1 {
 			cancel()
 			return errors.New("interrupted")
@@ -86,15 +86,15 @@ func TestBisectingWrite_CancellationIsNotARejection(t *testing.T) {
 	})
 
 	require.ErrorIs(t, err, context.Canceled)
-	assert.Zero(t, rep.Count, "a cancelled attempt says nothing about its rows")
+	assert.Zero(t, rep.Count(), "a cancelled attempt says nothing about its rows")
 }
 
 func TestBisectingWrite_EmptyBatchStillAttemptsOnce(t *testing.T) {
 	t.Parallel()
 	var attempts int
-	rep, err := ingest.BisectingWrite(t.Context(), 0, attemptOver(map[int]bool{}, &attempts))
+	rep, err := ingest.BisectingWrite(t.Context(), 0, nil, attemptOver(map[int]bool{}, &attempts))
 	require.NoError(t, err)
-	assert.Zero(t, rep.Count)
+	assert.Zero(t, rep.Count())
 	assert.Equal(t, 1, attempts)
 }
 
@@ -103,7 +103,7 @@ func TestBisectingWrite_EmptyBatchStillAttemptsOnce(t *testing.T) {
 func TestBisectingWrite_AttemptsRangesInOrder(t *testing.T) {
 	t.Parallel()
 	var order []int
-	_, err := ingest.BisectingWrite(t.Context(), 4, func(lo, hi int) error {
+	_, err := ingest.BisectingWrite(t.Context(), 4, nil, func(lo, hi int) error {
 		if hi-lo == 1 {
 			order = append(order, lo)
 			return nil
@@ -112,4 +112,50 @@ func TestBisectingWrite_AttemptsRangesInOrder(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []int{0, 1, 2, 3}, order)
+}
+
+// Both ways an item can be refused arrive through the same list, in walk order.
+//
+// Pre-rejected items used to be tallied on by the caller after the fact, so a
+// batch refused for two different reasons reported the count from one place and
+// the reason from the other -- and neither recorded which items they were.
+func TestBisectingWrite_PreRejectedAndDiscoveredMergeInOrder(t *testing.T) {
+	t.Parallel()
+	preRejected := map[int]error{1: errAlready, 5: errAlready}
+
+	rep, err := ingest.BisectingWrite(t.Context(), 8, preRejected, func(lo, hi int) error {
+		// Pre-rejected items are skipped by the caller's own predicate, so a
+		// range containing only those succeeds. Item 6 is genuinely bad.
+		for i := lo; i < hi; i++ {
+			if _, skipped := preRejected[i]; skipped {
+				continue
+			}
+			if i == 6 {
+				return errBad
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, rep.Count())
+	assert.Equal(t, []int{1, 5, 6}, ordinalsOf(rep), "walk order, regardless of which path found them")
+	assert.ErrorIs(t, rep.Items[0].Reason, errAlready)
+	assert.ErrorIs(t, rep.Items[2].Reason, errBad)
+
+	// Every reason is kept, not just whichever was asked for first.
+	assert.Equal(t, map[string]int{errAlready.Error(): 2, errBad.Error(): 1}, rep.Reasons())
+}
+
+var (
+	errAlready = errors.New("already stored")
+	errBad     = errors.New("constraint violation")
+)
+
+func ordinalsOf(r ingest.Rejected) []int {
+	out := make([]int, 0, len(r.Items))
+	for _, item := range r.Items {
+		out = append(out, item.Ordinal)
+	}
+	return out
 }

--- a/desktopexporter/internal/store/ingest/rejections.go
+++ b/desktopexporter/internal/store/ingest/rejections.go
@@ -1,0 +1,111 @@
+package ingest
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql/driver"
+	"fmt"
+	"time"
+
+	"github.com/duckdb/duckdb-go/v2"
+)
+
+// Kinds of rejection. The string is stored and shown, so it is part of the
+// contract rather than an internal label.
+const (
+	KindAlreadyStored = "span_already_stored"
+	KindRefused       = "span_refused"
+)
+
+// RejectionRecord is one (signal, kind) tally to write.
+type RejectionRecord struct {
+	Signal string
+	Kind   string
+	Count  int
+	// Sample is an id from the most recent occurrence, for the UI to link to.
+	// Empty when the refused row is not in the store and nothing can be linked.
+	Sample string
+}
+
+// rejectionID is sha256(signal, kind) truncated to a uuid, so the upsert finds
+// its row by primary key and the same fault from two senders shares one row.
+func rejectionID(signal, kind string) duckdb.UUID {
+	sum := sha256.Sum256([]byte(signal + "\x00" + kind))
+	var id [16]byte
+	copy(id[:], sum[:16])
+	return duckdb.UUID(id)
+}
+
+// RecordRejections tallies refused telemetry, one row per (signal, kind).
+//
+// Called after the append pass has committed, never inside it: a rejection is a
+// fact about a batch that succeeded, and rolling it back with a failed attempt
+// would lose the only record that anything was refused.
+func RecordRejections(ctx context.Context, conn driver.Conn, records []RejectionRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	dconn, ok := conn.(*duckdb.Conn)
+	if !ok {
+		return fmt.Errorf("RecordRejections: %w: connection is not a *duckdb.Conn", ErrIngestInternal)
+	}
+
+	const q = `insert into ingest_rejections
+			(id, signal, kind, sample, first_seen, last_seen, occurrences)
+		values (?::uuid, ?, ?, ?, ?, ?, ?)
+		on conflict (id) do update set
+			last_seen   = excluded.last_seen,
+			occurrences = ingest_rejections.occurrences + excluded.occurrences,
+			sample      = coalesce(excluded.sample, ingest_rejections.sample)`
+
+	now := time.Now().UnixNano()
+	for _, r := range records {
+		if r.Count <= 0 {
+			continue
+		}
+		var sample any
+		if r.Sample != "" {
+			sample = r.Sample
+		}
+		id := rejectionID(r.Signal, r.Kind)
+		args := []any{
+			id.String(),
+			r.Signal, r.Kind, sample, now, now, int64(r.Count),
+		}
+		named, err := prepareNamedValues(dconn, args)
+		if err != nil {
+			return fmt.Errorf("RecordRejections: %w: %w", ErrIngestInternal, err)
+		}
+		if _, err := dconn.ExecContext(ctx, q, named); err != nil {
+			return fmt.Errorf("RecordRejections: %w: %w", ErrIngestInternal, err)
+		}
+	}
+	return nil
+}
+
+// Tally folds a Rejected into one record per kind, carrying the last sample
+// seen for each. sampleFor turns an ordinal into a linkable id, and may return
+// "" when the refused row is not in the store.
+func Tally(signal string, r Rejected, kindFor func(error) string, sampleFor func(ordinal int) string) []RejectionRecord {
+	byKind := map[string]*RejectionRecord{}
+	order := []string{}
+	for _, item := range r.Items {
+		kind := kindFor(item.Reason)
+		rec, ok := byKind[kind]
+		if !ok {
+			rec = &RejectionRecord{Signal: signal, Kind: kind}
+			byKind[kind] = rec
+			order = append(order, kind)
+		}
+		rec.Count++
+		if s := sampleFor(item.Ordinal); s != "" {
+			rec.Sample = s
+		}
+	}
+	out := make([]RejectionRecord, 0, len(order))
+	for _, kind := range order {
+		out = append(out, *byKind[kind])
+	}
+	return out
+}

--- a/desktopexporter/internal/store/ingest/transaction.go
+++ b/desktopexporter/internal/store/ingest/transaction.go
@@ -1,0 +1,72 @@
+package ingest
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+)
+
+// InTransaction runs fn inside a DuckDB transaction on conn, committing when it
+// returns nil and rolling back otherwise.
+//
+// # Why ingest needs this rather than a transaction around the whole call
+//
+// The appenders flush every flushIntervalSpans rows, and every flush is a
+// commit of its own unless something holds them together. So a batch bigger
+// than one flush interval that failed later left everything before the last
+// boundary durable while the call reported failure. The collector then retried
+// the whole batch, whose early rows now collided with the copies already kept,
+// and the retry failed for a reason the first attempt created -- a batch that
+// can never succeed.
+//
+// Appenders honour a transaction opened on their own connection: flush inside
+// one, roll back, and no rows remain.
+//
+// # Why the boundary lives here and not around the whole ingest
+//
+// A failed append pass is retried in narrowing halves to find the rows that
+// caused it, and each attempt has to be able to fail without poisoning the
+// next. DuckDB offers no way to do that inside an enclosing transaction --
+// `begin` within a transaction is "cannot start a transaction within a
+// transaction", and SAVEPOINT is not implemented at all -- so every attempt
+// must be its own top-level transaction. Wrapping the whole ingest would make
+// bisection impossible.
+//
+// # Why the dictionary flush stays outside
+//
+// Dictionary rows are written with `on conflict do nothing` and are reachable
+// only through the owner rows that reference them, so committing them for a
+// batch that later fails leaves nothing worse than rows SweepOrphans already
+// exists to collect. Keeping them out of the transaction also keeps FlushedIDs
+// honest: it marks ids as written the moment their insert succeeds, and a
+// rollback that unmade those inserts would leave it claiming rows that no
+// longer exist -- the next batch would skip re-inserting them and its owners
+// would carry uuid[] references into nothing, which no foreign key catches.
+func InTransaction(ctx context.Context, conn driver.Conn, fn func() error) (err error) {
+	exec, ok := conn.(driver.ExecerContext)
+	if !ok {
+		return fmt.Errorf("InTransaction: %w: connection cannot execute statements", ErrIngestInternal)
+	}
+
+	if _, err := exec.ExecContext(ctx, "begin transaction", nil); err != nil {
+		return fmt.Errorf("InTransaction: %w: begin: %w", ErrIngestInternal, err)
+	}
+
+	defer func() {
+		if err != nil {
+			// Rollback runs even when ctx is already done: the context that
+			// cancelled the work must not also abandon the transaction, or the
+			// connection stays wedged for every batch after this one.
+			if _, rbErr := exec.ExecContext(context.WithoutCancel(ctx), "rollback", nil); rbErr != nil {
+				err = errors.Join(err, fmt.Errorf("InTransaction: rollback: %w", rbErr))
+			}
+			return
+		}
+		if _, cErr := exec.ExecContext(ctx, "commit", nil); cErr != nil {
+			err = fmt.Errorf("InTransaction: %w: commit: %w", ErrIngestInternal, cErr)
+		}
+	}()
+
+	return fn()
+}

--- a/desktopexporter/internal/store/ingest/transaction.go
+++ b/desktopexporter/internal/store/ingest/transaction.go
@@ -7,42 +7,21 @@ import (
 	"fmt"
 )
 
-// InTransaction runs fn inside a DuckDB transaction on conn, committing when it
-// returns nil and rolling back otherwise.
+// InTransaction runs fn inside a DuckDB transaction on conn, committing on nil
+// and rolling back otherwise.
 //
-// # Why ingest needs this rather than a transaction around the whole call
+// Appenders commit at every flush unless something holds them together, so
+// without this a batch that failed after its first flush left earlier rows
+// durable -- and the sender's retry then collided with them. Appenders honour a
+// transaction on their own connection.
 //
-// The appenders flush every flushIntervalSpans rows, and every flush is a
-// commit of its own unless something holds them together. So a batch bigger
-// than one flush interval that failed later left everything before the last
-// boundary durable while the call reported failure. The collector then retried
-// the whole batch, whose early rows now collided with the copies already kept,
-// and the retry failed for a reason the first attempt created -- a batch that
-// can never succeed.
+// The boundary is per attempt rather than around the whole ingest because
+// bisection retries need to fail independently, and DuckDB has no nested
+// transactions and no SAVEPOINT.
 //
-// Appenders honour a transaction opened on their own connection: flush inside
-// one, roll back, and no rows remain.
-//
-// # Why the boundary lives here and not around the whole ingest
-//
-// A failed append pass is retried in narrowing halves to find the rows that
-// caused it, and each attempt has to be able to fail without poisoning the
-// next. DuckDB offers no way to do that inside an enclosing transaction --
-// `begin` within a transaction is "cannot start a transaction within a
-// transaction", and SAVEPOINT is not implemented at all -- so every attempt
-// must be its own top-level transaction. Wrapping the whole ingest would make
-// bisection impossible.
-//
-// # Why the dictionary flush stays outside
-//
-// Dictionary rows are written with `on conflict do nothing` and are reachable
-// only through the owner rows that reference them, so committing them for a
-// batch that later fails leaves nothing worse than rows SweepOrphans already
-// exists to collect. Keeping them out of the transaction also keeps FlushedIDs
-// honest: it marks ids as written the moment their insert succeeds, and a
-// rollback that unmade those inserts would leave it claiming rows that no
-// longer exist -- the next batch would skip re-inserting them and its owners
-// would carry uuid[] references into nothing, which no foreign key catches.
+// The dictionary flush stays outside: its rows are written on-conflict-do-
+// nothing and swept if orphaned, and rolling them back would leave FlushedIDs
+// claiming rows that no longer exist.
 func InTransaction(ctx context.Context, conn driver.Conn, fn func() error) (err error) {
 	exec, ok := conn.(driver.ExecerContext)
 	if !ok {
@@ -53,19 +32,10 @@ func InTransaction(ctx context.Context, conn driver.Conn, fn func() error) (err 
 		return fmt.Errorf("InTransaction: %w: begin: %w", ErrIngestInternal, err)
 	}
 
-	// Closing a transaction ignores cancellation, in both directions.
-	//
-	// Ingest owns one connection for the life of the process, so a transaction
-	// left open does not fail one batch -- it fails every batch after it, with
-	// "cannot start a transaction within a transaction", and that `begin`
-	// returns early without ever reaching a rollback. The wedge is permanent
-	// until restart.
-	//
-	// Cancellation can arrive at either end. A cancelled ctx must not abandon
-	// the rollback, and it must not abandon the commit either: by then fn has
-	// already succeeded and the rows are written, so refusing to commit buys
-	// nothing and leaves the transaction open on a context error. The work is
-	// finished; closing the books is not optional.
+	// Closing ignores cancellation at both ends. Ingest owns one connection for
+	// the life of the process, so a transaction left open fails every later
+	// batch with "cannot start a transaction within a transaction" -- and that
+	// begin returns before reaching any rollback, so nothing recovers it.
 	closeCtx := context.WithoutCancel(ctx)
 
 	defer func() {
@@ -77,9 +47,7 @@ func InTransaction(ctx context.Context, conn driver.Conn, fn func() error) (err 
 		}
 		if _, cErr := exec.ExecContext(closeCtx, "commit", nil); cErr != nil {
 			err = fmt.Errorf("InTransaction: %w: commit: %w", ErrIngestInternal, cErr)
-			// A commit that failed may or may not have closed the transaction.
-			// Rolling back is harmless when it did and essential when it did
-			// not, and either way this is the last chance to close it.
+			// Harmless if the failed commit already closed it, essential if not.
 			if _, rbErr := exec.ExecContext(closeCtx, "rollback", nil); rbErr != nil {
 				err = errors.Join(err, fmt.Errorf("InTransaction: rollback after failed commit: %w", rbErr))
 			}

--- a/desktopexporter/internal/store/ingest/transaction.go
+++ b/desktopexporter/internal/store/ingest/transaction.go
@@ -53,18 +53,36 @@ func InTransaction(ctx context.Context, conn driver.Conn, fn func() error) (err 
 		return fmt.Errorf("InTransaction: %w: begin: %w", ErrIngestInternal, err)
 	}
 
+	// Closing a transaction ignores cancellation, in both directions.
+	//
+	// Ingest owns one connection for the life of the process, so a transaction
+	// left open does not fail one batch -- it fails every batch after it, with
+	// "cannot start a transaction within a transaction", and that `begin`
+	// returns early without ever reaching a rollback. The wedge is permanent
+	// until restart.
+	//
+	// Cancellation can arrive at either end. A cancelled ctx must not abandon
+	// the rollback, and it must not abandon the commit either: by then fn has
+	// already succeeded and the rows are written, so refusing to commit buys
+	// nothing and leaves the transaction open on a context error. The work is
+	// finished; closing the books is not optional.
+	closeCtx := context.WithoutCancel(ctx)
+
 	defer func() {
 		if err != nil {
-			// Rollback runs even when ctx is already done: the context that
-			// cancelled the work must not also abandon the transaction, or the
-			// connection stays wedged for every batch after this one.
-			if _, rbErr := exec.ExecContext(context.WithoutCancel(ctx), "rollback", nil); rbErr != nil {
+			if _, rbErr := exec.ExecContext(closeCtx, "rollback", nil); rbErr != nil {
 				err = errors.Join(err, fmt.Errorf("InTransaction: rollback: %w", rbErr))
 			}
 			return
 		}
-		if _, cErr := exec.ExecContext(ctx, "commit", nil); cErr != nil {
+		if _, cErr := exec.ExecContext(closeCtx, "commit", nil); cErr != nil {
 			err = fmt.Errorf("InTransaction: %w: commit: %w", ErrIngestInternal, cErr)
+			// A commit that failed may or may not have closed the transaction.
+			// Rolling back is harmless when it did and essential when it did
+			// not, and either way this is the last chance to close it.
+			if _, rbErr := exec.ExecContext(closeCtx, "rollback", nil); rbErr != nil {
+				err = errors.Join(err, fmt.Errorf("InTransaction: rollback after failed commit: %w", rbErr))
+			}
 		}
 	}()
 

--- a/desktopexporter/internal/store/ingest/transaction_test.go
+++ b/desktopexporter/internal/store/ingest/transaction_test.go
@@ -1,0 +1,98 @@
+package ingest_test
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"testing"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/ingest"
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/storetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A transaction must close even when the context that carried it is already
+// cancelled, at either end.
+//
+// Ingest owns one connection for the life of the process, so a transaction left
+// open does not cost one batch -- it costs every batch after it, because the
+// next `begin` fails with "cannot start a transaction within a transaction" and
+// returns before reaching any rollback. Nothing recovers that short of a
+// restart, which is why both the commit and the rollback ignore cancellation.
+func TestInTransaction_CancelDuringCommitDoesNotWedgeTheConnection(t *testing.T) {
+	t.Parallel()
+	s, _ := storetest.New(t)
+
+	err := s.WithConn(func(conn driver.Conn) error {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// fn succeeds, then the context dies before the deferred commit runs --
+		// the window where a commit bound to ctx would refuse to close the
+		// transaction it had already earned.
+		txErr := ingest.InTransaction(ctx, conn, func() error {
+			cancel()
+			return nil
+		})
+		require.NoError(t, txErr, "a cancel after the work is done must not fail the commit")
+
+		// The proof: another transaction can still be opened on this
+		// connection. Before the fix this failed permanently.
+		return ingest.InTransaction(context.Background(), conn, func() error { return nil })
+	})
+	require.NoError(t, err, "the connection must still be usable")
+}
+
+// The same at the other end: a cancelled batch rolls back rather than leaving
+// its transaction open.
+func TestInTransaction_CancelledWorkStillClosesTheTransaction(t *testing.T) {
+	t.Parallel()
+	s, _ := storetest.New(t)
+
+	sentinel := errors.New("work failed")
+
+	err := s.WithConn(func(conn driver.Conn) error {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Cancelled while the work is in flight, which is where a real
+		// shutdown lands: begin has already succeeded, so there is an open
+		// transaction that the cancelled context must not walk away from.
+		txErr := ingest.InTransaction(ctx, conn, func() error {
+			cancel()
+			return sentinel
+		})
+		require.ErrorIs(t, txErr, sentinel)
+
+		return ingest.InTransaction(context.Background(), conn, func() error { return nil })
+	})
+	require.NoError(t, err)
+}
+
+// Rolling back really does discard the work, rather than the transaction
+// having been closed early by something else.
+func TestInTransaction_RollbackDiscardsWrites(t *testing.T) {
+	t.Parallel()
+	s, ctx := storetest.New(t)
+
+	sentinel := errors.New("boom")
+	err := s.WithConn(func(conn driver.Conn) error {
+		txErr := ingest.InTransaction(ctx, conn, func() error {
+			exec := conn.(driver.ExecerContext)
+			if _, e := exec.ExecContext(ctx,
+				`insert into resources (id, attribute_ids) values (gen_random_uuid(), [])`, nil); e != nil {
+				return e
+			}
+			return sentinel
+		})
+		require.ErrorIs(t, txErr, sentinel)
+		return nil
+	})
+	require.NoError(t, err)
+
+	var n int
+	require.NoError(t, s.WithDBRead(func(db *sql.DB) error {
+		return db.QueryRowContext(ctx, "select count(*) from resources").Scan(&n)
+	}))
+	assert.Zero(t, n, "a rolled-back write must leave nothing behind")
+}

--- a/desktopexporter/internal/store/logs/logs.go
+++ b/desktopexporter/internal/store/logs/logs.go
@@ -59,8 +59,7 @@ var (
 // trade for a desktop tool sharing RAM with the user's actual work.
 const flushIntervalLogs = 500
 
-// scopeKey identifies a scope by its position in the batch: the ri'th
-// resource's si'th scope.
+// scopeKey identifies a scope by position: the ri'th resource's si'th scope.
 type scopeKey struct{ ri, si int }
 
 // Ingest ingests log records from pdata into the logs table.
@@ -109,8 +108,7 @@ func IngestReport(ctx context.Context, conn driver.Conn, logs plog.Logs, flushed
 		return ingest.Rejected{}, fmt.Errorf("Ingest: %w: %w", ErrLogsStoreInternal, err)
 	}
 
-	// Pass 2: append, retrying in narrowing halves so one unwritable record
-	// costs its own place in the batch rather than everyone else's.
+	// Pass 2: append, retrying in halves so a bad record costs only itself.
 	return ingest.BisectingWrite(ctx, len(logAttrs), func(lo, hi int) error {
 		return ingest.InTransaction(ctx, conn, func() error {
 			return appendPass(ctx, conn, logs, resourceIDs, scopeIDs, logAttrs,
@@ -119,12 +117,8 @@ func IngestReport(ctx context.Context, conn driver.Conn, logs plog.Logs, flushed
 	})
 }
 
-// appendPass writes the log rows keep says to write.
-//
-// keep is indexed by the record's ordinal in the walk, not by any id: ordinals
-// are what bisection halves, and they keep two occurrences of a repeated
-// identity separable. A skipped record still advances the cursor, because
-// logAttrs is consumed by position and pass 1 filled it for every record.
+// appendPass writes the records keep selects, by ordinal. Skipped records
+// still advance logCur, which is consumed by position.
 func appendPass(
 	ctx context.Context,
 	conn driver.Conn,
@@ -162,7 +156,7 @@ func appendPass(
 				}
 
 				if !keep(logCur) {
-					logCur++ // consumed by position, so still step over it
+					logCur++
 					continue
 				}
 
@@ -221,8 +215,7 @@ func appendPass(
 	// The two passes must have visited the same logs; a divergence would pair
 	// each record past that point with another record's attributes, silently.
 	if logCur != len(logAttrs) {
-		// ErrNotRowFault: a fault in this code, identical for every subset,
-		// so bisection must surface it instead of blaming rows.
+		// ErrNotRowFault: our bug, not a row's, so bisection must not search.
 		return fmt.Errorf("Ingest: %w: %w: pass mismatch (logs %d/%d)",
 			ErrLogsStoreInternal, ingest.ErrNotRowFault, logCur, len(logAttrs))
 	}

--- a/desktopexporter/internal/store/logs/logs.go
+++ b/desktopexporter/internal/store/logs/logs.go
@@ -221,8 +221,10 @@ func appendPass(
 	// The two passes must have visited the same logs; a divergence would pair
 	// each record past that point with another record's attributes, silently.
 	if logCur != len(logAttrs) {
-		return fmt.Errorf("Ingest: %w: pass mismatch (logs %d/%d)",
-			ErrLogsStoreInternal, logCur, len(logAttrs))
+		// ErrNotRowFault: a fault in this code, identical for every subset,
+		// so bisection must surface it instead of blaming rows.
+		return fmt.Errorf("Ingest: %w: %w: pass mismatch (logs %d/%d)",
+			ErrLogsStoreInternal, ingest.ErrNotRowFault, logCur, len(logAttrs))
 	}
 
 	return nil

--- a/desktopexporter/internal/store/logs/logs.go
+++ b/desktopexporter/internal/store/logs/logs.go
@@ -109,7 +109,7 @@ func IngestReport(ctx context.Context, conn driver.Conn, logs plog.Logs, flushed
 	}
 
 	// Pass 2: append, retrying in halves so a bad record costs only itself.
-	return ingest.BisectingWrite(ctx, len(logAttrs), func(lo, hi int) error {
+	return ingest.BisectingWrite(ctx, len(logAttrs), nil, func(lo, hi int) error {
 		return ingest.InTransaction(ctx, conn, func() error {
 			return appendPass(ctx, conn, logs, resourceIDs, scopeIDs, logAttrs,
 				func(ordinal int) bool { return ordinal >= lo && ordinal < hi })

--- a/desktopexporter/internal/store/logs/logs.go
+++ b/desktopexporter/internal/store/logs/logs.go
@@ -59,20 +59,33 @@ var (
 // trade for a desktop tool sharing RAM with the user's actual work.
 const flushIntervalLogs = 500
 
+// scopeKey identifies a scope by its position in the batch: the ri'th
+// resource's si'th scope.
+type scopeKey struct{ ri, si int }
+
 // Ingest ingests log records from pdata into the logs table.
 // The caller must hold any required lock on the connection.
 //
 // Two passes, matching spans.Ingest: hash and resolve resource/scope
 // identities, flush the dictionary, then append the log rows with the id
 // arrays. See spans.Ingest for why the dictionary cannot ride the appender.
-func Ingest(ctx context.Context, conn driver.Conn, logs plog.Logs, flushed *ingest.FlushedIDs) (err error) {
+// Ingest is IngestReport for callers with nowhere to put the report. Records
+// the store refused are still skipped rather than failing the batch; this form
+// just cannot say how many there were.
+func Ingest(ctx context.Context, conn driver.Conn, logs plog.Logs, flushed *ingest.FlushedIDs) error {
+	_, err := IngestReport(ctx, conn, logs, flushed)
+	return err
+}
+
+// IngestReport ingests a batch and reports the records it could not write. A
+// non-empty Rejected is not a failure: the batch landed, minus those rows.
+func IngestReport(ctx context.Context, conn driver.Conn, logs plog.Logs, flushed *ingest.FlushedIDs) (ingest.Rejected, error) {
 	if err := ctx.Err(); err != nil {
-		return err
+		return ingest.Rejected{}, err
 	}
 
 	// Pass 1: dictionary.
 	dict := ingest.NewDictionary(flushed)
-	type scopeKey struct{ ri, si int }
 	resourceIDs := map[int]duckdb.UUID{}
 	scopeIDs := map[scopeKey]duckdb.UUID{}
 
@@ -93,10 +106,34 @@ func Ingest(ctx context.Context, conn driver.Conn, logs plog.Logs, flushed *inge
 	}
 
 	if err := dict.Flush(ctx, conn); err != nil {
-		return fmt.Errorf("Ingest: %w: %w", ErrLogsStoreInternal, err)
+		return ingest.Rejected{}, fmt.Errorf("Ingest: %w: %w", ErrLogsStoreInternal, err)
 	}
 
-	// Pass 2: append.
+	// Pass 2: append, retrying in narrowing halves so one unwritable record
+	// costs its own place in the batch rather than everyone else's.
+	return ingest.BisectingWrite(ctx, len(logAttrs), func(lo, hi int) error {
+		return ingest.InTransaction(ctx, conn, func() error {
+			return appendPass(ctx, conn, logs, resourceIDs, scopeIDs, logAttrs,
+				func(ordinal int) bool { return ordinal >= lo && ordinal < hi })
+		})
+	})
+}
+
+// appendPass writes the log rows keep says to write.
+//
+// keep is indexed by the record's ordinal in the walk, not by any id: ordinals
+// are what bisection halves, and they keep two occurrences of a repeated
+// identity separable. A skipped record still advances the cursor, because
+// logAttrs is consumed by position and pass 1 filled it for every record.
+func appendPass(
+	ctx context.Context,
+	conn driver.Conn,
+	logs plog.Logs,
+	resourceIDs map[int]duckdb.UUID,
+	scopeIDs map[scopeKey]duckdb.UUID,
+	logAttrs [][]duckdb.UUID,
+	keep func(ordinal int) bool,
+) (err error) {
 	tables := []string{"logs"}
 	appenders, err := ingest.NewAppenders(conn, tables)
 	if err != nil {
@@ -122,6 +159,11 @@ func Ingest(ctx context.Context, conn driver.Conn, logs plog.Logs, flushed *inge
 			for _, log := range scopeLogs.LogRecords().All() {
 				if err := ctx.Err(); err != nil {
 					return err
+				}
+
+				if !keep(logCur) {
+					logCur++ // consumed by position, so still step over it
+					continue
 				}
 
 				var traceUUID *duckdb.UUID

--- a/desktopexporter/internal/store/metrics/metrics.go
+++ b/desktopexporter/internal/store/metrics/metrics.go
@@ -306,7 +306,7 @@ func IngestReport(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flus
 		return ingest.Rejected{}, err
 	}
 	// Pass 2: append, retrying in halves so a bad metric costs only itself.
-	return ingest.BisectingWrite(ctx, countMetrics(m), func(lo, hi int) error {
+	return ingest.BisectingWrite(ctx, countMetrics(m), nil, func(lo, hi int) error {
 		return ingest.InTransaction(ctx, conn, func() error {
 			return appendPass(ctx, conn, m, streamIDs, resourceIDs, scopeIDs, dpIdents,
 				func(ordinal int) bool { return ordinal >= lo && ordinal < hi })

--- a/desktopexporter/internal/store/metrics/metrics.go
+++ b/desktopexporter/internal/store/metrics/metrics.go
@@ -32,14 +32,12 @@ var (
 // the others.
 const flushIntervalMetrics = 100
 
-// scopeKey identifies a scope by its position in the batch: the ri'th
-// resource's si'th scope.
+// scopeKey identifies a scope by position: the ri'th resource's si'th scope.
 type scopeKey struct{ ri, si int }
 
-// countMetrics is the number of metrics in the batch, which is the unit
-// bisection blames and the unit flushIntervalMetrics already counts. Walked
-// rather than taken from pass 1's coords, which skips identities it cannot
-// resolve and so would not line up with pass 2's ordinals.
+// countMetrics counts metrics, the unit bisection blames. Walked rather than
+// read from pass 1's coords, which skips unresolvable identities and so would
+// not line up with pass 2's ordinals.
 func countMetrics(m pmetric.Metrics) int {
 	n := 0
 	for _, rm := range m.ResourceMetrics().All() {
@@ -50,9 +48,8 @@ func countMetrics(m pmetric.Metrics) int {
 	return n
 }
 
-// metricDatapointCount mirrors the type switch in appendPass exactly. A metric
-// that pass skips still has to step dpCur over its datapoints, and a type the
-// switch does not write contributes none.
+// metricDatapointCount mirrors appendPass's type switch, so a skipped metric
+// steps dpCur over exactly the datapoints that pass would have written.
 func metricDatapointCount(metric pmetric.Metric) int {
 	switch metric.Type() {
 	case pmetric.MetricTypeGauge:
@@ -308,8 +305,7 @@ func IngestReport(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flus
 	if err := insertSeries(ctx, dconn, prepareArg, seriesRows); err != nil {
 		return ingest.Rejected{}, err
 	}
-	// Pass 2: append, retrying in narrowing halves so one unwritable metric
-	// costs its own place in the batch rather than everyone else's.
+	// Pass 2: append, retrying in halves so a bad metric costs only itself.
 	return ingest.BisectingWrite(ctx, countMetrics(m), func(lo, hi int) error {
 		return ingest.InTransaction(ctx, conn, func() error {
 			return appendPass(ctx, conn, m, streamIDs, resourceIDs, scopeIDs, dpIdents,
@@ -318,11 +314,8 @@ func IngestReport(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flus
 	})
 }
 
-// appendPass writes the metric rows keep says to write.
-//
-// keep is indexed by the metric's ordinal in the walk. A skipped metric still
-// steps dpCur over its datapoints, because dpIdents is consumed by position and
-// collectSeries filled it for every metric whether or not this pass writes it.
+// appendPass writes the metrics keep selects, by ordinal. Skipped metrics still
+// step dpCur over their datapoints, since dpIdents is consumed by position.
 func appendPass(
 	ctx context.Context,
 	conn driver.Conn,
@@ -361,8 +354,6 @@ func appendPass(
 				ordinal := metricOrdinal
 				metricOrdinal++
 				if !keep(ordinal) {
-					// dpIdents is consumed by position, so a metric this pass
-					// declines to write still has to be stepped over.
 					dpCur += metricDatapointCount(metric)
 					continue
 				}
@@ -426,8 +417,7 @@ func appendPass(
 	// same order. A divergence would file every point past it under another
 	// series -- wrong lines on a chart, with no error anywhere.
 	if dpCur != len(dpIdents) {
-		// ErrNotRowFault: a fault in this code, identical for every subset,
-		// so bisection must surface it instead of blaming metrics.
+		// ErrNotRowFault: our bug, not a row's, so bisection must not search.
 		return fmt.Errorf("Ingest: %w: %w: datapoint pass mismatch (%d/%d)",
 			ErrMetricsStoreInternal, ingest.ErrNotRowFault, dpCur, len(dpIdents))
 	}

--- a/desktopexporter/internal/store/metrics/metrics.go
+++ b/desktopexporter/internal/store/metrics/metrics.go
@@ -32,6 +32,41 @@ var (
 // the others.
 const flushIntervalMetrics = 100
 
+// scopeKey identifies a scope by its position in the batch: the ri'th
+// resource's si'th scope.
+type scopeKey struct{ ri, si int }
+
+// countMetrics is the number of metrics in the batch, which is the unit
+// bisection blames and the unit flushIntervalMetrics already counts. Walked
+// rather than taken from pass 1's coords, which skips identities it cannot
+// resolve and so would not line up with pass 2's ordinals.
+func countMetrics(m pmetric.Metrics) int {
+	n := 0
+	for _, rm := range m.ResourceMetrics().All() {
+		for _, sm := range rm.ScopeMetrics().All() {
+			n += sm.Metrics().Len()
+		}
+	}
+	return n
+}
+
+// metricDatapointCount mirrors the type switch in appendPass exactly. A metric
+// that pass skips still has to step dpCur over its datapoints, and a type the
+// switch does not write contributes none.
+func metricDatapointCount(metric pmetric.Metric) int {
+	switch metric.Type() {
+	case pmetric.MetricTypeGauge:
+		return metric.Gauge().DataPoints().Len()
+	case pmetric.MetricTypeSum:
+		return metric.Sum().DataPoints().Len()
+	case pmetric.MetricTypeHistogram:
+		return metric.Histogram().DataPoints().Len()
+	case pmetric.MetricTypeExponentialHistogram:
+		return metric.ExponentialHistogram().DataPoints().Len()
+	}
+	return 0
+}
+
 // Ingest writes the metric data in m to the metric_streams,
 // metric_ingests, datapoints, exemplars, and attributes tables. The
 // caller must hold any required lock on the connection.
@@ -51,8 +86,17 @@ const flushIntervalMetrics = 100
 // The two-pass shape exists so the upsert sees ALL identities at once
 // and resolves them in one round-trip; doing the upsert per metric
 // would be O(metrics) round-trips per batch.
-func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *ingest.FlushedIDs) (err error) {
-	tables := []string{"exemplars", "datapoints", "metric_ingests"}
+// Ingest is IngestReport for callers with nowhere to put the report. Metrics
+// the store refused are still skipped rather than failing the batch; this form
+// just cannot say how many there were.
+func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *ingest.FlushedIDs) error {
+	_, err := IngestReport(ctx, conn, m, flushed)
+	return err
+}
+
+// IngestReport ingests a batch and reports the metrics it could not write. A
+// non-empty Rejected is not a failure: the batch landed, minus those metrics.
+func IngestReport(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *ingest.FlushedIDs) (_ ingest.Rejected, err error) {
 
 	// Pass 1: collect every distinct identity in this OTLP request, plus
 	// per-identity service_name (denormalized onto metric_streams). We
@@ -73,7 +117,6 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 	// the bulk of it: on the reference capture they are 82% of all attribute
 	// rows, resolving to 89 distinct sets across 294,607 datapoints.
 	dict := ingest.NewDictionary(flushed)
-	type scopeKey struct{ ri, si int }
 	resourceIDs := map[int]duckdb.UUID{}
 	scopeIDs := map[scopeKey]duckdb.UUID{}
 
@@ -89,7 +132,7 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 			scopeIDs[scopeKey{ri, si}] = dict.AddScope(scope)
 			for mi, metric := range scopeMetric.Metrics().All() {
 				if err := ctx.Err(); err != nil {
-					return err
+					return ingest.Rejected{}, err
 				}
 				identity := streamIdentityFromMetric(metric, scope.Name(), scope.Version(), serviceName)
 				identitySet[identity] = struct{}{}
@@ -99,10 +142,10 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 		}
 	}
 	if len(coords) == 0 {
-		return nil
+		return ingest.Rejected{}, nil
 	}
 	if err := ctx.Err(); err != nil {
-		return err
+		return ingest.Rejected{}, err
 	}
 	identities := make([]streamIdentity, 0, len(identitySet))
 	for id := range identitySet {
@@ -115,7 +158,7 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 	// to match the spans/logs single-file layout.
 	dconn, ok := conn.(*duckdb.Conn)
 	if !ok {
-		return fmt.Errorf("Ingest: %w: connection is not a *duckdb.Conn", ErrMetricsStoreInternal)
+		return ingest.Rejected{}, fmt.Errorf("Ingest: %w: connection is not a *duckdb.Conn", ErrMetricsStoreInternal)
 	}
 	prepareArg := func(v any) (driver.Value, error) {
 		nv := driver.NamedValue{Value: v}
@@ -145,7 +188,7 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 	serviceNames := make([]string, 0, len(identities))
 	for _, id := range identities {
 		if err := ctx.Err(); err != nil {
-			return err
+			return ingest.Rejected{}, err
 		}
 		newStreamIDs = append(newStreamIDs, uuid.NewString())
 		names = append(names, id.Name)
@@ -162,7 +205,7 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 		newStreamIDs, names, units, types, temporalities, monotonics,
 		scopeNames, scopeVersions, serviceNames)
 	if err != nil {
-		return fmt.Errorf("Ingest: %w: prep insert arg: %w", ErrMetricsStoreInternal, err)
+		return ingest.Rejected{}, fmt.Errorf("Ingest: %w: prep insert arg: %w", ErrMetricsStoreInternal, err)
 	}
 
 	const insertSQL = `insert into metric_streams (id, name, unit, metric_type, aggregation_temporality, is_monotonic, scope_name, scope_version, service_name)
@@ -170,7 +213,7 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 		        unnest(?::varchar[]), unnest(?::boolean[]), unnest(?::varchar[]), unnest(?::varchar[]), unnest(?::varchar[])
 		 on conflict (name, unit, metric_type, aggregation_temporality, is_monotonic, scope_name, scope_version, service_name) do nothing`
 	if _, err := dconn.ExecContext(ctx, insertSQL, insertArgs); err != nil {
-		return fmt.Errorf("Ingest: %w: stream insert: %w", ErrMetricsStoreInternal, err)
+		return ingest.Rejected{}, fmt.Errorf("Ingest: %w: stream insert: %w", ErrMetricsStoreInternal, err)
 	}
 
 	// The same eight arrays, joined against rather than OR'd together. The
@@ -180,7 +223,7 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 		names, units, types, temporalities, monotonics,
 		scopeNames, scopeVersions, serviceNames)
 	if err != nil {
-		return fmt.Errorf("Ingest: %w: prep select arg: %w", ErrMetricsStoreInternal, err)
+		return ingest.Rejected{}, fmt.Errorf("Ingest: %w: prep select arg: %w", ErrMetricsStoreInternal, err)
 	}
 
 	const selectSQL = `select s.id, s.name, s.unit, s.metric_type, s.aggregation_temporality,
@@ -197,7 +240,7 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 		    and s.scope_version = w.scope_version and s.service_name = w.service_name`
 	rows, err := dconn.QueryContext(ctx, selectSQL, selectArgs)
 	if err != nil {
-		return fmt.Errorf("Ingest: %w: stream select: %w", ErrMetricsStoreInternal, err)
+		return ingest.Rejected{}, fmt.Errorf("Ingest: %w: stream select: %w", ErrMetricsStoreInternal, err)
 	}
 
 	streamIDs := make(map[streamIdentity]duckdb.UUID, len(identities))
@@ -205,19 +248,19 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 	for {
 		if err := ctx.Err(); err != nil {
 			rows.Close()
-			return err
+			return ingest.Rejected{}, err
 		}
 		if err := rows.Next(dest); err != nil {
 			if err.Error() == "EOF" {
 				break
 			}
 			rows.Close()
-			return fmt.Errorf("Ingest: %w: stream scan: %w", ErrMetricsStoreInternal, err)
+			return ingest.Rejected{}, fmt.Errorf("Ingest: %w: stream scan: %w", ErrMetricsStoreInternal, err)
 		}
 		sid, err := decodeStreamID(dest[0])
 		if err != nil {
 			rows.Close()
-			return fmt.Errorf("Ingest: %w: %w", ErrMetricsStoreInternal, err)
+			return ingest.Rejected{}, fmt.Errorf("Ingest: %w: %w", ErrMetricsStoreInternal, err)
 		}
 		metricType := stringOrEmpty(dest[3])
 		key := streamIdentity{
@@ -235,7 +278,7 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 	rows.Close()
 
 	if len(streamIDs) != len(identities) {
-		return fmt.Errorf("Ingest: %w: resolved %d of %d stream identities", ErrMetricsStoreInternal, len(streamIDs), len(identities))
+		return ingest.Rejected{}, fmt.Errorf("Ingest: %w: resolved %d of %d stream identities", ErrMetricsStoreInternal, len(streamIDs), len(identities))
 	}
 
 	// Pass 2: open the appenders and walk the request again, writing
@@ -244,7 +287,7 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 	// alternative would be carrying stream IDs alongside coords, but
 	// the lookup is O(1) and keeps the inner loop self-contained).
 	if err := dict.Flush(ctx, conn); err != nil {
-		return fmt.Errorf("Ingest: %w: %w", ErrMetricsStoreInternal, err)
+		return ingest.Rejected{}, fmt.Errorf("Ingest: %w: %w", ErrMetricsStoreInternal, err)
 	}
 
 	// Resolve every datapoint's series before any of them are appended.
@@ -260,11 +303,37 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 	// the store, and one derivation each is all they get.
 	dpIdents, seriesRows, err := collectSeries(ctx, m, streamIDs, resourceIDs, dpAttrIDs)
 	if err != nil {
-		return err
+		return ingest.Rejected{}, err
 	}
 	if err := insertSeries(ctx, dconn, prepareArg, seriesRows); err != nil {
-		return err
+		return ingest.Rejected{}, err
 	}
+	// Pass 2: append, retrying in narrowing halves so one unwritable metric
+	// costs its own place in the batch rather than everyone else's.
+	return ingest.BisectingWrite(ctx, countMetrics(m), func(lo, hi int) error {
+		return ingest.InTransaction(ctx, conn, func() error {
+			return appendPass(ctx, conn, m, streamIDs, resourceIDs, scopeIDs, dpIdents,
+				func(ordinal int) bool { return ordinal >= lo && ordinal < hi })
+		})
+	})
+}
+
+// appendPass writes the metric rows keep says to write.
+//
+// keep is indexed by the metric's ordinal in the walk. A skipped metric still
+// steps dpCur over its datapoints, because dpIdents is consumed by position and
+// collectSeries filled it for every metric whether or not this pass writes it.
+func appendPass(
+	ctx context.Context,
+	conn driver.Conn,
+	m pmetric.Metrics,
+	streamIDs map[streamIdentity]duckdb.UUID,
+	resourceIDs map[int]duckdb.UUID,
+	scopeIDs map[scopeKey]duckdb.UUID,
+	dpIdents []dpIdentity,
+	keep func(ordinal int) bool,
+) (err error) {
+	tables := []string{"exemplars", "datapoints", "metric_ingests"}
 	dpCur := 0
 
 	appenders, err := ingest.NewAppenders(conn, tables)
@@ -276,6 +345,7 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 	}()
 
 	metricCount := 0
+	metricOrdinal := 0
 	for ri, resourceMetric := range m.ResourceMetrics().All() {
 		resource := resourceMetric.Resource()
 		serviceName := serviceNameFromAttrs(resource.Attributes())
@@ -287,6 +357,16 @@ func Ingest(ctx context.Context, conn driver.Conn, m pmetric.Metrics, flushed *i
 				if err := ctx.Err(); err != nil {
 					return err
 				}
+
+				ordinal := metricOrdinal
+				metricOrdinal++
+				if !keep(ordinal) {
+					// dpIdents is consumed by position, so a metric this pass
+					// declines to write still has to be stepped over.
+					dpCur += metricDatapointCount(metric)
+					continue
+				}
+
 				identity := streamIdentityFromMetric(metric, scope.Name(), scope.Version(), serviceName)
 				streamID, ok := streamIDs[identity]
 				if !ok {

--- a/desktopexporter/internal/store/metrics/metrics.go
+++ b/desktopexporter/internal/store/metrics/metrics.go
@@ -426,8 +426,10 @@ func appendPass(
 	// same order. A divergence would file every point past it under another
 	// series -- wrong lines on a chart, with no error anywhere.
 	if dpCur != len(dpIdents) {
-		return fmt.Errorf("Ingest: %w: datapoint pass mismatch (%d/%d)",
-			ErrMetricsStoreInternal, dpCur, len(dpIdents))
+		// ErrNotRowFault: a fault in this code, identical for every subset,
+		// so bisection must surface it instead of blaming metrics.
+		return fmt.Errorf("Ingest: %w: %w: datapoint pass mismatch (%d/%d)",
+			ErrMetricsStoreInternal, ingest.ErrNotRowFault, dpCur, len(dpIdents))
 	}
 
 	return nil

--- a/desktopexporter/internal/store/queries/ddl/tables/_order
+++ b/desktopexporter/internal/store/queries/ddl/tables/_order
@@ -20,3 +20,4 @@ metric_ingests.sql
 histogram_bounds.sql
 datapoints.sql
 exemplars.sql
+ingest_rejections.sql

--- a/desktopexporter/internal/store/queries/ddl/tables/ingest_rejections.sql
+++ b/desktopexporter/internal/store/queries/ddl/tables/ingest_rejections.sql
@@ -1,0 +1,30 @@
+-- Telemetry the store would not write, so the viewer can say so instead of
+-- rendering as though it arrived. The batch itself succeeds -- a refused row
+-- is not an error -- so without this row nothing would ever mention it.
+--
+-- One row per (signal, kind) rather than per refused item. A sender replaying
+-- a capture refuses thousands of spans for one reason, and the useful fact is
+-- "4,127 spans, since 14:32", not four thousand copies of it. That keying also
+-- bounds the table by how many kinds of problem exist rather than by traffic,
+-- so it needs no eviction.
+--
+-- No foreign key to anything: the whole point is describing rows that are not
+-- in the store, and the ones that are get pruned by retention independently.
+-- Same reasoning as logs and exemplars referencing spans without one.
+create table if not exists ingest_rejections (
+		-- sha256(signal, kind), so the upsert can find the row without a
+		-- secondary index and two senders hitting the same fault share it.
+		id uuid primary key,
+		signal varchar not null,
+		kind varchar not null,
+		-- A span id from the most recent occurrence. For an already-stored
+		-- rejection the span is in the store, so this is a working link --
+		-- better than keeping a copy of a row we already have.
+		sample varchar,
+		-- Only for a rejection no id can stand in for, where the row was
+		-- genuinely lost and nothing in the store represents it.
+		detail json,
+		first_seen bigint not null,
+		last_seen bigint not null,
+		occurrences ubigint not null default 1
+	)

--- a/desktopexporter/internal/store/spans/bisect.go
+++ b/desktopexporter/internal/store/spans/bisect.go
@@ -22,12 +22,15 @@ func appendSpansBisecting(
 	resourceIDs map[int]duckdb.UUID,
 	scopeIDs map[scopeKey]duckdb.UUID,
 	spanAttrs, eventAttrs, linkAttrs [][]duckdb.UUID,
+	skip map[int]bool,
 ) (ingest.Rejected, error) {
 	return ingest.BisectingWrite(ctx, len(spanAttrs), func(lo, hi int) error {
 		return ingest.InTransaction(ctx, conn, func() error {
 			return appendPass(ctx, conn, traces, resourceIDs, scopeIDs,
 				spanAttrs, eventAttrs, linkAttrs,
-				func(ordinal int) bool { return ordinal >= lo && ordinal < hi })
+				func(ordinal int) bool {
+					return ordinal >= lo && ordinal < hi && !skip[ordinal]
+				})
 		})
 	})
 }

--- a/desktopexporter/internal/store/spans/bisect.go
+++ b/desktopexporter/internal/store/spans/bisect.go
@@ -22,14 +22,15 @@ func appendSpansBisecting(
 	resourceIDs map[int]duckdb.UUID,
 	scopeIDs map[scopeKey]duckdb.UUID,
 	spanAttrs, eventAttrs, linkAttrs [][]duckdb.UUID,
-	skip map[int]bool,
+	skip map[int]error,
 ) (ingest.Rejected, error) {
-	return ingest.BisectingWrite(ctx, len(spanAttrs), func(lo, hi int) error {
+	return ingest.BisectingWrite(ctx, len(spanAttrs), skip, func(lo, hi int) error {
 		return ingest.InTransaction(ctx, conn, func() error {
 			return appendPass(ctx, conn, traces, resourceIDs, scopeIDs,
 				spanAttrs, eventAttrs, linkAttrs,
 				func(ordinal int) bool {
-					return ordinal >= lo && ordinal < hi && !skip[ordinal]
+					_, skipped := skip[ordinal]
+					return ordinal >= lo && ordinal < hi && !skipped
 				})
 		})
 	})

--- a/desktopexporter/internal/store/spans/bisect.go
+++ b/desktopexporter/internal/store/spans/bisect.go
@@ -1,0 +1,33 @@
+package spans
+
+import (
+	"context"
+	"database/sql/driver"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/ingest"
+	"github.com/duckdb/duckdb-go/v2"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// appendSpansBisecting writes every span it can and isolates the ones it
+// cannot, one span being the unit of blame.
+//
+// All the policy lives in ingest.BisectingWrite; this only supplies the two
+// things it asks for -- how many spans there are, and how to attempt a
+// contiguous range of them atomically.
+func appendSpansBisecting(
+	ctx context.Context,
+	conn driver.Conn,
+	traces ptrace.Traces,
+	resourceIDs map[int]duckdb.UUID,
+	scopeIDs map[scopeKey]duckdb.UUID,
+	spanAttrs, eventAttrs, linkAttrs [][]duckdb.UUID,
+) (ingest.Rejected, error) {
+	return ingest.BisectingWrite(ctx, len(spanAttrs), func(lo, hi int) error {
+		return ingest.InTransaction(ctx, conn, func() error {
+			return appendPass(ctx, conn, traces, resourceIDs, scopeIDs,
+				spanAttrs, eventAttrs, linkAttrs,
+				func(ordinal int) bool { return ordinal >= lo && ordinal < hi })
+		})
+	})
+}

--- a/desktopexporter/internal/store/spans/dedupe.go
+++ b/desktopexporter/internal/store/spans/dedupe.go
@@ -1,0 +1,125 @@
+package spans
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+
+	"github.com/duckdb/duckdb-go/v2"
+	"github.com/google/uuid"
+)
+
+// ErrSpanAlreadyStored is the reason a span was skipped because its id is
+// already in the store, or repeated earlier in the same batch. Span ids are
+// required to be unique, so this means the sender is reusing them -- most often
+// a replayed capture.
+var ErrSpanAlreadyStored = errors.New("span id already stored")
+
+// spanUUID is the span's 8-byte id widened into a uuid, zero-padded high.
+func spanUUID(id [8]byte) duckdb.UUID {
+	var padded [16]byte
+	copy(padded[8:], id[:])
+	return duckdb.UUID(padded)
+}
+
+// skipAlreadyStored returns the ordinals whose span id the store already holds,
+// or which repeat an earlier ordinal in this batch. The first occurrence of a
+// repeated id is kept.
+//
+// Bisection would find these anyway, but only by failing: every row bad means
+// 2n-1 transactions, measured at ~1ms per span, so replaying a large capture
+// spends minutes discovering one row at a time what one indexed lookup answers
+// at once. It also gives a truer reason than a constraint violation surfaced
+// from a failed flush.
+func skipAlreadyStored(ctx context.Context, conn driver.Conn, ids []duckdb.UUID) (map[int]bool, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	stored, err := storedSpanIDs(ctx, conn, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	skip := map[int]bool{}
+	seen := make(map[duckdb.UUID]struct{}, len(ids))
+	for ordinal, id := range ids {
+		_, repeated := seen[id]
+		if _, ok := stored[id]; ok || repeated {
+			skip[ordinal] = true
+			continue
+		}
+		seen[id] = struct{}{}
+	}
+	return skip, nil
+}
+
+// storedSpanIDs returns which of ids the spans table already holds. One bound
+// array argument, so the statement text is the same whatever the batch holds,
+// and span_id is the primary key so each probe is an index lookup.
+//
+// Runs on conn rather than the pool: ingest already holds the store's locks,
+// and reaching back through a locking Store method from inside WithConn would
+// deadlock.
+func storedSpanIDs(ctx context.Context, conn driver.Conn, ids []duckdb.UUID) (map[duckdb.UUID]struct{}, error) {
+	queryer, ok := conn.(driver.QueryerContext)
+	if !ok {
+		return nil, fmt.Errorf("storedSpanIDs: %w: connection cannot query", ErrSpansStoreInternal)
+	}
+
+	text := make([]string, len(ids))
+	for i, id := range ids {
+		text[i] = id.String()
+	}
+
+	const q = `select span_id::varchar from spans
+		where span_id in (select unnest(?::varchar[])::uuid)`
+
+	arg, err := prepareSpanArg(conn, text)
+	if err != nil {
+		return nil, fmt.Errorf("storedSpanIDs: %w: %w", ErrSpansStoreInternal, err)
+	}
+
+	rows, err := queryer.QueryContext(ctx, q, []driver.NamedValue{{Ordinal: 1, Value: arg}})
+	if err != nil {
+		return nil, fmt.Errorf("storedSpanIDs: %w: %w", ErrSpansStoreInternal, err)
+	}
+	defer rows.Close()
+
+	out := make(map[duckdb.UUID]struct{})
+	dest := make([]driver.Value, 1)
+	for {
+		if err := rows.Next(dest); err != nil {
+			break
+		}
+		s, ok := dest[0].(string)
+		if !ok {
+			continue
+		}
+		parsed, err := uuid.Parse(s)
+		if err != nil {
+			return nil, fmt.Errorf("storedSpanIDs: %w: %w", ErrSpansStoreInternal, err)
+		}
+		out[duckdb.UUID(parsed)] = struct{}{}
+	}
+	return out, nil
+}
+
+// prepareSpanArg converts a Go value into something the duckdb driver will bind,
+// matching the conversion metrics.Ingest already uses for its array arguments.
+func prepareSpanArg(conn driver.Conn, v any) (driver.Value, error) {
+	dconn, ok := conn.(*duckdb.Conn)
+	if !ok {
+		return driver.DefaultParameterConverter.ConvertValue(v)
+	}
+	nv := driver.NamedValue{Value: v}
+	err := dconn.CheckNamedValue(&nv)
+	if err == nil {
+		return nv.Value, nil
+	}
+	if !errors.Is(err, driver.ErrSkip) {
+		return nil, err
+	}
+	return driver.DefaultParameterConverter.ConvertValue(v)
+}

--- a/desktopexporter/internal/store/spans/dedupe.go
+++ b/desktopexporter/internal/store/spans/dedupe.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/ingest"
 	"github.com/duckdb/duckdb-go/v2"
 	"github.com/google/uuid"
 )
@@ -122,4 +123,29 @@ func prepareSpanArg(conn driver.Conn, v any) (driver.Value, error) {
 		return nil, err
 	}
 	return driver.DefaultParameterConverter.ConvertValue(v)
+}
+
+// recordSpanRejections tallies what this batch was refused, one row per kind.
+//
+// The sample is the refused span's own id. For an already-stored rejection that
+// row is in the store, so it is a working link -- better than keeping a copy of
+// something we already have.
+func recordSpanRejections(ctx context.Context, conn driver.Conn, r ingest.Rejected, spanIDs []duckdb.UUID) error {
+	if r.Count() == 0 {
+		return nil
+	}
+	records := ingest.Tally("traces", r,
+		func(reason error) string {
+			if errors.Is(reason, ErrSpanAlreadyStored) {
+				return ingest.KindAlreadyStored
+			}
+			return ingest.KindRefused
+		},
+		func(ordinal int) string {
+			if ordinal < 0 || ordinal >= len(spanIDs) {
+				return ""
+			}
+			return spanIDs[ordinal].String()
+		})
+	return ingest.RecordRejections(ctx, conn, records)
 }

--- a/desktopexporter/internal/store/spans/dedupe.go
+++ b/desktopexporter/internal/store/spans/dedupe.go
@@ -32,7 +32,7 @@ func spanUUID(id [8]byte) duckdb.UUID {
 // spends minutes discovering one row at a time what one indexed lookup answers
 // at once. It also gives a truer reason than a constraint violation surfaced
 // from a failed flush.
-func skipAlreadyStored(ctx context.Context, conn driver.Conn, ids []duckdb.UUID) (map[int]bool, error) {
+func skipAlreadyStored(ctx context.Context, conn driver.Conn, ids []duckdb.UUID) (map[int]error, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
@@ -42,12 +42,12 @@ func skipAlreadyStored(ctx context.Context, conn driver.Conn, ids []duckdb.UUID)
 		return nil, err
 	}
 
-	skip := map[int]bool{}
+	skip := map[int]error{}
 	seen := make(map[duckdb.UUID]struct{}, len(ids))
 	for ordinal, id := range ids {
 		_, repeated := seen[id]
 		if _, ok := stored[id]; ok || repeated {
-			skip[ordinal] = true
+			skip[ordinal] = ErrSpanAlreadyStored
 			continue
 		}
 		seen[id] = struct{}{}

--- a/desktopexporter/internal/store/spans/ingest_atomicity_test.go
+++ b/desktopexporter/internal/store/spans/ingest_atomicity_test.go
@@ -119,3 +119,44 @@ func TestIngest_FailedBatchDoesNotPoisonDictionaryCache(t *testing.T) {
 	`)
 	assert.Zero(t, dangling, "spans reference dictionary rows that do not exist")
 }
+
+// Repeated failures must not wedge the connection.
+//
+// Ingest owns one long-lived connection for the life of the process, so a
+// transaction left open by a rollback that did not happen would fail every
+// later batch with "transaction already active" -- one bad sender silencing
+// every other one. The appenders are also rebuilt per batch on that same
+// connection after a flush error, which is the other thing that has to survive.
+func TestIngest_RepeatedFailuresLeaveConnectionUsable(t *testing.T) {
+	t.Parallel()
+	s, ctx := storetest.New(t)
+
+	for i := range 3 {
+		err := s.WithConn(func(conn driver.Conn) error {
+			return spans.Ingest(ctx, conn, tracesWithDuplicateSpanID(600), s.FlushedIDs())
+		})
+		require.Error(t, err, "batch %d should fail", i)
+		assert.Zero(t, countRows(t, s, ctx, "select count(*) from spans"),
+			"batch %d left rows behind", i)
+	}
+
+	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
+		return spans.Ingest(ctx, conn, createTestTracePdata(), s.FlushedIDs())
+	}), "a good batch after three failed ones must still ingest")
+	assert.Equal(t, 9, countRows(t, s, ctx, "select count(*) from spans"))
+}
+
+// The failure has to say what happened. A duplicate key is a user-facing
+// condition -- their sender is reusing span ids -- so the message must survive
+// the joins on the way out rather than being flattened into "ingest failed".
+func TestIngest_DuplicateErrorNamesTheConstraint(t *testing.T) {
+	t.Parallel()
+	s, ctx := storetest.New(t)
+
+	err := s.WithConn(func(conn driver.Conn) error {
+		return spans.Ingest(ctx, conn, tracesWithDuplicateSpanID(600), s.FlushedIDs())
+	})
+	require.Error(t, err)
+	t.Logf("error surfaced to the exporter:\n%v", err)
+	assert.Contains(t, err.Error(), "PRIMARY KEY or UNIQUE constraint")
+}

--- a/desktopexporter/internal/store/spans/ingest_atomicity_test.go
+++ b/desktopexporter/internal/store/spans/ingest_atomicity_test.go
@@ -84,10 +84,7 @@ func TestIngest_OneDuplicateDoesNotCostTheBatch(t *testing.T) {
 
 	assert.Equal(t, 1, rep.Count, "exactly one span should have been rejected")
 	require.Error(t, rep.Reason)
-	// DuckDB words this two ways -- "Duplicate key ... violates primary key
-	// constraint" when the collision is with a stored row, "PRIMARY KEY or
-	// UNIQUE constraint violation: duplicate key" when it is within the batch.
-	assert.Contains(t, rep.Reason.Error(), "uplicate key",
+	assert.ErrorIs(t, rep.Reason, spans.ErrSpanAlreadyStored,
 		"the report should say why, so a sender can tell its ids are being reused")
 
 	assert.Equal(t, 599, countRows(t, s, ctx, "select count(*) from spans"))
@@ -171,4 +168,53 @@ func TestIngest_NoDanglingAttributeReferences(t *testing.T) {
 		from (select unnest(attribute_ids) as id from spans) x
 		where not exists (select 1 from attributes a where a.id = x.id)
 	`), "spans reference dictionary rows that do not exist")
+}
+
+// When a batch repeats an id, the first occurrence is the one that lands.
+// Bisection attempts ranges in order to make this true rather than incidental,
+// and dedupe keeps the first ordinal it sees for the same reason.
+func TestIngest_FirstOccurrenceOfARepeatedIDWins(t *testing.T) {
+	t.Parallel()
+	s, ctx := storetest.New(t)
+
+	tr := ptrace.NewTraces()
+	rs := tr.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "first-wins")
+	ss := rs.ScopeSpans().AppendEmpty()
+	ss.Scope().SetName("sc")
+	traceID := mustDecodeTraceID("000000000000000000000000000000cc")
+
+	for _, name := range []string{"first", "second"} {
+		sp := ss.Spans().AppendEmpty()
+		sp.SetTraceID(traceID)
+		sp.SetSpanID(mustDecodeSpanID("0000000000000001")) // same id twice
+		sp.SetName(name)
+		sp.SetStartTimestamp(pcommon.Timestamp(time.Now().UnixNano()))
+		sp.SetEndTimestamp(pcommon.Timestamp(time.Now().UnixNano() + 1))
+	}
+
+	rep, err := ingestReport(t, s, tr)
+	require.NoError(t, err)
+	assert.Equal(t, 1, rep.Count)
+	assert.Equal(t, 1, countRows(t, s, ctx, "select count(*) from spans"))
+	assert.Equal(t, 1, countRows(t, s, ctx,
+		"select count(*) from spans where name = 'first'"),
+		"the first occurrence should be the one stored")
+}
+
+// A batch mixing stored and new spans keeps the new ones.
+func TestIngest_MixedResendKeepsTheNewSpans(t *testing.T) {
+	t.Parallel()
+	s, ctx := storetest.New(t)
+
+	_, err := ingestReport(t, s, tracesWithDuplicateSpanID(100, 0))
+	require.NoError(t, err)
+	require.Equal(t, 100, countRows(t, s, ctx, "select count(*) from spans"))
+
+	// 150 spans, ids 1..150: the first 100 are already stored.
+	rep, err := ingestReport(t, s, tracesWithDuplicateSpanID(150, 0))
+	require.NoError(t, err)
+	assert.Equal(t, 100, rep.Count, "the overlap should be reported")
+	assert.Equal(t, 150, countRows(t, s, ctx, "select count(*) from spans"),
+		"the 50 new spans should have landed")
 }

--- a/desktopexporter/internal/store/spans/ingest_atomicity_test.go
+++ b/desktopexporter/internal/store/spans/ingest_atomicity_test.go
@@ -82,9 +82,9 @@ func TestIngest_OneDuplicateDoesNotCostTheBatch(t *testing.T) {
 	rep, err := ingestReport(t, s, tracesWithDuplicateSpanID(600, 1))
 	require.NoError(t, err, "a duplicate row must not fail the batch")
 
-	assert.Equal(t, 1, rep.Count, "exactly one span should have been rejected")
-	require.Error(t, rep.Reason)
-	assert.ErrorIs(t, rep.Reason, spans.ErrSpanAlreadyStored,
+	assert.Equal(t, 1, rep.Count(), "exactly one span should have been rejected")
+	require.Error(t, rep.Reason())
+	assert.ErrorIs(t, rep.Reason(), spans.ErrSpanAlreadyStored,
 		"the report should say why, so a sender can tell its ids are being reused")
 
 	assert.Equal(t, 599, countRows(t, s, ctx, "select count(*) from spans"))
@@ -103,7 +103,7 @@ func TestIngest_ManyDuplicatesCostOnlyThemselves(t *testing.T) {
 	rep, err := ingestReport(t, s, tracesWithDuplicateSpanID(600, 25))
 	require.NoError(t, err)
 
-	assert.Equal(t, 25, rep.Count)
+	assert.Equal(t, 25, rep.Count())
 	assert.Equal(t, 575, countRows(t, s, ctx, "select count(*) from spans"))
 }
 
@@ -120,7 +120,7 @@ func TestIngest_ResendRejectedWithoutFailing(t *testing.T) {
 
 	rep, err := ingestReport(t, s, createTestTracePdata())
 	require.NoError(t, err, "a resent batch must not be an error")
-	assert.Equal(t, 9, rep.Count, "every span in a resend is already stored")
+	assert.Equal(t, 9, rep.Count(), "every span in a resend is already stored")
 	assert.Equal(t, 9, countRows(t, s, ctx, "select count(*) from spans"),
 		"a resend must not duplicate rows")
 	assert.Equal(t, events, countRows(t, s, ctx, "select count(*) from events"),
@@ -195,7 +195,7 @@ func TestIngest_FirstOccurrenceOfARepeatedIDWins(t *testing.T) {
 
 	rep, err := ingestReport(t, s, tr)
 	require.NoError(t, err)
-	assert.Equal(t, 1, rep.Count)
+	assert.Equal(t, 1, rep.Count())
 	assert.Equal(t, 1, countRows(t, s, ctx, "select count(*) from spans"))
 	assert.Equal(t, 1, countRows(t, s, ctx,
 		"select count(*) from spans where name = 'first'"),
@@ -214,7 +214,7 @@ func TestIngest_MixedResendKeepsTheNewSpans(t *testing.T) {
 	// 150 spans, ids 1..150: the first 100 are already stored.
 	rep, err := ingestReport(t, s, tracesWithDuplicateSpanID(150, 0))
 	require.NoError(t, err)
-	assert.Equal(t, 100, rep.Count, "the overlap should be reported")
+	assert.Equal(t, 100, rep.Count(), "the overlap should be reported")
 	assert.Equal(t, 150, countRows(t, s, ctx, "select count(*) from spans"),
 		"the 50 new spans should have landed")
 }

--- a/desktopexporter/internal/store/spans/ingest_atomicity_test.go
+++ b/desktopexporter/internal/store/spans/ingest_atomicity_test.go
@@ -1,0 +1,121 @@
+package spans_test
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/spans"
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/storetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// tracesWithDuplicateSpanID builds one trace of n spans whose last span reuses
+// the first span's id. n is deliberately a caller's choice: a batch larger than
+// flushIntervalSpans crosses an explicit flush, which is where partial commits
+// come from.
+func tracesWithDuplicateSpanID(n int) ptrace.Traces {
+	baseTime := time.Now().UnixNano()
+	tr := ptrace.NewTraces()
+	rs := tr.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "dupe-service")
+	ss := rs.ScopeSpans().AppendEmpty()
+	ss.Scope().SetName("dupe-scope")
+
+	traceID := mustDecodeTraceID("000000000000000000000000000000aa")
+	ids := make([]int, 0, n)
+	for i := 1; i < n; i++ {
+		ids = append(ids, i)
+	}
+	ids = append(ids, 1) // the duplicate, last
+	for _, n := range ids {
+		s := ss.Spans().AppendEmpty()
+		s.SetTraceID(traceID)
+		s.SetSpanID(mustDecodeSpanID(fmt.Sprintf("%016x", n)))
+		s.SetName(fmt.Sprintf("span-%d", n))
+		s.SetKind(ptrace.SpanKindInternal)
+		s.SetStartTimestamp(pcommon.Timestamp(baseTime))
+		s.SetEndTimestamp(pcommon.Timestamp(baseTime + int64(time.Second)))
+		s.Attributes().PutStr("span.n", fmt.Sprintf("%d", n))
+
+		e := s.Events().AppendEmpty()
+		e.SetName(fmt.Sprintf("event-%d", n))
+		e.SetTimestamp(pcommon.Timestamp(baseTime))
+		e.Attributes().PutStr("event.n", fmt.Sprintf("%d", n))
+
+		l := s.Links().AppendEmpty()
+		l.SetTraceID(traceID)
+		l.SetSpanID(mustDecodeSpanID("00000000000000ff"))
+		l.Attributes().PutStr("link.n", fmt.Sprintf("%d", n))
+	}
+	return tr
+}
+
+// A batch that fails partway must leave nothing behind.
+//
+// The appenders flush every flushIntervalSpans (500) spans, and each flush used
+// to be its own commit. So a batch of more than 500 spans that failed later --
+// on a duplicate span id, say -- left the first 500 durable while the call
+// returned an error. The collector then retried the whole batch, whose first
+// 500 spans now collided with the copies we had already kept, and the retry
+// failed for a reason the first attempt created. That is a batch that can never
+// succeed, and it needs a batch larger than one flush interval to reproduce.
+func TestIngest_FailedBatchOver500SpansCommitsNothing(t *testing.T) {
+	t.Parallel()
+	s, ctx := storetest.New(t)
+
+	err := s.WithConn(func(conn driver.Conn) error {
+		return spans.Ingest(ctx, conn, tracesWithDuplicateSpanID(600), s.FlushedIDs())
+	})
+	require.Error(t, err, "a duplicate span id must fail the batch")
+
+	assert.Zero(t, countRows(t, s, ctx, "select count(*) from spans"),
+		"spans from a flush before the failure survived, so a retry of this batch can never succeed")
+	assert.Zero(t, countRows(t, s, ctx, "select count(*) from events"))
+	assert.Zero(t, countRows(t, s, ctx, "select count(*) from links"))
+
+	// The retry the collector would make must now work.
+	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
+		return spans.Ingest(ctx, conn, createTestTracePdata(), s.FlushedIDs())
+	}), "a clean batch after a failed one must still ingest")
+}
+
+// The dictionary cache must not keep claiming rows a rollback removed.
+//
+// FlushedIDs marks ids as soon as their insert succeeds, and the insert does
+// succeed -- it is the appender flush afterwards that fails. Without
+// invalidation the next batch would skip re-inserting those rows and its spans
+// would carry uuid[] references into nothing, which no foreign key catches.
+func TestIngest_FailedBatchDoesNotPoisonDictionaryCache(t *testing.T) {
+	t.Parallel()
+	s, ctx := storetest.New(t)
+
+	err := s.WithConn(func(conn driver.Conn) error {
+		return spans.Ingest(ctx, conn, tracesWithDuplicateSpanID(600), s.FlushedIDs())
+	})
+	require.Error(t, err)
+
+	// A clean batch reusing the same resource, scope and attribute values must
+	// still write its dictionary rows.
+	clean := createTestTracePdata()
+	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
+		return spans.Ingest(ctx, conn, clean, s.FlushedIDs())
+	}))
+
+	assert.NotZero(t, countRows(t, s, ctx, "select count(*) from spans"))
+	assert.NotZero(t, countRows(t, s, ctx, "select count(*) from attributes"),
+		"dictionary rows must be rewritten after a rollback")
+	assert.NotZero(t, countRows(t, s, ctx, "select count(*) from resources"))
+
+	// Every attribute id a span references must resolve to a real row.
+	dangling := countRows(t, s, ctx, `
+		select count(*)
+		from (select unnest(attribute_ids) as id from spans) x
+		where not exists (select 1 from attributes a where a.id = x.id)
+	`)
+	assert.Zero(t, dangling, "spans reference dictionary rows that do not exist")
+}

--- a/desktopexporter/internal/store/spans/ingest_atomicity_test.go
+++ b/desktopexporter/internal/store/spans/ingest_atomicity_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store"
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/ingest"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/spans"
 	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/storetest"
 	"github.com/stretchr/testify/assert"
@@ -14,11 +16,10 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-// tracesWithDuplicateSpanID builds one trace of n spans whose last span reuses
-// the first span's id. n is deliberately a caller's choice: a batch larger than
-// flushIntervalSpans crosses an explicit flush, which is where partial commits
-// come from.
-func tracesWithDuplicateSpanID(n int) ptrace.Traces {
+// tracesWithDuplicateSpanID builds one trace of n spans whose last `dupes` span
+// ids repeat earlier ones. Every span carries an event and a link, so the child
+// rows are exercised alongside their parent.
+func tracesWithDuplicateSpanID(n, dupes int) ptrace.Traces {
 	baseTime := time.Now().UnixNano()
 	tr := ptrace.NewTraces()
 	rs := tr.ResourceSpans().AppendEmpty()
@@ -28,135 +29,146 @@ func tracesWithDuplicateSpanID(n int) ptrace.Traces {
 
 	traceID := mustDecodeTraceID("000000000000000000000000000000aa")
 	ids := make([]int, 0, n)
-	for i := 1; i < n; i++ {
+	for i := 1; i <= n-dupes; i++ {
 		ids = append(ids, i)
 	}
-	ids = append(ids, 1) // the duplicate, last
-	for _, n := range ids {
+	for i := 1; i <= dupes; i++ {
+		ids = append(ids, i) // repeats of ids already in this batch
+	}
+
+	for _, k := range ids {
 		s := ss.Spans().AppendEmpty()
 		s.SetTraceID(traceID)
-		s.SetSpanID(mustDecodeSpanID(fmt.Sprintf("%016x", n)))
-		s.SetName(fmt.Sprintf("span-%d", n))
+		s.SetSpanID(mustDecodeSpanID(fmt.Sprintf("%016x", k)))
+		s.SetName(fmt.Sprintf("span-%d", k))
 		s.SetKind(ptrace.SpanKindInternal)
 		s.SetStartTimestamp(pcommon.Timestamp(baseTime))
 		s.SetEndTimestamp(pcommon.Timestamp(baseTime + int64(time.Second)))
-		s.Attributes().PutStr("span.n", fmt.Sprintf("%d", n))
+		s.Attributes().PutStr("span.n", fmt.Sprintf("%d", k))
 
 		e := s.Events().AppendEmpty()
-		e.SetName(fmt.Sprintf("event-%d", n))
+		e.SetName(fmt.Sprintf("event-%d", k))
 		e.SetTimestamp(pcommon.Timestamp(baseTime))
-		e.Attributes().PutStr("event.n", fmt.Sprintf("%d", n))
+		e.Attributes().PutStr("event.n", fmt.Sprintf("%d", k))
 
 		l := s.Links().AppendEmpty()
 		l.SetTraceID(traceID)
 		l.SetSpanID(mustDecodeSpanID("00000000000000ff"))
-		l.Attributes().PutStr("link.n", fmt.Sprintf("%d", n))
+		l.Attributes().PutStr("link.n", fmt.Sprintf("%d", k))
 	}
 	return tr
 }
 
-// A batch that fails partway must leave nothing behind.
+func ingestReport(t *testing.T, s *store.Store, tr ptrace.Traces) (ingest.Rejected, error) {
+	t.Helper()
+	var rep ingest.Rejected
+	err := s.WithConn(func(conn driver.Conn) error {
+		var iErr error
+		rep, iErr = spans.IngestReport(t.Context(), conn, tr, s.FlushedIDs())
+		return iErr
+	})
+	return rep, err
+}
+
+// One bad span costs itself, not the batch.
 //
-// The appenders flush every flushIntervalSpans (500) spans, and each flush used
-// to be its own commit. So a batch of more than 500 spans that failed later --
-// on a duplicate span id, say -- left the first 500 durable while the call
-// returned an error. The collector then retried the whole batch, whose first
-// 500 spans now collided with the copies we had already kept, and the retry
-// failed for a reason the first attempt created. That is a batch that can never
-// succeed, and it needs a batch larger than one flush interval to reproduce.
-func TestIngest_FailedBatchOver500SpansCommitsNothing(t *testing.T) {
+// The appender only discovers a constraint violation at flush, and a failed
+// flush discards its whole buffer, so a duplicate id used to throw away every
+// good span beside it. 600 spans carrying one duplicate must store 599.
+func TestIngest_OneDuplicateDoesNotCostTheBatch(t *testing.T) {
 	t.Parallel()
 	s, ctx := storetest.New(t)
 
-	err := s.WithConn(func(conn driver.Conn) error {
-		return spans.Ingest(ctx, conn, tracesWithDuplicateSpanID(600), s.FlushedIDs())
-	})
-	require.Error(t, err, "a duplicate span id must fail the batch")
+	rep, err := ingestReport(t, s, tracesWithDuplicateSpanID(600, 1))
+	require.NoError(t, err, "a duplicate row must not fail the batch")
 
-	assert.Zero(t, countRows(t, s, ctx, "select count(*) from spans"),
-		"spans from a flush before the failure survived, so a retry of this batch can never succeed")
-	assert.Zero(t, countRows(t, s, ctx, "select count(*) from events"))
-	assert.Zero(t, countRows(t, s, ctx, "select count(*) from links"))
+	assert.Equal(t, 1, rep.Count, "exactly one span should have been rejected")
+	require.Error(t, rep.Reason)
+	// DuckDB words this two ways -- "Duplicate key ... violates primary key
+	// constraint" when the collision is with a stored row, "PRIMARY KEY or
+	// UNIQUE constraint violation: duplicate key" when it is within the batch.
+	assert.Contains(t, rep.Reason.Error(), "uplicate key",
+		"the report should say why, so a sender can tell its ids are being reused")
 
-	// The retry the collector would make must now work.
-	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
-		return spans.Ingest(ctx, conn, createTestTracePdata(), s.FlushedIDs())
-	}), "a clean batch after a failed one must still ingest")
+	assert.Equal(t, 599, countRows(t, s, ctx, "select count(*) from spans"))
+	assert.Equal(t, 599, countRows(t, s, ctx, "select count(*) from events"))
+	assert.Equal(t, 599, countRows(t, s, ctx, "select count(*) from links"))
 }
 
-// The dictionary cache must not keep claiming rows a rollback removed.
+// Several bad spans, still only they are lost.
 //
-// FlushedIDs marks ids as soon as their insert succeeds, and the insert does
-// succeed -- it is the appender flush afterwards that fails. Without
-// invalidation the next batch would skip re-inserting those rows and its spans
-// would carry uuid[] references into nothing, which no foreign key catches.
-func TestIngest_FailedBatchDoesNotPoisonDictionaryCache(t *testing.T) {
+// DuckDB names only the first violation it hits, so the count cannot come from
+// reading the error -- it comes from narrowing until each bad row stands alone.
+func TestIngest_ManyDuplicatesCostOnlyThemselves(t *testing.T) {
 	t.Parallel()
 	s, ctx := storetest.New(t)
 
-	err := s.WithConn(func(conn driver.Conn) error {
-		return spans.Ingest(ctx, conn, tracesWithDuplicateSpanID(600), s.FlushedIDs())
-	})
-	require.Error(t, err)
+	rep, err := ingestReport(t, s, tracesWithDuplicateSpanID(600, 25))
+	require.NoError(t, err)
 
-	// A clean batch reusing the same resource, scope and attribute values must
-	// still write its dictionary rows.
-	clean := createTestTracePdata()
-	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
-		return spans.Ingest(ctx, conn, clean, s.FlushedIDs())
-	}))
-
-	assert.NotZero(t, countRows(t, s, ctx, "select count(*) from spans"))
-	assert.NotZero(t, countRows(t, s, ctx, "select count(*) from attributes"),
-		"dictionary rows must be rewritten after a rollback")
-	assert.NotZero(t, countRows(t, s, ctx, "select count(*) from resources"))
-
-	// Every attribute id a span references must resolve to a real row.
-	dangling := countRows(t, s, ctx, `
-		select count(*)
-		from (select unnest(attribute_ids) as id from spans) x
-		where not exists (select 1 from attributes a where a.id = x.id)
-	`)
-	assert.Zero(t, dangling, "spans reference dictionary rows that do not exist")
+	assert.Equal(t, 25, rep.Count)
+	assert.Equal(t, 575, countRows(t, s, ctx, "select count(*) from spans"))
 }
 
-// Repeated failures must not wedge the connection.
-//
-// Ingest owns one long-lived connection for the life of the process, so a
-// transaction left open by a rollback that did not happen would fail every
-// later batch with "transaction already active" -- one bad sender silencing
-// every other one. The appenders are also rebuilt per batch on that same
-// connection after a flush error, which is the other thing that has to survive.
-func TestIngest_RepeatedFailuresLeaveConnectionUsable(t *testing.T) {
+// A resent batch stores nothing new and is not an error. This is the reported
+// case: a sender re-emitting a trace the store already holds.
+func TestIngest_ResendRejectedWithoutFailing(t *testing.T) {
+	t.Parallel()
+	s, ctx := storetest.New(t)
+
+	_, err := ingestReport(t, s, createTestTracePdata())
+	require.NoError(t, err)
+	require.Equal(t, 9, countRows(t, s, ctx, "select count(*) from spans"))
+	events := countRows(t, s, ctx, "select count(*) from events")
+
+	rep, err := ingestReport(t, s, createTestTracePdata())
+	require.NoError(t, err, "a resent batch must not be an error")
+	assert.Equal(t, 9, rep.Count, "every span in a resend is already stored")
+	assert.Equal(t, 9, countRows(t, s, ctx, "select count(*) from spans"),
+		"a resend must not duplicate rows")
+	assert.Equal(t, events, countRows(t, s, ctx, "select count(*) from events"),
+		"a resend must not duplicate child rows either")
+}
+
+// Rejecting rows must leave no children behind and must not wedge the
+// connection. Ingest owns one connection for the life of the process, so a
+// transaction left open would fail every batch after this one.
+func TestIngest_RejectionsLeaveNoChildrenAndNoOpenTransaction(t *testing.T) {
 	t.Parallel()
 	s, ctx := storetest.New(t)
 
 	for i := range 3 {
-		err := s.WithConn(func(conn driver.Conn) error {
-			return spans.Ingest(ctx, conn, tracesWithDuplicateSpanID(600), s.FlushedIDs())
-		})
-		require.Error(t, err, "batch %d should fail", i)
-		assert.Zero(t, countRows(t, s, ctx, "select count(*) from spans"),
-			"batch %d left rows behind", i)
+		_, err := ingestReport(t, s, tracesWithDuplicateSpanID(600, 5))
+		require.NoError(t, err, "batch %d", i)
 	}
 
-	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
-		return spans.Ingest(ctx, conn, createTestTracePdata(), s.FlushedIDs())
-	}), "a good batch after three failed ones must still ingest")
-	assert.Equal(t, 9, countRows(t, s, ctx, "select count(*) from spans"))
+	assert.Zero(t, countRows(t, s, ctx, `
+		select count(*) from events e
+		where not exists (select 1 from spans s where s.span_id = e.span_id)
+	`), "orphaned events")
+	assert.Zero(t, countRows(t, s, ctx, `
+		select count(*) from links l
+		where not exists (select 1 from spans s where s.span_id = l.span_id)
+	`), "orphaned links")
+
+	_, err := ingestReport(t, s, createTestTracePdata())
+	require.NoError(t, err, "a later batch must still ingest")
 }
 
-// The failure has to say what happened. A duplicate key is a user-facing
-// condition -- their sender is reusing span ids -- so the message must survive
-// the joins on the way out rather than being flattened into "ingest failed".
-func TestIngest_DuplicateErrorNamesTheConstraint(t *testing.T) {
+// Dictionary rows written for spans that were then rejected are harmless
+// orphans, but a span that *was* written must never reference a missing one.
+func TestIngest_NoDanglingAttributeReferences(t *testing.T) {
 	t.Parallel()
 	s, ctx := storetest.New(t)
 
-	err := s.WithConn(func(conn driver.Conn) error {
-		return spans.Ingest(ctx, conn, tracesWithDuplicateSpanID(600), s.FlushedIDs())
-	})
-	require.Error(t, err)
-	t.Logf("error surfaced to the exporter:\n%v", err)
-	assert.Contains(t, err.Error(), "PRIMARY KEY or UNIQUE constraint")
+	_, err := ingestReport(t, s, tracesWithDuplicateSpanID(600, 25))
+	require.NoError(t, err)
+	_, err = ingestReport(t, s, createTestTracePdata())
+	require.NoError(t, err)
+
+	assert.Zero(t, countRows(t, s, ctx, `
+		select count(*)
+		from (select unnest(attribute_ids) as id from spans) x
+		where not exists (select 1 from attributes a where a.id = x.id)
+	`), "spans reference dictionary rows that do not exist")
 }

--- a/desktopexporter/internal/store/spans/rejections_test.go
+++ b/desktopexporter/internal/store/spans/rejections_test.go
@@ -1,0 +1,76 @@
+package spans_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store"
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/storetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type rejectionRow struct {
+	kind        string
+	occurrences int64
+	sample      string
+}
+
+func readRejections(t *testing.T, s *store.Store) []rejectionRow {
+	t.Helper()
+	out, err := readStore(s, func(db *sql.DB) ([]rejectionRow, error) {
+		rows, err := db.Query(`select kind, occurrences, coalesce(sample, '')
+			from ingest_rejections order by kind`)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		var got []rejectionRow
+		for rows.Next() {
+			var r rejectionRow
+			if err := rows.Scan(&r.kind, &r.occurrences, &r.sample); err != nil {
+				return nil, err
+			}
+			got = append(got, r)
+		}
+		return got, rows.Err()
+	})
+	require.NoError(t, err)
+	return out
+}
+
+// A resend records one row saying how many spans it refused, with a span id to
+// link to -- not one row per refused span.
+func TestRejections_ResendRecordsOneAggregateRow(t *testing.T) {
+	t.Parallel()
+	s, _ := storetest.New(t)
+
+	_, err := ingestReport(t, s, createTestTracePdata())
+	require.NoError(t, err)
+	assert.Empty(t, readRejections(t, s), "a clean batch records nothing")
+
+	_, err = ingestReport(t, s, createTestTracePdata())
+	require.NoError(t, err)
+
+	got := readRejections(t, s)
+	require.Len(t, got, 1, "one row per (signal, kind), not per span")
+	assert.Equal(t, "span_already_stored", got[0].kind)
+	assert.EqualValues(t, 9, got[0].occurrences)
+	assert.NotEmpty(t, got[0].sample, "a span id to link to")
+}
+
+// Repeating the resend accumulates into the same row rather than growing the
+// table, which is what keeps a replay loop from bloating the database.
+func TestRejections_RepeatedResendsAccumulateInOneRow(t *testing.T) {
+	t.Parallel()
+	s, _ := storetest.New(t)
+
+	for range 4 {
+		_, err := ingestReport(t, s, createTestTracePdata())
+		require.NoError(t, err)
+	}
+
+	got := readRejections(t, s)
+	require.Len(t, got, 1, "a replay loop must not grow the table")
+	assert.EqualValues(t, 27, got[0].occurrences, "3 resends of 9 spans")
+}

--- a/desktopexporter/internal/store/spans/spans.go
+++ b/desktopexporter/internal/store/spans/spans.go
@@ -26,8 +26,7 @@ var (
 	ErrSpansStoreInternal = errors.New("spans store internal error")
 )
 
-// scopeKey identifies a scope by its position in the batch: the ri'th resource's
-// si'th scope. Pass 1 resolves each to a dictionary id and pass 2 reads it back.
+// scopeKey identifies a scope by position: the ri'th resource's si'th scope.
 type scopeKey struct{ ri, si int }
 
 // flushIntervalSpans bounds how many spans accumulate in the appenders before
@@ -64,33 +63,23 @@ func resourceServiceName(attrs pcommon.Map) string {
 	return ""
 }
 
-// Ingest ingests trace spans from pdata into the spans, events, links, and
-// attributes tables. The caller must hold any required lock on the connection.
-//
-// Two passes. The first walks the resource/scope hierarchy, hashing every
-// attribute into a Dictionary and resolving each resource and scope to a
-// content-derived id; it then writes the dictionary in three inserts. The
-// second opens the appenders and walks again, appending owners with the id
-// arrays the first pass produced.
-//
-// The split exists because the dictionary needs conflict handling and the
-// appender has none: its whole surface is AppendRow/Flush/Clear/Close, and a
-// duplicate errors at flush and takes the chunk with it. Ordering is safe
-// because the inserts commit before any appender flush, and the appenders open
-// after the resolve -- the same shape metrics.Ingest already used for its
-// stream upsert.
-// Ingest is IngestReport for callers with nowhere to put the report. Rows the
-// store refused are still skipped rather than failing the batch; this form just
-// cannot tell you how many there were.
+// Ingest is IngestReport for callers with nowhere to put the report. Refused
+// rows are still skipped rather than failing the batch.
 func Ingest(ctx context.Context, conn driver.Conn, traces ptrace.Traces, flushed *ingest.FlushedIDs) error {
 	_, err := IngestReport(ctx, conn, traces, flushed)
 	return err
 }
 
-// IngestReport ingests a batch and reports the spans it could not write.
+// IngestReport ingests trace spans into the spans, events, links and attributes
+// tables, reporting the spans it could not write. A non-empty Rejected is not a
+// failure: the batch landed without them. The caller must hold any required
+// lock on the connection.
 //
-// A non-empty RejectedSpans is not a failure: the batch landed, minus the rows
-// the store refused. Only a fault that stops the whole batch returns an error.
+// Two passes. The first hashes every attribute into a Dictionary, resolves each
+// resource and scope to a content-derived id, and writes the dictionary in
+// three inserts. The second appends the owner rows with the id arrays the first
+// produced. They are split because the dictionary needs conflict handling and
+// the appender has none.
 func IngestReport(ctx context.Context, conn driver.Conn, traces ptrace.Traces, flushed *ingest.FlushedIDs) (ingest.Rejected, error) {
 	if err := ctx.Err(); err != nil {
 		return ingest.Rejected{}, err
@@ -133,19 +122,14 @@ func IngestReport(ctx context.Context, conn driver.Conn, traces ptrace.Traces, f
 		return ingest.Rejected{}, fmt.Errorf("Ingest: %w: %w", ErrSpansStoreInternal, err)
 	}
 
-	// Pass 2: append the signal rows, retrying in narrowing halves so a bad row
-	// costs its own batch rather than everyone else's.
+	// Pass 2: append, retrying in halves so a bad row costs only itself.
 	return appendSpansBisecting(ctx, conn, traces, resourceIDs, scopeIDs,
 		spanAttrs, eventAttrs, linkAttrs)
 }
 
-// appendPass writes the signal rows for the spans keep says to write.
-//
-// keep is indexed by the span's ordinal in the walk, not by its id: a batch can
-// carry the same span id twice, and the two occurrences have to be separable so
-// the first can be kept and the second dropped. Skipped spans still advance the
-// event and link cursors, because those slices are consumed by position and
-// pass 1 filled them for every span whether or not this pass writes it.
+// appendPass writes the spans keep selects, by ordinal rather than id so two
+// occurrences of one id stay separable. Skipped spans still advance all three
+// cursors, which are consumed by position.
 func appendPass(
 	ctx context.Context,
 	conn driver.Conn,
@@ -184,8 +168,6 @@ func appendPass(
 				}
 
 				if !keep(spanCur) {
-					// Consumed by position, so a span this pass declines to
-					// write still has to be stepped over in all three slices.
 					spanCur++
 					eventCur += span.Events().Len()
 					linkCur += span.Links().Len()
@@ -294,10 +276,7 @@ func appendPass(
 	// other span's attributes -- corruption with no error, which is why this is
 	// checked rather than assumed.
 	if spanCur != len(spanAttrs) || eventCur != len(eventAttrs) || linkCur != len(linkAttrs) {
-		// ErrNotRowFault because this is a fault in this code, not in any
-		// row: it fails identically for every subset, so bisecting it would
-		// blame each span in turn and report the whole thing as a quiet
-		// tally rather than the loud failure it is meant to be.
+		// ErrNotRowFault: our bug, not a row's, so bisection must not search.
 		return fmt.Errorf("Ingest: %w: %w: pass mismatch (spans %d/%d, events %d/%d, links %d/%d)",
 			ErrSpansStoreInternal, ingest.ErrNotRowFault, spanCur, len(spanAttrs),
 			eventCur, len(eventAttrs), linkCur, len(linkAttrs))

--- a/desktopexporter/internal/store/spans/spans.go
+++ b/desktopexporter/internal/store/spans/spans.go
@@ -26,6 +26,10 @@ var (
 	ErrSpansStoreInternal = errors.New("spans store internal error")
 )
 
+// scopeKey identifies a scope by its position in the batch: the ri'th resource's
+// si'th scope. Pass 1 resolves each to a dictionary id and pass 2 reads it back.
+type scopeKey struct{ ri, si int }
+
 // flushIntervalSpans bounds how many spans accumulate in the appenders before
 // they are pushed to DuckDB. It exists to cap memory on a pathological batch,
 // not to make writes visible sooner -- nothing reads mid-batch, since ingest
@@ -75,15 +79,26 @@ func resourceServiceName(attrs pcommon.Map) string {
 // because the inserts commit before any appender flush, and the appenders open
 // after the resolve -- the same shape metrics.Ingest already used for its
 // stream upsert.
-func Ingest(ctx context.Context, conn driver.Conn, traces ptrace.Traces, flushed *ingest.FlushedIDs) (err error) {
+// Ingest is IngestReport for callers with nowhere to put the report. Rows the
+// store refused are still skipped rather than failing the batch; this form just
+// cannot tell you how many there were.
+func Ingest(ctx context.Context, conn driver.Conn, traces ptrace.Traces, flushed *ingest.FlushedIDs) error {
+	_, err := IngestReport(ctx, conn, traces, flushed)
+	return err
+}
+
+// IngestReport ingests a batch and reports the spans it could not write.
+//
+// A non-empty RejectedSpans is not a failure: the batch landed, minus the rows
+// the store refused. Only a fault that stops the whole batch returns an error.
+func IngestReport(ctx context.Context, conn driver.Conn, traces ptrace.Traces, flushed *ingest.FlushedIDs) (ingest.Rejected, error) {
 	if err := ctx.Err(); err != nil {
-		return err
+		return ingest.Rejected{}, err
 	}
 
 	// Pass 1: hash everything and resolve resource/scope identities.
 	dict := ingest.NewDictionary(flushed)
 
-	type scopeKey struct{ ri, si int }
 	resourceIDs := map[int]duckdb.UUID{}
 	scopeIDs := map[scopeKey]duckdb.UUID{}
 
@@ -115,10 +130,31 @@ func Ingest(ctx context.Context, conn driver.Conn, traces ptrace.Traces, flushed
 	}
 
 	if err := dict.Flush(ctx, conn); err != nil {
-		return fmt.Errorf("Ingest: %w: %w", ErrSpansStoreInternal, err)
+		return ingest.Rejected{}, fmt.Errorf("Ingest: %w: %w", ErrSpansStoreInternal, err)
 	}
 
-	// Pass 2: append the signal rows.
+	// Pass 2: append the signal rows, retrying in narrowing halves so a bad row
+	// costs its own batch rather than everyone else's.
+	return appendSpansBisecting(ctx, conn, traces, resourceIDs, scopeIDs,
+		spanAttrs, eventAttrs, linkAttrs)
+}
+
+// appendPass writes the signal rows for the spans keep says to write.
+//
+// keep is indexed by the span's ordinal in the walk, not by its id: a batch can
+// carry the same span id twice, and the two occurrences have to be separable so
+// the first can be kept and the second dropped. Skipped spans still advance the
+// event and link cursors, because those slices are consumed by position and
+// pass 1 filled them for every span whether or not this pass writes it.
+func appendPass(
+	ctx context.Context,
+	conn driver.Conn,
+	traces ptrace.Traces,
+	resourceIDs map[int]duckdb.UUID,
+	scopeIDs map[scopeKey]duckdb.UUID,
+	spanAttrs, eventAttrs, linkAttrs [][]duckdb.UUID,
+	keep func(ordinal int) bool,
+) (err error) {
 	tables := []string{"events", "links", "spans"}
 	appenders, err := ingest.NewAppenders(conn, tables)
 	if err != nil {
@@ -145,6 +181,15 @@ func Ingest(ctx context.Context, conn driver.Conn, traces ptrace.Traces, flushed
 			for _, span := range scopeSpan.Spans().All() {
 				if err := ctx.Err(); err != nil {
 					return err
+				}
+
+				if !keep(spanCur) {
+					// Consumed by position, so a span this pass declines to
+					// write still has to be stepped over in all three slices.
+					spanCur++
+					eventCur += span.Events().Len()
+					linkCur += span.Links().Len()
+					continue
 				}
 
 				traceUUID := duckdb.UUID(span.TraceID())

--- a/desktopexporter/internal/store/spans/spans.go
+++ b/desktopexporter/internal/store/spans/spans.go
@@ -133,20 +133,11 @@ func IngestReport(ctx context.Context, conn driver.Conn, traces ptrace.Traces, f
 		return ingest.Rejected{}, err
 	}
 
-	// Pass 2: append, retrying in halves so a bad row costs only itself.
-	rejected, err := appendSpansBisecting(ctx, conn, traces, resourceIDs, scopeIDs,
+	// Pass 2: append, retrying in halves so a bad row costs only itself. The
+	// skipped ordinals go in as pre-rejected rather than being tallied on
+	// afterwards, so every rejection is built in one place and in walk order.
+	return appendSpansBisecting(ctx, conn, traces, resourceIDs, scopeIDs,
 		spanAttrs, eventAttrs, linkAttrs, skip)
-	if err != nil {
-		return rejected, err
-	}
-
-	if len(skip) > 0 {
-		rejected.Count += len(skip)
-		if rejected.Reason == nil {
-			rejected.Reason = ErrSpanAlreadyStored
-		}
-	}
-	return rejected, nil
 }
 
 // appendPass writes the spans keep selects, by ordinal rather than id so two

--- a/desktopexporter/internal/store/spans/spans.go
+++ b/desktopexporter/internal/store/spans/spans.go
@@ -136,8 +136,21 @@ func IngestReport(ctx context.Context, conn driver.Conn, traces ptrace.Traces, f
 	// Pass 2: append, retrying in halves so a bad row costs only itself. The
 	// skipped ordinals go in as pre-rejected rather than being tallied on
 	// afterwards, so every rejection is built in one place and in walk order.
-	return appendSpansBisecting(ctx, conn, traces, resourceIDs, scopeIDs,
+	rejected, err := appendSpansBisecting(ctx, conn, traces, resourceIDs, scopeIDs,
 		spanAttrs, eventAttrs, linkAttrs, skip)
+	if err != nil {
+		return rejected, err
+	}
+
+	// Recorded after the appends commit, never inside them: a rejection
+	// describes a batch that succeeded, and rolling it back with a failed
+	// attempt would lose the only trace that anything was refused.
+	if err := recordSpanRejections(ctx, conn, rejected, spanIDs); err != nil {
+		// The telemetry landed. Failing the batch because we could not write
+		// a note about it would turn a report into an outage.
+		return rejected, nil
+	}
+	return rejected, nil
 }
 
 // appendPass writes the spans keep selects, by ordinal rather than id so two

--- a/desktopexporter/internal/store/spans/spans.go
+++ b/desktopexporter/internal/store/spans/spans.go
@@ -101,12 +101,16 @@ func IngestReport(ctx context.Context, conn driver.Conn, traces ptrace.Traces, f
 	// so a future edit that desynchronises the two passes fails loudly instead
 	// of silently pairing a span with another span's attributes.
 	var spanAttrs, eventAttrs, linkAttrs [][]duckdb.UUID
+	// Span ids in walk order, so dedupe below can speak in the same ordinals
+	// the append pass and bisection do.
+	var spanIDs []duckdb.UUID
 
 	for ri, resourceSpan := range traces.ResourceSpans().All() {
 		resourceIDs[ri] = dict.AddResource(resourceSpan.Resource())
 		for si, scopeSpan := range resourceSpan.ScopeSpans().All() {
 			scopeIDs[scopeKey{ri, si}] = dict.AddScope(scopeSpan.Scope())
 			for _, span := range scopeSpan.Spans().All() {
+				spanIDs = append(spanIDs, spanUUID(span.SpanID()))
 				spanAttrs = append(spanAttrs, dict.AddAttributes(span.Attributes(), ingest.ScopeSpan))
 				for _, event := range span.Events().All() {
 					eventAttrs = append(eventAttrs, dict.AddAttributes(event.Attributes(), ingest.ScopeEvent))
@@ -122,9 +126,27 @@ func IngestReport(ctx context.Context, conn driver.Conn, traces ptrace.Traces, f
 		return ingest.Rejected{}, fmt.Errorf("Ingest: %w: %w", ErrSpansStoreInternal, err)
 	}
 
+	// Skip ids the store already holds before writing rather than after
+	// failing: bisection would find them, but one transaction at a time.
+	skip, err := skipAlreadyStored(ctx, conn, spanIDs)
+	if err != nil {
+		return ingest.Rejected{}, err
+	}
+
 	// Pass 2: append, retrying in halves so a bad row costs only itself.
-	return appendSpansBisecting(ctx, conn, traces, resourceIDs, scopeIDs,
-		spanAttrs, eventAttrs, linkAttrs)
+	rejected, err := appendSpansBisecting(ctx, conn, traces, resourceIDs, scopeIDs,
+		spanAttrs, eventAttrs, linkAttrs, skip)
+	if err != nil {
+		return rejected, err
+	}
+
+	if len(skip) > 0 {
+		rejected.Count += len(skip)
+		if rejected.Reason == nil {
+			rejected.Reason = ErrSpanAlreadyStored
+		}
+	}
+	return rejected, nil
 }
 
 // appendPass writes the spans keep selects, by ordinal rather than id so two

--- a/desktopexporter/internal/store/spans/spans.go
+++ b/desktopexporter/internal/store/spans/spans.go
@@ -294,8 +294,12 @@ func appendPass(
 	// other span's attributes -- corruption with no error, which is why this is
 	// checked rather than assumed.
 	if spanCur != len(spanAttrs) || eventCur != len(eventAttrs) || linkCur != len(linkAttrs) {
-		return fmt.Errorf("Ingest: %w: pass mismatch (spans %d/%d, events %d/%d, links %d/%d)",
-			ErrSpansStoreInternal, spanCur, len(spanAttrs),
+		// ErrNotRowFault because this is a fault in this code, not in any
+		// row: it fails identically for every subset, so bisecting it would
+		// blame each span in turn and report the whole thing as a quiet
+		// tally rather than the loud failure it is meant to be.
+		return fmt.Errorf("Ingest: %w: %w: pass mismatch (spans %d/%d, events %d/%d, links %d/%d)",
+			ErrSpansStoreInternal, ingest.ErrNotRowFault, spanCur, len(spanAttrs),
 			eventCur, len(eventAttrs), linkCur, len(linkAttrs))
 	}
 

--- a/desktopexporter/internal/store/store.go
+++ b/desktopexporter/internal/store/store.go
@@ -27,6 +27,7 @@ const maxPoolConns = 4
 var (
 	ErrStoreConnectionClosed = errors.New("store connection is closed")
 	ErrStoreInitFailed       = errors.New("store initialization failed")
+	ErrStoreTransaction      = errors.New("store transaction failed")
 )
 
 type Store struct {
@@ -244,7 +245,18 @@ func (s *Store) Close() error {
 //
 // Lock order is ingestMu then mu, and nothing acquires them the other way
 // round, so the pair cannot deadlock.
-func (s *Store) WithConn(fn func(conn driver.Conn) error) error {
+//
+// fn runs inside a transaction, so a batch that fails partway leaves nothing
+// behind. Without one, ingest commits at every appender flush and at every
+// appender close, and those are neither atomic with each other nor ordered
+// usefully: a duplicate span id fails the spans appender while the links and
+// events appended alongside it commit regardless, orphaning children whose
+// parent row was rejected -- and every collector retry lays down another set.
+// DuckDB appenders honour a transaction opened on their own connection
+// (verified: flush inside a transaction, then rollback, leaves no rows), so
+// wrapping here fixes all three signals at once, in the same place their
+// serialization already lives.
+func (s *Store) WithConn(fn func(conn driver.Conn) error) (err error) {
 	s.ingestMu.Lock()
 	defer s.ingestMu.Unlock()
 
@@ -254,6 +266,37 @@ func (s *Store) WithConn(fn func(conn driver.Conn) error) error {
 	if s.db == nil || s.conn == nil {
 		return ErrStoreConnectionClosed
 	}
+
+	exec, ok := s.conn.(driver.ExecerContext)
+	if !ok {
+		return fmt.Errorf("WithConn: %w: connection cannot execute statements", ErrStoreTransaction)
+	}
+	ctx := context.Background()
+	if _, err := exec.ExecContext(ctx, "begin transaction", nil); err != nil {
+		return fmt.Errorf("WithConn: %w: begin: %w", ErrStoreTransaction, err)
+	}
+
+	defer func() {
+		if err != nil {
+			// FlushedIDs marks dictionary ids the moment their insert
+			// succeeds, which a rollback then unmakes. Left alone, the next
+			// batch would skip re-inserting rows that no longer exist and its
+			// spans would carry uuid[] references into nothing -- no foreign
+			// key catches that, attrs_json just joins empty, and attributes
+			// silently stop appearing. Forget is the coarse invalidation that
+			// is always safe: it costs one dictionary flush per sender to
+			// rebuild, on a path only an already-failed batch reaches.
+			s.flushed.Forget()
+			if _, rbErr := exec.ExecContext(ctx, "rollback", nil); rbErr != nil {
+				err = errors.Join(err, fmt.Errorf("WithConn: rollback: %w", rbErr))
+			}
+			return
+		}
+		if _, cErr := exec.ExecContext(ctx, "commit", nil); cErr != nil {
+			s.flushed.Forget()
+			err = fmt.Errorf("WithConn: %w: commit: %w", ErrStoreTransaction, cErr)
+		}
+	}()
 
 	return fn(s.conn)
 }

--- a/desktopexporter/internal/store/store.go
+++ b/desktopexporter/internal/store/store.go
@@ -246,17 +246,12 @@ func (s *Store) Close() error {
 // Lock order is ingestMu then mu, and nothing acquires them the other way
 // round, so the pair cannot deadlock.
 //
-// fn runs inside a transaction, so a batch that fails partway leaves nothing
-// behind. Without one, ingest commits at every appender flush and at every
-// appender close, and those are neither atomic with each other nor ordered
-// usefully: a duplicate span id fails the spans appender while the links and
-// events appended alongside it commit regardless, orphaning children whose
-// parent row was rejected -- and every collector retry lays down another set.
-// DuckDB appenders honour a transaction opened on their own connection
-// (verified: flush inside a transaction, then rollback, leaves no rows), so
-// wrapping here fixes all three signals at once, in the same place their
-// serialization already lives.
-func (s *Store) WithConn(fn func(conn driver.Conn) error) (err error) {
+// No transaction is opened here. Ingest owns its own, per appender pass,
+// because a failed pass is retried in narrowing halves to isolate the rows
+// that caused it -- and DuckDB has neither nested transactions ("cannot start
+// a transaction within a transaction") nor SAVEPOINT, so each attempt has to
+// be top level. See ingest.InTransaction.
+func (s *Store) WithConn(fn func(conn driver.Conn) error) error {
 	s.ingestMu.Lock()
 	defer s.ingestMu.Unlock()
 
@@ -266,37 +261,6 @@ func (s *Store) WithConn(fn func(conn driver.Conn) error) (err error) {
 	if s.db == nil || s.conn == nil {
 		return ErrStoreConnectionClosed
 	}
-
-	exec, ok := s.conn.(driver.ExecerContext)
-	if !ok {
-		return fmt.Errorf("WithConn: %w: connection cannot execute statements", ErrStoreTransaction)
-	}
-	ctx := context.Background()
-	if _, err := exec.ExecContext(ctx, "begin transaction", nil); err != nil {
-		return fmt.Errorf("WithConn: %w: begin: %w", ErrStoreTransaction, err)
-	}
-
-	defer func() {
-		if err != nil {
-			// FlushedIDs marks dictionary ids the moment their insert
-			// succeeds, which a rollback then unmakes. Left alone, the next
-			// batch would skip re-inserting rows that no longer exist and its
-			// spans would carry uuid[] references into nothing -- no foreign
-			// key catches that, attrs_json just joins empty, and attributes
-			// silently stop appearing. Forget is the coarse invalidation that
-			// is always safe: it costs one dictionary flush per sender to
-			// rebuild, on a path only an already-failed batch reaches.
-			s.flushed.Forget()
-			if _, rbErr := exec.ExecContext(ctx, "rollback", nil); rbErr != nil {
-				err = errors.Join(err, fmt.Errorf("WithConn: rollback: %w", rbErr))
-			}
-			return
-		}
-		if _, cErr := exec.ExecContext(ctx, "commit", nil); cErr != nil {
-			s.flushed.Forget()
-			err = fmt.Errorf("WithConn: %w: commit: %w", ErrStoreTransaction, cErr)
-		}
-	}()
 
 	return fn(s.conn)
 }

--- a/desktopexporter/internal/store/store.go
+++ b/desktopexporter/internal/store/store.go
@@ -27,7 +27,6 @@ const maxPoolConns = 4
 var (
 	ErrStoreConnectionClosed = errors.New("store connection is closed")
 	ErrStoreInitFailed       = errors.New("store initialization failed")
-	ErrStoreTransaction      = errors.New("store transaction failed")
 )
 
 type Store struct {
@@ -246,11 +245,8 @@ func (s *Store) Close() error {
 // Lock order is ingestMu then mu, and nothing acquires them the other way
 // round, so the pair cannot deadlock.
 //
-// No transaction is opened here. Ingest owns its own, per appender pass,
-// because a failed pass is retried in narrowing halves to isolate the rows
-// that caused it -- and DuckDB has neither nested transactions ("cannot start
-// a transaction within a transaction") nor SAVEPOINT, so each attempt has to
-// be top level. See ingest.InTransaction.
+// No transaction here: ingest opens one per bisection attempt, and DuckDB has
+// no nested transactions. See ingest.InTransaction.
 func (s *Store) WithConn(fn func(conn driver.Conn) error) error {
 	s.ingestMu.Lock()
 	defer s.ingestMu.Unlock()


### PR DESCRIPTION
Fixes #409. Merge before #415, which builds on it.

## Fixed

- One duplicate span used to throw away the whole batch, because a failed appender flush discards its entire buffer. Failed appends now retry in narrowing halves until each bad row is alone; everything else lands. `k` bad rows in `n` costs `O(k log n)` attempts, `k=0` costs one, so the normal path is untouched.
- Appenders commit at every flush, so a batch over 500 spans failing later left the earlier ones durable — and the sender's retry then collided with our own leftovers and failed for a reason the first attempt created. Each attempt is now its own transaction. The boundary sits in ingest, not `WithConn`, because DuckDB has no nested transactions and no `SAVEPOINT`.
- Spans already stored are skipped before the write, in one indexed probe, instead of discovered one failed transaction at a time. Replay is the live case: **800 all-duplicate spans went 789ms → 2ms**, and clean batches are unchanged within noise.
- A cancel landing on the commit left the transaction open, and since ingest owns one connection for the process, every later batch then failed until restart. Both ends now close under `context.WithoutCancel`.
- Faults no row caused (the pass-mismatch guards) would have been blamed on every row in turn and returned as `nil` — a corruption alarm turned into a silent tally. They wrap `ErrNotRowFault` and abort the search.
- `CloseAppenders` returns the first error instead of joining the derived "transaction is aborted" copies behind it.
- The exporter logs what was refused, with counts per reason. The batch succeeds, so nothing else would mention it.

## Also here

- Logs and metrics use the same path. Their ids are minted per row so nothing can collide today — uniformity, free when nothing fails.
- `ingest_rejections` table records the tally, one row per (signal, kind) so a replay loop cannot grow it. Nothing reads it yet; the RPC and home-page panel follow.

## Behaviour

| batch | before | after |
|---|---|---|
| 600 spans, 1 duplicate | batch dropped | 599 stored, 1 reported |
| 600 spans, 25 duplicates | batch dropped | 575 stored, 25 reported |
| resend of a stored trace | error, batch dropped | nothing duplicated, no error |
| 800 spans, all duplicates | batch dropped | 2ms, nothing duplicated |

Verified live: resending 17 seeded traces leaves 17 traces / 99 spans, zero `Dropping data`, one warning reading `rejected=99 reasons={"span already stored":99}`.
