### PR TITLE
Key a span by its trace and its id

### DIFF
--- a/desktopexporter/internal/store/queries/ddl/indexes/idx_events_span.sql
+++ b/desktopexporter/internal/store/queries/ddl/indexes/idx_events_span.sql
@@ -1,1 +1,1 @@
-create index if not exists idx_events_span on events(span_id)
+create index if not exists idx_events_span on events(trace_id, span_id)

--- a/desktopexporter/internal/store/queries/ddl/indexes/idx_links_span.sql
+++ b/desktopexporter/internal/store/queries/ddl/indexes/idx_links_span.sql
@@ -1,1 +1,1 @@
-create index if not exists idx_links_span on links(span_id)
+create index if not exists idx_links_span on links(trace_id, span_id)

--- a/desktopexporter/internal/store/queries/ddl/indexes/idx_links_trace.sql
+++ b/desktopexporter/internal/store/queries/ddl/indexes/idx_links_trace.sql
@@ -1,1 +1,1 @@
-create index if not exists idx_links_trace on links(trace_id, linked_span_id)
+create index if not exists idx_links_trace on links(linked_trace_id, linked_span_id)

--- a/desktopexporter/internal/store/queries/ddl/macros/link_json.sql
+++ b/desktopexporter/internal/store/queries/ddl/macros/link_json.sql
@@ -1,11 +1,11 @@
 -- link_json renders one span link for the wire.
 --
 -- traceID and spanID go out in OTLP wire form (dash-less lowercase hex) via
--- trace_id_wire / span_id_wire; linked_span_id is the span pointed *at*, as
--- distinct from the owning span_id.
+-- trace_id_wire / span_id_wire; linked_trace_id / linked_span_id are the context pointed *at*, as
+-- distinct from the owning trace_id / span_id.
 create or replace macro link_json(l, attrs) as (
     json_object(
-        'traceID', trace_id_wire(l.trace_id),
+        'traceID', trace_id_wire(l.linked_trace_id),
         'spanID', span_id_wire(l.linked_span_id),
         'traceState', l.trace_state,
         'droppedAttributesCount', l.dropped_attributes_count,

--- a/desktopexporter/internal/store/queries/ddl/tables/events.sql
+++ b/desktopexporter/internal/store/queries/ddl/tables/events.sql
@@ -1,9 +1,12 @@
 create table if not exists events (
 		id uuid primary key,
+		-- The owning span's trace. Part of the key that reaches it: a span id
+		-- alone does not identify a span across traces.
+		trace_id uuid not null,
 		span_id uuid not null,
 		name varchar,
 		timestamp bigint,
 		attribute_ids uuid[] not null,
 		dropped_attributes_count uinteger,
-		foreign key (span_id) references spans(span_id)
+		foreign key (trace_id, span_id) references spans(trace_id, span_id)
 	)

--- a/desktopexporter/internal/store/queries/ddl/tables/links.sql
+++ b/desktopexporter/internal/store/queries/ddl/tables/links.sql
@@ -1,12 +1,16 @@
 create table if not exists links (
 		id uuid primary key,
+		-- The owning span, by the pair that identifies one.
+		trace_id uuid not null,
 		span_id uuid not null,
-		trace_id uuid,
+		-- The context pointed *at*, which is a different trace entirely.
+		-- Named to match linked_span_id beside it.
+		linked_trace_id uuid,
 		linked_span_id uuid,
 		trace_state varchar,
 		attribute_ids uuid[] not null,
 		dropped_attributes_count uinteger,
 		-- As on spans: W3C trace flags for the linked context.
 		flags uinteger,
-		foreign key (span_id) references spans(span_id)
+		foreign key (trace_id, span_id) references spans(trace_id, span_id)
 	)

--- a/desktopexporter/internal/store/queries/ddl/tables/spans.sql
+++ b/desktopexporter/internal/store/queries/ddl/tables/spans.sql
@@ -1,7 +1,7 @@
 create table if not exists spans (
 		trace_id uuid,
 		trace_state varchar,
-		span_id uuid primary key,
+		span_id uuid not null,
 		parent_span_id uuid,
 		-- W3C trace flags plus the is_remote bit for the parent context.
 		-- Logs and metric datapoints have always stored theirs; spans and
@@ -51,6 +51,12 @@ create table if not exists spans (
 		-- and the appender takes a plain string more happily than a nullable.
 		resource_schema_url varchar not null default '',
 		scope_schema_url varchar not null default '',
+		-- Composite, because a span id is only required to be unique within
+		-- its trace. Global uniqueness is a property of random 8-byte
+		-- generation, not a guarantee, and keying on span_id alone rejected
+		-- conformant senders whose ids are unique per trace but not across
+		-- traces -- fixtures, replays, any deterministic generator.
+		primary key (trace_id, span_id),
 		foreign key (resource_id) references resources(id),
 		foreign key (scope_id) references scopes(id)
 	)

--- a/desktopexporter/internal/store/queries/spans/salvage_spans.sql
+++ b/desktopexporter/internal/store/queries/spans/salvage_spans.sql
@@ -146,7 +146,7 @@
 				s.dropped_attributes_count, s.dropped_events_count, s.dropped_links_count,
 				s.status_code, s.status_message
 			from walked st
-			join spans s on s.span_id = st.span_id
+			join spans s on s.trace_id = st.trace_id and s.span_id = st.span_id
 		),
 
 		-- The attributes this trace references, as one MAP, probed by the three
@@ -180,9 +180,11 @@
 			where id in (
 				select unnest(attribute_ids) from tree
 				union select unnest(e.attribute_ids) from events e
-					where e.span_id in (select span_id from tree)
+					where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
 				union select unnest(l.attribute_ids) from links l
-					where l.span_id in (select span_id from tree)
+					where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
 			)
 		),
 
@@ -200,7 +202,7 @@
 		-- 0.19s CPU. attrs_mapped orders by (key, id) exactly as attrs_json
 		-- does, so the rendered JSON is byte-identical to both earlier forms.
 		span_attrs as (
-			select ts.span_id as id, attrs_mapped(ts.attribute_ids, dm.m) as attrs
+			select ts.trace_id, ts.span_id as id, attrs_mapped(ts.attribute_ids, dm.m) as attrs
 			from tree ts, dict_map dm
 			where len(ts.attribute_ids) > 0
 		),
@@ -208,33 +210,37 @@
 		event_attrs as (
 			select e.id, attrs_mapped(e.attribute_ids, dm.m) as attrs
 			from events e, dict_map dm
-			where e.span_id in (select span_id from tree)
+			where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
 				and len(e.attribute_ids) > 0
 		),
 
 		link_attrs as (
 			select l.id, attrs_mapped(l.attribute_ids, dm.m) as attrs
 			from links l, dict_map dm
-			where l.span_id in (select span_id from tree)
+			where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
 				and len(l.attribute_ids) > 0
 		),
 
 		event_data as (
-			select e.span_id,
+			select e.trace_id, e.span_id,
 				to_json(list(event_json(e, ea.attrs) order by e.timestamp)) as events
 			from events e
 			left join event_attrs ea on ea.id = e.id
-			where e.span_id in (select span_id from tree)
-			group by e.span_id
+			where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
+			group by e.trace_id, e.span_id
 		),
 
 		link_data as (
-			select l.span_id,
+			select l.trace_id, l.span_id,
 				json_group_array(link_json(l, la.attrs)) as links
 			from links l
 			left join link_attrs la on la.id = l.id
-			where l.span_id in (select span_id from tree)
-			group by l.span_id
+			where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
+			group by l.trace_id, l.span_id
 		),
 
 		-- Resource and scope JSON is built once per *distinct owner*, which is
@@ -298,10 +304,10 @@
 			from tree ts
 			join resource_data rd on rd.id = ts.resource_id
 			join scope_data scd on scd.id = ts.scope_id
-			left join span_attrs sa on sa.id = ts.span_id
+			left join span_attrs sa on sa.trace_id = ts.trace_id and sa.id = ts.span_id
 			{{.MatchedJoin}}
-			left join event_data ed on ts.span_id = ed.span_id
-			left join link_data ld on ts.span_id = ld.span_id
+			left join event_data ed on ts.trace_id = ed.trace_id and ts.span_id = ed.span_id
+			left join link_data ld on ts.trace_id = ld.trace_id and ts.span_id = ld.span_id
 		)
 
 		select case

