### PR TITLE
Restore depth-first salvage ordering

### DIFF
--- a/desktopexporter/internal/store/queries/spans/salvage_spans.sql
+++ b/desktopexporter/internal/store/queries/spans/salvage_spans.sql
@@ -43,11 +43,11 @@
 		ranked as materialized (
 			select t.*,
 				row_number() over (
-					partition by t.parent_span_id order by t.start_time
+					partition by t.parent_span_id order by t.start_time, t.span_id
 				) as sibling_rank,
 				row_number() over (order by
 					case when t.parent_span_id is null then 0 else 1 end,
-					t.start_time
+					t.start_time, t.span_id
 				) as root_rank
 			from trace_spans t
 		),
@@ -56,7 +56,7 @@
 			select
 				r.trace_id, r.span_id, r.parent_span_id, r.start_time,
 				0 as depth,
-				array[r.root_rank] as sort_path
+				array[0, r.root_rank] as sort_path
 			from ranked r
 			where r.parent_span_id is null
 				or r.parent_span_id not in (select span_id from trace_spans)
@@ -91,17 +91,23 @@
 		),
 
 		-- The walk that may enter a cycle, so it carries its own ancestry and
-		-- refuses to revisit. DuckDB has no CYCLE clause; this is the pattern
-		-- its docs prescribe for traversing a graph that may contain one.
+		-- refuses to revisit. relative_path mirrors the normal walk's complete
+		-- sibling path: depth alone would group grandchildren after every sibling,
+		-- but the frontend needs each subtree contiguous to recover display parents.
+		-- DuckDB has no CYCLE clause; this is the pattern its docs prescribe for
+		-- traversing a graph that may contain one.
 		salvage_walk as (
 			select sd.span_id, sd.parent_span_id, sd.trace_id, sd.start_time,
-				sd.entry_rank, 0 as depth, [sd.span_id] as visited
+				sd.entry_rank, 0 as depth, []::bigint[] as relative_path,
+				[sd.span_id] as visited
 			from salvage_seed sd
 
 			union all
 
 			select r.span_id, r.parent_span_id, r.trace_id, r.start_time,
-				sw.entry_rank, sw.depth + 1, list_append(sw.visited, r.span_id)
+				sw.entry_rank, sw.depth + 1,
+				sw.relative_path || array[r.sibling_rank],
+				list_append(sw.visited, r.span_id)
 			from salvage_seed r
 			join salvage_walk sw on r.parent_span_id = sw.span_id
 			where list_position(sw.visited, r.span_id) is null
@@ -109,7 +115,8 @@
 
 		-- One placement per span: the earliest entry that reaches it.
 		salvaged as materialized (
-			select span_id, parent_span_id, trace_id, start_time, depth, entry_rank
+			select span_id, parent_span_id, trace_id, start_time, depth, entry_rank,
+				relative_path
 			from salvage_walk
 			qualify row_number() over (
 				partition by span_id order by entry_rank, depth
@@ -133,8 +140,7 @@
 			union all
 
 			select sv.trace_id, sv.span_id, sv.parent_span_id, sv.start_time, sv.depth,
-				array[1000000 + sv.entry_rank::int] ||
-					case when sv.depth = 0 then []::int[] else array[sv.depth] end,
+				array[1, sv.entry_rank] || sv.relative_path,
 				true,
 				sv.depth = 0 and exists (
 					select 1 from salvaged p

--- a/desktopexporter/internal/store/spans/spans_test.go
+++ b/desktopexporter/internal/store/spans/spans_test.go
@@ -1710,11 +1710,15 @@ func TestSearchSpansReportsUnplacedSpans(t *testing.T) {
 	add(traces, withCycle, "0000000000000013", "0000000000000012", 20)
 	// Nothing but a self-parenting span: no root exists at all.
 	add(traces, allCycle, "0000000000000021", "0000000000000021", 0)
-	// A two-span cycle with a healthy two-span subtree beneath one member.
+	// A genuine root, plus a two-span cycle with a branched subtree beneath one
+	// member. Span 34 has to stay beside parent 33, before sibling 35.
+	add(traces, cycleWithSubtree, "0000000000000030", "", 50)
 	add(traces, cycleWithSubtree, "0000000000000031", "0000000000000032", 0)
 	add(traces, cycleWithSubtree, "0000000000000032", "0000000000000031", 10)
 	add(traces, cycleWithSubtree, "0000000000000033", "0000000000000031", 20)
 	add(traces, cycleWithSubtree, "0000000000000034", "0000000000000033", 30)
+	// Same timestamp as sibling 33: span id is the deterministic tie-break.
+	add(traces, cycleWithSubtree, "0000000000000035", "0000000000000031", 20)
 	// Two cycles that share nothing.
 	add(traces, twoCycles, "0000000000000041", "0000000000000042", 0)
 	add(traces, twoCycles, "0000000000000042", "0000000000000041", 10)
@@ -1736,16 +1740,25 @@ func TestSearchSpansReportsUnplacedSpans(t *testing.T) {
 		return spans.Ingest(ctx, conn, traces, s.FlushedIDs())
 	}))
 
+	type placement struct {
+		spanID       string
+		parentSpanID string
+		depth        int
+		matched      bool
+		salvaged     bool
+		cyclePoint   bool
+	}
 	type walked struct {
 		placed     int
 		unplaced   int
 		salvaged   int
 		cyclePoint int
 		cycleIDs   []string
+		spans      []placement
 	}
-	get := func(traceHex string) walked {
+	fetch := func(traceHex string, criteria any) walked {
 		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
-			return spans.SearchSpans(ctx, db, traceHex, nil)
+			return spans.SearchSpans(ctx, db, traceHex, criteria)
 		})
 		require.NoError(t, err)
 		var td struct {
@@ -1753,14 +1766,25 @@ func TestSearchSpansReportsUnplacedSpans(t *testing.T) {
 			Spans             []struct {
 				Salvaged   bool `json:"salvaged"`
 				CyclePoint bool `json:"cyclePoint"`
+				Depth      int  `json:"depth"`
+				Matched    bool `json:"matched"`
 				SpanData   struct {
-					SpanID string `json:"spanID"`
+					SpanID       string `json:"spanID"`
+					ParentSpanID string `json:"parentSpanID"`
 				} `json:"spanData"`
 			} `json:"spans"`
 		}
 		require.NoError(t, json.Unmarshal(raw, &td))
 		w := walked{placed: len(td.Spans), unplaced: td.UnplacedSpanCount}
 		for _, sp := range td.Spans {
+			w.spans = append(w.spans, placement{
+				spanID:       sp.SpanData.SpanID,
+				parentSpanID: sp.SpanData.ParentSpanID,
+				depth:        sp.Depth,
+				matched:      sp.Matched,
+				salvaged:     sp.Salvaged,
+				cyclePoint:   sp.CyclePoint,
+			})
 			if sp.Salvaged {
 				w.salvaged++
 			}
@@ -1771,6 +1795,7 @@ func TestSearchSpansReportsUnplacedSpans(t *testing.T) {
 		}
 		return w
 	}
+	get := func(traceHex string) walked { return fetch(traceHex, nil) }
 
 	t.Run("healthy trace carries no flags", func(t *testing.T) {
 		w := get(healthy)
@@ -1792,15 +1817,53 @@ func TestSearchSpansReportsUnplacedSpans(t *testing.T) {
 		assert.Equal(t, []string{"0000000000000012"}, w.cycleIDs)
 	})
 
-	t.Run("a subtree hanging off a cycle comes back too", func(t *testing.T) {
+	t.Run("a branched subtree hanging off a cycle keeps depth-first order", func(t *testing.T) {
 		// Salvage must not stop at the cycle members: spans descended from one
-		// are perfectly well-formed and were stranded only by association.
+		// are perfectly well-formed and were stranded only by association. The
+		// full path is also structural data: the frontend derives display parents
+		// from preorder plus depth, so 34 must precede its parent's next sibling.
 		w := get(cycleWithSubtree)
-		assert.Equal(t, 4, w.placed, "both cycle members plus the two below them")
+		assert.Equal(t, 6, w.placed, "the genuine root and every recovered span appear once")
 		assert.Equal(t, 0, w.unplaced)
-		assert.Equal(t, 4, w.salvaged)
+		assert.Equal(t, 5, w.salvaged)
 		assert.Equal(t, 1, w.cyclePoint, "only the closing link is at fault")
 		assert.Equal(t, []string{"0000000000000031"}, w.cycleIDs)
+
+		want := []placement{
+			{spanID: "0000000000000030", depth: 0, matched: true},
+			{spanID: "0000000000000031", parentSpanID: "0000000000000032", depth: 0, matched: true, salvaged: true, cyclePoint: true},
+			{spanID: "0000000000000032", parentSpanID: "0000000000000031", depth: 1, matched: true, salvaged: true},
+			{spanID: "0000000000000033", parentSpanID: "0000000000000031", depth: 1, matched: true, salvaged: true},
+			{spanID: "0000000000000034", parentSpanID: "0000000000000033", depth: 2, matched: true, salvaged: true},
+			{spanID: "0000000000000035", parentSpanID: "0000000000000031", depth: 1, matched: true, salvaged: true},
+		}
+		assert.Equal(t, want, w.spans,
+			"genuine roots lead; each recovered subtree is contiguous in sibling order")
+
+		seen := make(map[string]struct{}, len(w.spans))
+		for _, sp := range w.spans {
+			seen[sp.spanID] = struct{}{}
+		}
+		assert.Len(t, seen, len(w.spans), "the competing salvage entries must not duplicate a span")
+
+		criteria := map[string]any{
+			"id":   "nested-match",
+			"type": "condition",
+			"query": map[string]any{
+				"field":         map[string]any{"name": "name", "searchScope": "field"},
+				"fieldOperator": "=",
+				"value":         "span-0000000000000034",
+			},
+		}
+		searched := fetch(cycleWithSubtree, criteria)
+		wantSearched := append([]placement(nil), want...)
+		for i := range wantSearched {
+			wantSearched[i].matched = wantSearched[i].spanID == "0000000000000034"
+		}
+		assert.Equal(t, wantSearched, searched.spans,
+			"search annotates the same depth-first tree rather than changing its topology")
+		assert.Equal(t, w.unplaced, searched.unplaced)
+		assert.Equal(t, w.cycleIDs, searched.cycleIDs)
 	})
 
 	t.Run("two independent cycles are blamed separately", func(t *testing.T) {

--- a/desktopexporter/internal/store/spans/testdata/salvage_spans_no_search.sql
+++ b/desktopexporter/internal/store/spans/testdata/salvage_spans_no_search.sql
@@ -43,11 +43,11 @@
 		ranked as materialized (
 			select t.*,
 				row_number() over (
-					partition by t.parent_span_id order by t.start_time
+					partition by t.parent_span_id order by t.start_time, t.span_id
 				) as sibling_rank,
 				row_number() over (order by
 					case when t.parent_span_id is null then 0 else 1 end,
-					t.start_time
+					t.start_time, t.span_id
 				) as root_rank
 			from trace_spans t
 		),
@@ -56,7 +56,7 @@
 			select
 				r.trace_id, r.span_id, r.parent_span_id, r.start_time,
 				0 as depth,
-				array[r.root_rank] as sort_path
+				array[0, r.root_rank] as sort_path
 			from ranked r
 			where r.parent_span_id is null
 				or r.parent_span_id not in (select span_id from trace_spans)
@@ -91,17 +91,23 @@
 		),
 
 		-- The walk that may enter a cycle, so it carries its own ancestry and
-		-- refuses to revisit. DuckDB has no CYCLE clause; this is the pattern
-		-- its docs prescribe for traversing a graph that may contain one.
+		-- refuses to revisit. relative_path mirrors the normal walk's complete
+		-- sibling path: depth alone would group grandchildren after every sibling,
+		-- but the frontend needs each subtree contiguous to recover display parents.
+		-- DuckDB has no CYCLE clause; this is the pattern its docs prescribe for
+		-- traversing a graph that may contain one.
 		salvage_walk as (
 			select sd.span_id, sd.parent_span_id, sd.trace_id, sd.start_time,
-				sd.entry_rank, 0 as depth, [sd.span_id] as visited
+				sd.entry_rank, 0 as depth, []::bigint[] as relative_path,
+				[sd.span_id] as visited
 			from salvage_seed sd
 
 			union all
 
 			select r.span_id, r.parent_span_id, r.trace_id, r.start_time,
-				sw.entry_rank, sw.depth + 1, list_append(sw.visited, r.span_id)
+				sw.entry_rank, sw.depth + 1,
+				sw.relative_path || array[r.sibling_rank],
+				list_append(sw.visited, r.span_id)
 			from salvage_seed r
 			join salvage_walk sw on r.parent_span_id = sw.span_id
 			where list_position(sw.visited, r.span_id) is null
@@ -109,7 +115,8 @@
 
 		-- One placement per span: the earliest entry that reaches it.
 		salvaged as materialized (
-			select span_id, parent_span_id, trace_id, start_time, depth, entry_rank
+			select span_id, parent_span_id, trace_id, start_time, depth, entry_rank,
+				relative_path
 			from salvage_walk
 			qualify row_number() over (
 				partition by span_id order by entry_rank, depth
@@ -133,8 +140,7 @@
 			union all
 
 			select sv.trace_id, sv.span_id, sv.parent_span_id, sv.start_time, sv.depth,
-				array[1000000 + sv.entry_rank::int] ||
-					case when sv.depth = 0 then []::int[] else array[sv.depth] end,
+				array[1, sv.entry_rank] || sv.relative_path,
 				true,
 				sv.depth = 0 and exists (
 					select 1 from salvaged p

--- a/desktopexporter/internal/store/spans/testdata/salvage_spans_with_search.sql
+++ b/desktopexporter/internal/store/spans/testdata/salvage_spans_with_search.sql
@@ -43,11 +43,11 @@
 		ranked as materialized (
 			select t.*,
 				row_number() over (
-					partition by t.parent_span_id order by t.start_time
+					partition by t.parent_span_id order by t.start_time, t.span_id
 				) as sibling_rank,
 				row_number() over (order by
 					case when t.parent_span_id is null then 0 else 1 end,
-					t.start_time
+					t.start_time, t.span_id
 				) as root_rank
 			from trace_spans t
 		),
@@ -56,7 +56,7 @@
 			select
 				r.trace_id, r.span_id, r.parent_span_id, r.start_time,
 				0 as depth,
-				array[r.root_rank] as sort_path
+				array[0, r.root_rank] as sort_path
 			from ranked r
 			where r.parent_span_id is null
 				or r.parent_span_id not in (select span_id from trace_spans)
@@ -98,17 +98,23 @@
 		),
 
 		-- The walk that may enter a cycle, so it carries its own ancestry and
-		-- refuses to revisit. DuckDB has no CYCLE clause; this is the pattern
-		-- its docs prescribe for traversing a graph that may contain one.
+		-- refuses to revisit. relative_path mirrors the normal walk's complete
+		-- sibling path: depth alone would group grandchildren after every sibling,
+		-- but the frontend needs each subtree contiguous to recover display parents.
+		-- DuckDB has no CYCLE clause; this is the pattern its docs prescribe for
+		-- traversing a graph that may contain one.
 		salvage_walk as (
 			select sd.span_id, sd.parent_span_id, sd.trace_id, sd.start_time,
-				sd.entry_rank, 0 as depth, [sd.span_id] as visited
+				sd.entry_rank, 0 as depth, []::bigint[] as relative_path,
+				[sd.span_id] as visited
 			from salvage_seed sd
 
 			union all
 
 			select r.span_id, r.parent_span_id, r.trace_id, r.start_time,
-				sw.entry_rank, sw.depth + 1, list_append(sw.visited, r.span_id)
+				sw.entry_rank, sw.depth + 1,
+				sw.relative_path || array[r.sibling_rank],
+				list_append(sw.visited, r.span_id)
 			from salvage_seed r
 			join salvage_walk sw on r.parent_span_id = sw.span_id
 			where list_position(sw.visited, r.span_id) is null
@@ -116,7 +122,8 @@
 
 		-- One placement per span: the earliest entry that reaches it.
 		salvaged as materialized (
-			select span_id, parent_span_id, trace_id, start_time, depth, entry_rank
+			select span_id, parent_span_id, trace_id, start_time, depth, entry_rank,
+				relative_path
 			from salvage_walk
 			qualify row_number() over (
 				partition by span_id order by entry_rank, depth
@@ -140,8 +147,7 @@
 			union all
 
 			select sv.trace_id, sv.span_id, sv.parent_span_id, sv.start_time, sv.depth,
-				array[1000000 + sv.entry_rank::int] ||
-					case when sv.depth = 0 then []::int[] else array[sv.depth] end,
+				array[1, sv.entry_rank] || sv.relative_path,
 				true,
 				sv.depth = 0 and exists (
 					select 1 from salvaged p


### PR DESCRIPTION
## Why

Recovered trace components were sorted by salvage-entry rank and depth only. Siblings therefore shared one sort path, and every depth-two row followed every depth-one row. Because the waterfall reconstructs display parents from preorder plus depth, a nested recovered span could be attached to the wrong sibling, corrupting collapse, search reveal, gutter, and hierarchical keyboard behavior.

Related issue: N/A

## Alignment

Agreed approach: carry the complete relative sibling path through the cycle-aware walk, while preserving reported parent IDs, one-placement deduplication, and `cyclePoint` semantics.

## What changed

- Carry a full sibling-rank ancestry path through `salvage_walk` and use it for lexicographic depth-first preorder.
- Rank tied siblings and roots by `(start_time, span_id)` for deterministic output.
- Prefix ordinary trees with `0` and recovered trees with `1`, guaranteeing genuine roots sort ahead of recovered components.
- Extend the malformed-trace fixture with a genuine root, a cycle, tied siblings, and a nested descendant.
- Assert exact row order, depth, original parent IDs, uniqueness, salvage flags, the exact closing `cyclePoint`, and identical topology with and without search.
- Regenerate both salvage SQL goldens.

## Verification

### Targeted tests

- `TestSearchSpansReportsUnplacedSpans/a_branched_subtree_hanging_off_a_cycle_keeps_depth-first_order` reproduces the old breadth-like order and pins the corrected preorder.
- `TestSearchSpansReportsUnplacedSpans` continues to cover direct cycles, self-cycles, independent cycles, ordinary orphans, and earlier off-cycle descendants.
- The malformed-trace suite passed 20 consecutive runs with equal-timestamp siblings.

### Commands

```text
go test ./internal/store/spans -run TestSearchSpansReportsUnplacedSpans -count=20
go test ./internal/store/spans -count=1
make test
```

All Go packages passed, all 900 Vitest tests passed, all 9 Playwright accessibility tests passed, and formatting, Svelte, Playwright TypeScript, and embedded-asset freshness checks passed.

### Manual verification

- N/A. The correction is to backend row topology and is covered through the public `SearchSpans` JSON response.

## Interface evidence

N/A. No frontend code or visual styling changed.

## Generated artifacts

- Regenerated `salvage_spans_no_search.sql` and `salvage_spans_with_search.sql` using the golden-test update flag.

## Checklist

- [x] The change is focused and contains only related work.
- [x] I linked maintainer alignment for substantial work, or this is a narrow bug fix, documentation change, or polish.
- [x] I added or updated focused tests for every changed behavior.
- [x] I verified visual and assistive behavior for interface changes.
- [x] I reviewed and understand every submitted change, including generated or agent-assisted code.
- [x] I updated relevant documentation and comments.
- [x] I included current generated artifacts where required.