--- a/desktopexporter/internal/store/queries/spans/search_spans.sql
+++ b/desktopexporter/internal/store/queries/spans/search_spans.sql
@@ -80,7 +80,7 @@
 				s.dropped_attributes_count, s.dropped_events_count, s.dropped_links_count,
 				s.status_code, s.status_message
 			from spans_tree st
-			join spans s on s.span_id = st.span_id
+			join spans s on s.trace_id = st.trace_id and s.span_id = st.span_id
 		),
 
 		-- The attributes this trace references, as one MAP, probed by the three
@@ -114,9 +114,11 @@
 			where id in (
 				select unnest(attribute_ids) from tree
 				union select unnest(e.attribute_ids) from events e
-					where e.span_id in (select span_id from tree)
+					where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
 				union select unnest(l.attribute_ids) from links l
-					where l.span_id in (select span_id from tree)
+					where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
 			)
 		),
 
@@ -134,7 +136,7 @@
 		-- 0.19s CPU. attrs_mapped orders by (key, id) exactly as attrs_json
 		-- does, so the rendered JSON is byte-identical to both earlier forms.
 		span_attrs as (
-			select ts.span_id as id, attrs_mapped(ts.attribute_ids, dm.m) as attrs
+			select ts.trace_id, ts.span_id as id, attrs_mapped(ts.attribute_ids, dm.m) as attrs
 			from tree ts, dict_map dm
 			where len(ts.attribute_ids) > 0
 		),
@@ -142,33 +144,37 @@
 		event_attrs as (
 			select e.id, attrs_mapped(e.attribute_ids, dm.m) as attrs
 			from events e, dict_map dm
-			where e.span_id in (select span_id from tree)
+			where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
 				and len(e.attribute_ids) > 0
 		),
 
 		link_attrs as (
 			select l.id, attrs_mapped(l.attribute_ids, dm.m) as attrs
 			from links l, dict_map dm
-			where l.span_id in (select span_id from tree)
+			where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
 				and len(l.attribute_ids) > 0
 		),
 
 		event_data as (
-			select e.span_id,
+			select e.trace_id, e.span_id,
 				to_json(list(event_json(e, ea.attrs) order by e.timestamp)) as events
 			from events e
 			left join event_attrs ea on ea.id = e.id
-			where e.span_id in (select span_id from tree)
-			group by e.span_id
+			where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
+			group by e.trace_id, e.span_id
 		),
 
 		link_data as (
-			select l.span_id,
+			select l.trace_id, l.span_id,
 				json_group_array(link_json(l, la.attrs)) as links
 			from links l
 			left join link_attrs la on la.id = l.id
-			where l.span_id in (select span_id from tree)
-			group by l.span_id
+			where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
+			group by l.trace_id, l.span_id
 		),
 
 		-- Resource and scope JSON is built once per *distinct owner*, which is
@@ -221,10 +227,10 @@
 			from tree ts
 			join resource_data rd on rd.id = ts.resource_id
 			join scope_data scd on scd.id = ts.scope_id
-			left join span_attrs sa on sa.id = ts.span_id
+			left join span_attrs sa on sa.trace_id = ts.trace_id and sa.id = ts.span_id
 			{{.MatchedJoin}}
-			left join event_data ed on ts.span_id = ed.span_id
-			left join link_data ld on ts.span_id = ld.span_id
+			left join event_data ed on ts.trace_id = ed.trace_id and ts.span_id = ed.span_id
+			left join link_data ld on ts.trace_id = ld.trace_id and ts.span_id = ld.span_id
 		)
 
 		select case

--- a/desktopexporter/internal/store/schema/version.go
+++ b/desktopexporter/internal/store/schema/version.go
@@ -68,7 +68,7 @@ package schema
 // of stream identity. Same mechanism as versions 3 and 6: a new column on an
 // existing table, so a version 6 file fails the metric appender's column count
 // on its first metric batch.
-const Version = 7
+const Version = 8
 
 // VersionTableQuery creates the version table.
 //

--- a/desktopexporter/internal/store/spans/composite_key_test.go
+++ b/desktopexporter/internal/store/spans/composite_key_test.go
@@ -1,0 +1,95 @@
+package spans_test
+
+import (
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/spans"
+	"github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/storetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// traceReusingSpanIDs builds one trace whose spans use ids 1 and 2, with an
+// event and a link on each, named after the trace so they can be told apart.
+func traceReusingSpanIDs(traceHex, label string) ptrace.Traces {
+	base := time.Now().UnixNano()
+	tr := ptrace.NewTraces()
+	rs := tr.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", label)
+	ss := rs.ScopeSpans().AppendEmpty()
+	ss.Scope().SetName("sc")
+	traceID := mustDecodeTraceID(traceHex)
+
+	for _, n := range []string{"0000000000000001", "0000000000000002"} {
+		sp := ss.Spans().AppendEmpty()
+		sp.SetTraceID(traceID)
+		sp.SetSpanID(mustDecodeSpanID(n))
+		sp.SetName(label + "-" + n)
+		sp.SetStartTimestamp(pcommon.Timestamp(base))
+		sp.SetEndTimestamp(pcommon.Timestamp(base + int64(time.Second)))
+
+		e := sp.Events().AppendEmpty()
+		e.SetName(label + "-event")
+		e.SetTimestamp(pcommon.Timestamp(base))
+
+		l := sp.Links().AppendEmpty()
+		l.SetTraceID(mustDecodeTraceID("000000000000000000000000000000ff"))
+		l.SetSpanID(mustDecodeSpanID("00000000000000ff"))
+	}
+	return tr
+}
+
+// Two traces may legitimately use the same span ids.
+//
+// Span ids are only required to be unique within a trace -- global uniqueness
+// is a property of random generation, not a guarantee. Keying spans on span_id
+// alone rejected the second trace outright, which made a conformant sender look
+// like it was reusing ids.
+func TestCompositeKey_TwoTracesMayShareSpanIDs(t *testing.T) {
+	t.Parallel()
+	s, ctx := storetest.New(t)
+
+	repA, err := ingestReport(t, s, traceReusingSpanIDs("000000000000000000000000000000a1", "alpha"))
+	require.NoError(t, err)
+	assert.Zero(t, repA.Count())
+
+	repB, err := ingestReport(t, s, traceReusingSpanIDs("000000000000000000000000000000b2", "bravo"))
+	require.NoError(t, err)
+	assert.Zero(t, repB.Count(), "a second trace reusing span ids is not a duplicate")
+
+	assert.Equal(t, 4, countRows(t, s, ctx, "select count(*) from spans"))
+	assert.Equal(t, 4, countRows(t, s, ctx, "select count(*) from events"))
+	assert.Equal(t, 4, countRows(t, s, ctx, "select count(*) from links"))
+}
+
+// Fetching one of those traces must not pull in the other's children, which is
+// the contamination the composite key makes possible if a join forgets the
+// trace.
+func TestCompositeKey_TraceFetchDoesNotBorrowAnotherTracesChildren(t *testing.T) {
+	t.Parallel()
+	s, ctx := storetest.New(t)
+
+	_, err := ingestReport(t, s, traceReusingSpanIDs("000000000000000000000000000000a1", "alpha"))
+	require.NoError(t, err)
+	_, err = ingestReport(t, s, traceReusingSpanIDs("000000000000000000000000000000b2", "bravo"))
+	require.NoError(t, err)
+
+	raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+		return spans.SearchSpans(ctx, db, "00000000-0000-0000-0000-0000000000a1", nil)
+	})
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+
+	body := string(raw)
+	assert.Contains(t, body, "alpha-event")
+	assert.NotContains(t, body, "bravo-event",
+		"events from the other trace leaked in through a span id match")
+	assert.Equal(t, 2, len(got["spans"].([]any)))
+}

--- a/desktopexporter/internal/store/spans/dedupe.go
+++ b/desktopexporter/internal/store/spans/dedupe.go
@@ -11,11 +11,17 @@ import (
 	"github.com/google/uuid"
 )
 
-// ErrSpanAlreadyStored is the reason a span was skipped because its id is
-// already in the store, or repeated earlier in the same batch. Span ids are
-// required to be unique, so this means the sender is reusing them -- most often
-// a replayed capture.
-var ErrSpanAlreadyStored = errors.New("span id already stored")
+// ErrSpanAlreadyStored is the reason a span was skipped because the store
+// already holds it, or because an earlier span in the same batch claimed the
+// same identity.
+var ErrSpanAlreadyStored = errors.New("span already stored")
+
+// spanKey identifies one span. A span id is only required to be unique within
+// its trace, so the trace is part of the identity rather than context.
+type spanKey struct {
+	trace duckdb.UUID
+	span  duckdb.UUID
+}
 
 // spanUUID is the span's 8-byte id widened into a uuid, zero-padded high.
 func spanUUID(id [8]byte) duckdb.UUID {
@@ -24,87 +30,112 @@ func spanUUID(id [8]byte) duckdb.UUID {
 	return duckdb.UUID(padded)
 }
 
-// skipAlreadyStored returns the ordinals whose span id the store already holds,
-// or which repeat an earlier ordinal in this batch. The first occurrence of a
-// repeated id is kept.
+// skipAlreadyStored returns the ordinals the store already holds, or which
+// repeat an earlier ordinal in this batch. The first occurrence is kept.
 //
 // Bisection would find these anyway, but only by failing: every row bad means
 // 2n-1 transactions, measured at ~1ms per span, so replaying a large capture
 // spends minutes discovering one row at a time what one indexed lookup answers
-// at once. It also gives a truer reason than a constraint violation surfaced
-// from a failed flush.
-func skipAlreadyStored(ctx context.Context, conn driver.Conn, ids []duckdb.UUID) (map[int]error, error) {
-	if len(ids) == 0 {
+// at once.
+func skipAlreadyStored(ctx context.Context, conn driver.Conn, keys []spanKey) (map[int]error, error) {
+	if len(keys) == 0 {
 		return nil, nil
 	}
 
-	stored, err := storedSpanIDs(ctx, conn, ids)
+	stored, err := storedSpans(ctx, conn, keys)
 	if err != nil {
 		return nil, err
 	}
 
 	skip := map[int]error{}
-	seen := make(map[duckdb.UUID]struct{}, len(ids))
-	for ordinal, id := range ids {
-		_, repeated := seen[id]
-		if _, ok := stored[id]; ok || repeated {
+	seen := make(map[spanKey]struct{}, len(keys))
+	for ordinal, key := range keys {
+		_, repeated := seen[key]
+		if _, ok := stored[key]; ok || repeated {
 			skip[ordinal] = ErrSpanAlreadyStored
 			continue
 		}
-		seen[id] = struct{}{}
+		seen[key] = struct{}{}
 	}
 	return skip, nil
 }
 
-// storedSpanIDs returns which of ids the spans table already holds. One bound
-// array argument, so the statement text is the same whatever the batch holds,
-// and span_id is the primary key so each probe is an index lookup.
+// storedSpans returns which of keys the spans table already holds. Two bound
+// arrays, so the statement text is the same whatever the batch holds, and
+// (trace_id, span_id) is the primary key so each probe is an index lookup.
 //
 // Runs on conn rather than the pool: ingest already holds the store's locks,
 // and reaching back through a locking Store method from inside WithConn would
 // deadlock.
-func storedSpanIDs(ctx context.Context, conn driver.Conn, ids []duckdb.UUID) (map[duckdb.UUID]struct{}, error) {
+func storedSpans(ctx context.Context, conn driver.Conn, keys []spanKey) (map[spanKey]struct{}, error) {
 	queryer, ok := conn.(driver.QueryerContext)
 	if !ok {
-		return nil, fmt.Errorf("storedSpanIDs: %w: connection cannot query", ErrSpansStoreInternal)
+		return nil, fmt.Errorf("storedSpans: %w: connection cannot query", ErrSpansStoreInternal)
 	}
 
-	text := make([]string, len(ids))
-	for i, id := range ids {
-		text[i] = id.String()
+	traces := make([]string, len(keys))
+	spanIDs := make([]string, len(keys))
+	for i, k := range keys {
+		traces[i] = k.trace.String()
+		spanIDs[i] = k.span.String()
 	}
 
-	const q = `select span_id::varchar from spans
-		where span_id in (select unnest(?::varchar[])::uuid)`
+	// The two arrays are unnested together so they stay paired: a span id is
+	// only looked for under the trace it arrived with.
+	const q = `select s.trace_id::varchar, s.span_id::varchar
+		from spans s
+		join (select unnest(?::varchar[])::uuid as trace_id,
+		             unnest(?::varchar[])::uuid as span_id) w
+			on w.trace_id = s.trace_id and w.span_id = s.span_id`
 
-	arg, err := prepareSpanArg(conn, text)
+	traceArg, err := prepareSpanArg(conn, traces)
 	if err != nil {
-		return nil, fmt.Errorf("storedSpanIDs: %w: %w", ErrSpansStoreInternal, err)
+		return nil, fmt.Errorf("storedSpans: %w: %w", ErrSpansStoreInternal, err)
+	}
+	spanArg, err := prepareSpanArg(conn, spanIDs)
+	if err != nil {
+		return nil, fmt.Errorf("storedSpans: %w: %w", ErrSpansStoreInternal, err)
 	}
 
-	rows, err := queryer.QueryContext(ctx, q, []driver.NamedValue{{Ordinal: 1, Value: arg}})
+	rows, err := queryer.QueryContext(ctx, q, []driver.NamedValue{
+		{Ordinal: 1, Value: traceArg},
+		{Ordinal: 2, Value: spanArg},
+	})
 	if err != nil {
-		return nil, fmt.Errorf("storedSpanIDs: %w: %w", ErrSpansStoreInternal, err)
+		return nil, fmt.Errorf("storedSpans: %w: %w", ErrSpansStoreInternal, err)
 	}
 	defer rows.Close()
 
-	out := make(map[duckdb.UUID]struct{})
-	dest := make([]driver.Value, 1)
+	out := make(map[spanKey]struct{})
+	dest := make([]driver.Value, 2)
 	for {
 		if err := rows.Next(dest); err != nil {
 			break
 		}
-		s, ok := dest[0].(string)
-		if !ok {
+		traceText, ok1 := dest[0].(string)
+		spanText, ok2 := dest[1].(string)
+		if !ok1 || !ok2 {
 			continue
 		}
-		parsed, err := uuid.Parse(s)
+		trace, err := parseUUIDText(traceText)
 		if err != nil {
-			return nil, fmt.Errorf("storedSpanIDs: %w: %w", ErrSpansStoreInternal, err)
+			return nil, fmt.Errorf("storedSpans: %w: %w", ErrSpansStoreInternal, err)
 		}
-		out[duckdb.UUID(parsed)] = struct{}{}
+		span, err := parseUUIDText(spanText)
+		if err != nil {
+			return nil, fmt.Errorf("storedSpans: %w: %w", ErrSpansStoreInternal, err)
+		}
+		out[spanKey{trace: trace, span: span}] = struct{}{}
 	}
 	return out, nil
+}
+
+func parseUUIDText(s string) (duckdb.UUID, error) {
+	parsed, err := uuid.Parse(s)
+	if err != nil {
+		return duckdb.UUID{}, err
+	}
+	return duckdb.UUID(parsed), nil
 }
 
 // prepareSpanArg converts a Go value into something the duckdb driver will bind,
@@ -128,9 +159,9 @@ func prepareSpanArg(conn driver.Conn, v any) (driver.Value, error) {
 // recordSpanRejections tallies what this batch was refused, one row per kind.
 //
 // The sample is the refused span's own id. For an already-stored rejection that
-// row is in the store, so it is a working link -- better than keeping a copy of
-// something we already have.
-func recordSpanRejections(ctx context.Context, conn driver.Conn, r ingest.Rejected, spanIDs []duckdb.UUID) error {
+// row is in the store, so it is a working link rather than a copy of something
+// we already have.
+func recordSpanRejections(ctx context.Context, conn driver.Conn, r ingest.Rejected, keys []spanKey) error {
 	if r.Count() == 0 {
 		return nil
 	}
@@ -142,10 +173,10 @@ func recordSpanRejections(ctx context.Context, conn driver.Conn, r ingest.Reject
 			return ingest.KindRefused
 		},
 		func(ordinal int) string {
-			if ordinal < 0 || ordinal >= len(spanIDs) {
+			if ordinal < 0 || ordinal >= len(keys) {
 				return ""
 			}
-			return spanIDs[ordinal].String()
+			return keys[ordinal].span.String()
 		})
 	return ingest.RecordRejections(ctx, conn, records)
 }

--- a/desktopexporter/internal/store/spans/spans.go
+++ b/desktopexporter/internal/store/spans/spans.go
@@ -101,16 +101,19 @@ func IngestReport(ctx context.Context, conn driver.Conn, traces ptrace.Traces, f
 	// so a future edit that desynchronises the two passes fails loudly instead
 	// of silently pairing a span with another span's attributes.
 	var spanAttrs, eventAttrs, linkAttrs [][]duckdb.UUID
-	// Span ids in walk order, so dedupe below can speak in the same ordinals
-	// the append pass and bisection do.
-	var spanIDs []duckdb.UUID
+	// Span identities in walk order, so dedupe below can speak in the same
+	// ordinals the append pass and bisection do.
+	var spanKeys []spanKey
 
 	for ri, resourceSpan := range traces.ResourceSpans().All() {
 		resourceIDs[ri] = dict.AddResource(resourceSpan.Resource())
 		for si, scopeSpan := range resourceSpan.ScopeSpans().All() {
 			scopeIDs[scopeKey{ri, si}] = dict.AddScope(scopeSpan.Scope())
 			for _, span := range scopeSpan.Spans().All() {
-				spanIDs = append(spanIDs, spanUUID(span.SpanID()))
+				spanKeys = append(spanKeys, spanKey{
+					trace: duckdb.UUID(span.TraceID()),
+					span:  spanUUID(span.SpanID()),
+				})
 				spanAttrs = append(spanAttrs, dict.AddAttributes(span.Attributes(), ingest.ScopeSpan))
 				for _, event := range span.Events().All() {
 					eventAttrs = append(eventAttrs, dict.AddAttributes(event.Attributes(), ingest.ScopeEvent))
@@ -128,7 +131,7 @@ func IngestReport(ctx context.Context, conn driver.Conn, traces ptrace.Traces, f
 
 	// Skip ids the store already holds before writing rather than after
 	// failing: bisection would find them, but one transaction at a time.
-	skip, err := skipAlreadyStored(ctx, conn, spanIDs)
+	skip, err := skipAlreadyStored(ctx, conn, spanKeys)
 	if err != nil {
 		return ingest.Rejected{}, err
 	}
@@ -145,7 +148,7 @@ func IngestReport(ctx context.Context, conn driver.Conn, traces ptrace.Traces, f
 	// Recorded after the appends commit, never inside them: a rejection
 	// describes a batch that succeeded, and rolling it back with a failed
 	// attempt would lose the only trace that anything was refused.
-	if err := recordSpanRejections(ctx, conn, rejected, spanIDs); err != nil {
+	if err := recordSpanRejections(ctx, conn, rejected, spanKeys); err != nil {
 		// The telemetry landed. Failing the batch because we could not write
 		// a note about it would turn a report into an outage.
 		return rejected, nil
@@ -252,6 +255,7 @@ func appendPass(
 					eventCur++
 					err = appenders["events"].AppendRow(
 						duckdb.UUID(uuid.New()),        // ID UUID
+						traceUUID,                      // TraceID UUID
 						spanUUID,                       // SpanID UUID
 						event.Name(),                   // Name VARCHAR
 						int64(event.Timestamp()),       // Timestamp BIGINT
@@ -274,8 +278,9 @@ func appendPass(
 					linkCur++
 					err = appenders["links"].AppendRow(
 						duckdb.UUID(uuid.New()),       // ID UUID
-						spanUUID,                      // SpanID UUID
-						linkTraceUUID,                 // TraceID UUID
+						traceUUID,                     // TraceID UUID (owner)
+						spanUUID,                      // SpanID UUID (owner)
+						linkTraceUUID,                 // LinkedTraceID UUID
 						linkSpanUUID,                  // LinkedSpanID UUID
 						link.TraceState().AsRaw(),     // TraceState VARCHAR
 						linkAttrIDs,                   // AttributeIDs UUID[]
@@ -580,9 +585,18 @@ func DeleteSpansByIDs(ctx context.Context, db *sql.DB, spanIDs []any) error {
 	// One bound list per statement, rather than one placeholder per id: the
 	// SQL is static and cannot disagree with the argument count.
 	ids := util.ToStringList(spanIDs)
+	// Children are found by the pair that owns them. Matching on span_id alone
+	// would take another trace's events wherever two traces share a span id,
+	// which the composite key permits.
+	//
+	// A span id no longer identifies one span, so this deletes every span
+	// carrying one of these ids -- which is what it did before, and what the
+	// child deletes now match.
 	childQueries := []string{
-		`delete from links where span_id in (select id from uuid_list(?))`,
-		`delete from events where span_id in (select id from uuid_list(?))`,
+		`delete from links where (trace_id, span_id) in
+			(select trace_id, span_id from spans where span_id in (select id from uuid_list(?)))`,
+		`delete from events where (trace_id, span_id) in
+			(select trace_id, span_id from spans where span_id in (select id from uuid_list(?)))`,
 		`delete from spans where span_id in (select id from uuid_list(?))`,
 	}
 	for _, q := range childQueries {
@@ -600,8 +614,8 @@ func DeleteSpansByTraceIDs(ctx context.Context, db *sql.DB, traceIDs []any) erro
 	}
 	ids := util.ToStringList(traceIDs)
 	childQueries := []string{
-		`delete from links where span_id in (select span_id from spans where trace_id in (select id from uuid_list(?)))`,
-		`delete from events where span_id in (select span_id from spans where trace_id in (select id from uuid_list(?)))`,
+		`delete from links where trace_id in (select id from uuid_list(?))`,
+		`delete from events where trace_id in (select id from uuid_list(?))`,
 		`delete from spans where trace_id in (select id from uuid_list(?))`,
 	}
 	for _, q := range childQueries {
@@ -717,11 +731,20 @@ var eventColumns = map[string]struct{}{
 	"dropped_attributes_count": {},
 }
 
+// A child reaches its owning span by the pair that identifies one. Matching on
+// span_id alone would pull in another trace's events wherever two traces happen
+// to share a span id -- which the composite key now permits, because a span id
+// is only unique within its trace.
+const (
+	eventOwner = "e.trace_id = s.trace_id and e.span_id = s.span_id"
+	linkOwner  = "l.trace_id = s.trace_id and l.span_id = s.span_id"
+)
+
 var linkColumns = map[string]struct{}{
 	"flags":                    {},
 	"id":                       {},
 	"span_id":                  {},
-	"trace_id":                 {},
+	"linked_trace_id":          {},
 	"linked_span_id":           {},
 	"trace_state":              {},
 	"dropped_attributes_count": {},
@@ -766,16 +789,19 @@ func mapTraceFieldExpression(field *search.FieldDefinition) (string, error) {
 		if err := util.ValidateColumnName(snake, eventColumns); err != nil {
 			return "", fmt.Errorf("event field %q: %w: %w", field.Name, err, ErrInvalidTraceQuery)
 		}
-		return fmt.Sprintf("exists(select 1 from events e where e.span_id = s.span_id and e.%s {COND})", snake), nil
+		return fmt.Sprintf("exists(select 1 from events e where %s and e.%s {COND})", eventOwner, snake), nil
 	}
 	if col, found := strings.CutPrefix(field.Name, "link."); found {
 		snake := util.CamelToSnake(col)
-		// The served link JSON calls the linked target "spanID" (OTLP wire
-		// shape); the owning span is implicit in where the link appears.
-		// Alias the wire name to the linked_span_id column so searching
-		// what the UI displays actually matches.
-		if snake == "span_id" {
+		// The served link JSON calls the linked target "spanID" and
+		// "traceID" (OTLP wire shape); the owning span is implicit in where
+		// the link appears. Alias both wire names to the linked_ columns so
+		// searching what the UI displays actually matches.
+		switch snake {
+		case "span_id":
 			snake = "linked_span_id"
+		case "trace_id":
+			snake = "linked_trace_id"
 		}
 		if err := util.ValidateColumnName(snake, linkColumns); err != nil {
 			return "", fmt.Errorf("link field %q: %w: %w", field.Name, err, ErrInvalidTraceQuery)
@@ -786,10 +812,10 @@ func mapTraceFieldExpression(field *search.FieldDefinition) (string, error) {
 		switch snake {
 		case "linked_span_id":
 			colExpr = "right(replace(l." + snake + "::varchar, '-', ''), 16)"
-		case "trace_id":
-			colExpr = "replace(l.trace_id::varchar, '-', '')"
+		case "linked_trace_id":
+			colExpr = "replace(l.linked_trace_id::varchar, '-', '')"
 		}
-		return fmt.Sprintf("exists(select 1 from links l where l.span_id = s.span_id and %s {COND})", colExpr), nil
+		return fmt.Sprintf("exists(select 1 from links l where %s and %s {COND})", linkOwner, colExpr), nil
 	}
 	if field.Name == "duration" {
 		return "(s.end_time - s.start_time)", nil
@@ -853,12 +879,12 @@ func mapTraceAttributeExpressions(field *search.FieldDefinition, query *search.Q
 	case "event":
 		if p := ingest.IDProbe("e.attribute_ids", field, query, ingest.ScopeEvent); p != "" {
 			return []string{search.Complete(
-				"exists(select 1 from events e where e.span_id = s.span_id and " + p + ")")}, nil
+				"exists(select 1 from events e where " + eventOwner + " and " + p + ")")}, nil
 		}
 	case "link":
 		if p := ingest.IDProbe("l.attribute_ids", field, query, ingest.ScopeLink); p != "" {
 			return []string{search.Complete(
-				"exists(select 1 from links l where l.span_id = s.span_id and " + p + ")")}, nil
+				"exists(select 1 from links l where " + linkOwner + " and " + p + ")")}, nil
 		}
 	}
 
@@ -880,13 +906,13 @@ func mapTraceAttributeExpressions(field *search.FieldDefinition, query *search.Q
 		return []string{fmt.Sprintf(`exists(
 			select 1 from events e, unnest(e.attribute_ids) as t(aid)
 			join attributes a on a.id = t.aid
-			where e.span_id = s.span_id and a.key = %s and a.value {COND}
+			where e.trace_id = s.trace_id and e.span_id = s.span_id and a.key = %s and a.value {COND}
 		)`, keyParam)}, nil
 	case "link":
 		return []string{fmt.Sprintf(`exists(
 			select 1 from links l, unnest(l.attribute_ids) as t(aid)
 			join attributes a on a.id = t.aid
-			where l.span_id = s.span_id and a.key = %s and a.value {COND}
+			where l.trace_id = s.trace_id and l.span_id = s.span_id and a.key = %s and a.value {COND}
 		)`, keyParam)}, nil
 	default:
 		return nil, fmt.Errorf("unknown attribute scope %s: %w", field.AttributeScope, ErrInvalidTraceQuery)
@@ -905,8 +931,8 @@ func mapTraceGlobalExpressions() ([]string, error) {
 		"CAST(s.trace_state AS VARCHAR) {COND}",
 		"CAST(sc.name AS VARCHAR) {COND}",
 		"CAST(sc.version AS VARCHAR) {COND}",
-		"exists(select 1 from events e where e.span_id = s.span_id and CAST(e.name AS VARCHAR) {COND})",
-		"exists(select 1 from links l where l.span_id = s.span_id and (replace(l.trace_id::varchar, '-', '') {COND} or CAST(l.trace_state AS VARCHAR) {COND} or right(replace(l.linked_span_id::varchar, '-', ''), 16) {COND}))",
+		"exists(select 1 from events e where " + eventOwner + " and CAST(e.name AS VARCHAR) {COND})",
+		"exists(select 1 from links l where " + linkOwner + " and (replace(l.linked_trace_id::varchar, '-', '') {COND} or CAST(l.trace_state AS VARCHAR) {COND} or right(replace(l.linked_span_id::varchar, '-', ''), 16) {COND}))",
 		// Free-text search over attributes now takes three clauses where it used
 		// to take one. Under the old schema every attribute a span could reach
 		// -- its own, its resource's, its scope's, and every event's and link's
@@ -918,8 +944,8 @@ func mapTraceGlobalExpressions() ([]string, error) {
 		// concatenating those three arrays is one unnest. Events and links are
 		// separate rows and need their own EXISTS.
 		matchAnyAttribute("unnest(s.attribute_ids || r.attribute_ids || sc.attribute_ids) as t(aid)", ""),
-		matchAnyAttribute("events e, unnest(e.attribute_ids) as t(aid)", "e.span_id = s.span_id and "),
-		matchAnyAttribute("links l, unnest(l.attribute_ids) as t(aid)", "l.span_id = s.span_id and "),
+		matchAnyAttribute("events e, unnest(e.attribute_ids) as t(aid)", eventOwner+" and "),
+		matchAnyAttribute("links l, unnest(l.attribute_ids) as t(aid)", linkOwner+" and "),
 	}, nil
 }
 

--- a/desktopexporter/internal/store/spans/testdata/salvage_spans_no_search.sql
+++ b/desktopexporter/internal/store/spans/testdata/salvage_spans_no_search.sql
@@ -146,7 +146,7 @@
 				s.dropped_attributes_count, s.dropped_events_count, s.dropped_links_count,
 				s.status_code, s.status_message
 			from walked st
-			join spans s on s.span_id = st.span_id
+			join spans s on s.trace_id = st.trace_id and s.span_id = st.span_id
 		),
 
 		-- The attributes this trace references, as one MAP, probed by the three
@@ -180,9 +180,11 @@
 			where id in (
 				select unnest(attribute_ids) from tree
 				union select unnest(e.attribute_ids) from events e
-					where e.span_id in (select span_id from tree)
+					where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
 				union select unnest(l.attribute_ids) from links l
-					where l.span_id in (select span_id from tree)
+					where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
 			)
 		),
 
@@ -200,7 +202,7 @@
 		-- 0.19s CPU. attrs_mapped orders by (key, id) exactly as attrs_json
 		-- does, so the rendered JSON is byte-identical to both earlier forms.
 		span_attrs as (
-			select ts.span_id as id, attrs_mapped(ts.attribute_ids, dm.m) as attrs
+			select ts.trace_id, ts.span_id as id, attrs_mapped(ts.attribute_ids, dm.m) as attrs
 			from tree ts, dict_map dm
 			where len(ts.attribute_ids) > 0
 		),
@@ -208,33 +210,37 @@
 		event_attrs as (
 			select e.id, attrs_mapped(e.attribute_ids, dm.m) as attrs
 			from events e, dict_map dm
-			where e.span_id in (select span_id from tree)
+			where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
 				and len(e.attribute_ids) > 0
 		),
 
 		link_attrs as (
 			select l.id, attrs_mapped(l.attribute_ids, dm.m) as attrs
 			from links l, dict_map dm
-			where l.span_id in (select span_id from tree)
+			where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
 				and len(l.attribute_ids) > 0
 		),
 
 		event_data as (
-			select e.span_id,
+			select e.trace_id, e.span_id,
 				to_json(list(event_json(e, ea.attrs) order by e.timestamp)) as events
 			from events e
 			left join event_attrs ea on ea.id = e.id
-			where e.span_id in (select span_id from tree)
-			group by e.span_id
+			where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
+			group by e.trace_id, e.span_id
 		),
 
 		link_data as (
-			select l.span_id,
+			select l.trace_id, l.span_id,
 				json_group_array(link_json(l, la.attrs)) as links
 			from links l
 			left join link_attrs la on la.id = l.id
-			where l.span_id in (select span_id from tree)
-			group by l.span_id
+			where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
+			group by l.trace_id, l.span_id
 		),
 
 		-- Resource and scope JSON is built once per *distinct owner*, which is
@@ -298,10 +304,10 @@
 			from tree ts
 			join resource_data rd on rd.id = ts.resource_id
 			join scope_data scd on scd.id = ts.scope_id
-			left join span_attrs sa on sa.id = ts.span_id
+			left join span_attrs sa on sa.trace_id = ts.trace_id and sa.id = ts.span_id
 			
-			left join event_data ed on ts.span_id = ed.span_id
-			left join link_data ld on ts.span_id = ld.span_id
+			left join event_data ed on ts.trace_id = ed.trace_id and ts.span_id = ed.span_id
+			left join link_data ld on ts.trace_id = ld.trace_id and ts.span_id = ld.span_id
 		)
 
 		select case

--- a/desktopexporter/internal/store/spans/testdata/salvage_spans_with_search.sql
+++ b/desktopexporter/internal/store/spans/testdata/salvage_spans_with_search.sql
@@ -153,7 +153,7 @@
 				s.dropped_attributes_count, s.dropped_events_count, s.dropped_links_count,
 				s.status_code, s.status_message
 			from walked st
-			join spans s on s.span_id = st.span_id
+			join spans s on s.trace_id = st.trace_id and s.span_id = st.span_id
 		),
 
 		-- The attributes this trace references, as one MAP, probed by the three
@@ -187,9 +187,11 @@
 			where id in (
 				select unnest(attribute_ids) from tree
 				union select unnest(e.attribute_ids) from events e
-					where e.span_id in (select span_id from tree)
+					where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
 				union select unnest(l.attribute_ids) from links l
-					where l.span_id in (select span_id from tree)
+					where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
 			)
 		),
 
@@ -207,7 +209,7 @@
 		-- 0.19s CPU. attrs_mapped orders by (key, id) exactly as attrs_json
 		-- does, so the rendered JSON is byte-identical to both earlier forms.
 		span_attrs as (
-			select ts.span_id as id, attrs_mapped(ts.attribute_ids, dm.m) as attrs
+			select ts.trace_id, ts.span_id as id, attrs_mapped(ts.attribute_ids, dm.m) as attrs
 			from tree ts, dict_map dm
 			where len(ts.attribute_ids) > 0
 		),
@@ -215,33 +217,37 @@
 		event_attrs as (
 			select e.id, attrs_mapped(e.attribute_ids, dm.m) as attrs
 			from events e, dict_map dm
-			where e.span_id in (select span_id from tree)
+			where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
 				and len(e.attribute_ids) > 0
 		),
 
 		link_attrs as (
 			select l.id, attrs_mapped(l.attribute_ids, dm.m) as attrs
 			from links l, dict_map dm
-			where l.span_id in (select span_id from tree)
+			where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
 				and len(l.attribute_ids) > 0
 		),
 
 		event_data as (
-			select e.span_id,
+			select e.trace_id, e.span_id,
 				to_json(list(event_json(e, ea.attrs) order by e.timestamp)) as events
 			from events e
 			left join event_attrs ea on ea.id = e.id
-			where e.span_id in (select span_id from tree)
-			group by e.span_id
+			where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
+			group by e.trace_id, e.span_id
 		),
 
 		link_data as (
-			select l.span_id,
+			select l.trace_id, l.span_id,
 				json_group_array(link_json(l, la.attrs)) as links
 			from links l
 			left join link_attrs la on la.id = l.id
-			where l.span_id in (select span_id from tree)
-			group by l.span_id
+			where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
+			group by l.trace_id, l.span_id
 		),
 
 		-- Resource and scope JSON is built once per *distinct owner*, which is
@@ -305,10 +311,10 @@
 			from tree ts
 			join resource_data rd on rd.id = ts.resource_id
 			join scope_data scd on scd.id = ts.scope_id
-			left join span_attrs sa on sa.id = ts.span_id
+			left join span_attrs sa on sa.trace_id = ts.trace_id and sa.id = ts.span_id
 			left join matched_spans ms on ts.span_id = ms.span_id
-			left join event_data ed on ts.span_id = ed.span_id
-			left join link_data ld on ts.span_id = ld.span_id
+			left join event_data ed on ts.trace_id = ed.trace_id and ts.span_id = ed.span_id
+			left join link_data ld on ts.trace_id = ld.trace_id and ts.span_id = ld.span_id
 		)
 
 		select case

--- a/desktopexporter/internal/store/spans/testdata/search_spans_no_search.sql
+++ b/desktopexporter/internal/store/spans/testdata/search_spans_no_search.sql
@@ -80,7 +80,7 @@
 				s.dropped_attributes_count, s.dropped_events_count, s.dropped_links_count,
 				s.status_code, s.status_message
 			from spans_tree st
-			join spans s on s.span_id = st.span_id
+			join spans s on s.trace_id = st.trace_id and s.span_id = st.span_id
 		),
 
 		-- The attributes this trace references, as one MAP, probed by the three
@@ -114,9 +114,11 @@
 			where id in (
 				select unnest(attribute_ids) from tree
 				union select unnest(e.attribute_ids) from events e
-					where e.span_id in (select span_id from tree)
+					where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
 				union select unnest(l.attribute_ids) from links l
-					where l.span_id in (select span_id from tree)
+					where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
 			)
 		),
 
@@ -134,7 +136,7 @@
 		-- 0.19s CPU. attrs_mapped orders by (key, id) exactly as attrs_json
 		-- does, so the rendered JSON is byte-identical to both earlier forms.
 		span_attrs as (
-			select ts.span_id as id, attrs_mapped(ts.attribute_ids, dm.m) as attrs
+			select ts.trace_id, ts.span_id as id, attrs_mapped(ts.attribute_ids, dm.m) as attrs
 			from tree ts, dict_map dm
 			where len(ts.attribute_ids) > 0
 		),
@@ -142,33 +144,37 @@
 		event_attrs as (
 			select e.id, attrs_mapped(e.attribute_ids, dm.m) as attrs
 			from events e, dict_map dm
-			where e.span_id in (select span_id from tree)
+			where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
 				and len(e.attribute_ids) > 0
 		),
 
 		link_attrs as (
 			select l.id, attrs_mapped(l.attribute_ids, dm.m) as attrs
 			from links l, dict_map dm
-			where l.span_id in (select span_id from tree)
+			where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
 				and len(l.attribute_ids) > 0
 		),
 
 		event_data as (
-			select e.span_id,
+			select e.trace_id, e.span_id,
 				to_json(list(event_json(e, ea.attrs) order by e.timestamp)) as events
 			from events e
 			left join event_attrs ea on ea.id = e.id
-			where e.span_id in (select span_id from tree)
-			group by e.span_id
+			where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
+			group by e.trace_id, e.span_id
 		),
 
 		link_data as (
-			select l.span_id,
+			select l.trace_id, l.span_id,
 				json_group_array(link_json(l, la.attrs)) as links
 			from links l
 			left join link_attrs la on la.id = l.id
-			where l.span_id in (select span_id from tree)
-			group by l.span_id
+			where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
+			group by l.trace_id, l.span_id
 		),
 
 		-- Resource and scope JSON is built once per *distinct owner*, which is
@@ -221,10 +227,10 @@
 			from tree ts
 			join resource_data rd on rd.id = ts.resource_id
 			join scope_data scd on scd.id = ts.scope_id
-			left join span_attrs sa on sa.id = ts.span_id
+			left join span_attrs sa on sa.trace_id = ts.trace_id and sa.id = ts.span_id
 			
-			left join event_data ed on ts.span_id = ed.span_id
-			left join link_data ld on ts.span_id = ld.span_id
+			left join event_data ed on ts.trace_id = ed.trace_id and ts.span_id = ed.span_id
+			left join link_data ld on ts.trace_id = ld.trace_id and ts.span_id = ld.span_id
 		)
 
 		select case

--- a/desktopexporter/internal/store/spans/testdata/search_spans_with_search.sql
+++ b/desktopexporter/internal/store/spans/testdata/search_spans_with_search.sql
@@ -87,7 +87,7 @@
 				s.dropped_attributes_count, s.dropped_events_count, s.dropped_links_count,
 				s.status_code, s.status_message
 			from spans_tree st
-			join spans s on s.span_id = st.span_id
+			join spans s on s.trace_id = st.trace_id and s.span_id = st.span_id
 		),
 
 		-- The attributes this trace references, as one MAP, probed by the three
@@ -121,9 +121,11 @@
 			where id in (
 				select unnest(attribute_ids) from tree
 				union select unnest(e.attribute_ids) from events e
-					where e.span_id in (select span_id from tree)
+					where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
 				union select unnest(l.attribute_ids) from links l
-					where l.span_id in (select span_id from tree)
+					where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
 			)
 		),
 
@@ -141,7 +143,7 @@
 		-- 0.19s CPU. attrs_mapped orders by (key, id) exactly as attrs_json
 		-- does, so the rendered JSON is byte-identical to both earlier forms.
 		span_attrs as (
-			select ts.span_id as id, attrs_mapped(ts.attribute_ids, dm.m) as attrs
+			select ts.trace_id, ts.span_id as id, attrs_mapped(ts.attribute_ids, dm.m) as attrs
 			from tree ts, dict_map dm
 			where len(ts.attribute_ids) > 0
 		),
@@ -149,33 +151,37 @@
 		event_attrs as (
 			select e.id, attrs_mapped(e.attribute_ids, dm.m) as attrs
 			from events e, dict_map dm
-			where e.span_id in (select span_id from tree)
+			where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
 				and len(e.attribute_ids) > 0
 		),
 
 		link_attrs as (
 			select l.id, attrs_mapped(l.attribute_ids, dm.m) as attrs
 			from links l, dict_map dm
-			where l.span_id in (select span_id from tree)
+			where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
 				and len(l.attribute_ids) > 0
 		),
 
 		event_data as (
-			select e.span_id,
+			select e.trace_id, e.span_id,
 				to_json(list(event_json(e, ea.attrs) order by e.timestamp)) as events
 			from events e
 			left join event_attrs ea on ea.id = e.id
-			where e.span_id in (select span_id from tree)
-			group by e.span_id
+			where exists (select 1 from tree t
+					where t.trace_id = e.trace_id and t.span_id = e.span_id)
+			group by e.trace_id, e.span_id
 		),
 
 		link_data as (
-			select l.span_id,
+			select l.trace_id, l.span_id,
 				json_group_array(link_json(l, la.attrs)) as links
 			from links l
 			left join link_attrs la on la.id = l.id
-			where l.span_id in (select span_id from tree)
-			group by l.span_id
+			where exists (select 1 from tree t
+					where t.trace_id = l.trace_id and t.span_id = l.span_id)
+			group by l.trace_id, l.span_id
 		),
 
 		-- Resource and scope JSON is built once per *distinct owner*, which is
@@ -228,10 +234,10 @@
 			from tree ts
 			join resource_data rd on rd.id = ts.resource_id
 			join scope_data scd on scd.id = ts.scope_id
-			left join span_attrs sa on sa.id = ts.span_id
+			left join span_attrs sa on sa.trace_id = ts.trace_id and sa.id = ts.span_id
 			left join matched_spans ms on ts.span_id = ms.span_id
-			left join event_data ed on ts.span_id = ed.span_id
-			left join link_data ld on ts.span_id = ld.span_id
+			left join event_data ed on ts.trace_id = ed.trace_id and ts.span_id = ed.span_id
+			left join link_data ld on ts.trace_id = ld.trace_id and ts.span_id = ld.span_id
 		)
 
 		select case


### PR DESCRIPTION
Stacked on #414 — merge that first and this retargets to `main` on its own. **Schema 7 → 8.**

## Fixed

- A span id is only required to be unique *within its trace*. Keying `spans` on `span_id` alone was stricter than OTLP and rejected conformant senders — fixtures numbering spans per trace, replay tools, any deterministic generator. Their second trace looked like a duplicate of the first. `spans` is now keyed on `(trace_id, span_id)`.
- `events` and `links` carry the owning trace and foreign-key the pair. Every join from a child to its span carries the trace too: without it, two traces sharing a span id contaminate each other.
- `links.trace_id` → `linked_trace_id`. It always meant the context pointed *at*, and now reads correctly beside `linked_span_id`.

## What the test caught

Two traces each using span ids `1` and `2`. With the key changed but the queries not, fetching one trace returned **all four spans**, both traces' events, and `unplacedSpanCount: -2`. The offenders were the tree walk's payload join (`join spans s on s.span_id = st.span_id`) and five child predicates. The predicates now share `eventOwner` / `linkOwner` constants so a sixth cannot forget.

## Notes

- Wire format unchanged — `link_json` still emits `traceID` for the linked context. Frontend suite passes untouched (587 tests, no edits).
- Anyone with an existing `--db` file gets `ErrSchemaIncompatible` on open. Documented behaviour for a version bump, but worth knowing it lands right after a release.
- `deleteSpansByIDs` is now ambiguous on the wire: a span id no longer identifies one span, so it deletes across traces. Existing behaviour preserved rather than silently changed; taking pairs is a follow-up.
- SQL goldens regenerated; the diff is only trace scoping.
