### PR TITLE
Drop unused exemplar trace index

### DIFF
--- a/desktopexporter/internal/store/queries/ddl/indexes/_order
+++ b/desktopexporter/internal/store/queries/ddl/indexes/_order
@@ -26,4 +26,3 @@ idx_datapoints_stream_time.sql
 idx_datapoints_series.sql
 idx_metric_series_stream.sql
 idx_exemplars_datapoint.sql
-idx_exemplars_trace.sql

--- a/desktopexporter/internal/store/queries/ddl/indexes/idx_exemplars_trace.sql
+++ b/desktopexporter/internal/store/queries/ddl/indexes/idx_exemplars_trace.sql
@@ -1,1 +1,0 @@
-create index if not exists idx_exemplars_trace on exemplars(trace_id, span_id)


### PR DESCRIPTION
## Summary
- stop creating the composite exemplar trace/span index in new databases
- leave existing version-10 databases untouched and compatible

## Why
DuckDB 1.5.5 cannot use multicolumn ART indexes for query scans, and no production query filters, joins, or deletes exemplars by trace or span ID. The index therefore adds ingest work without serving a read path.

A temporary A/B benchmark ingested one high-cardinality exemplar per datapoint, with 20 samples of 5 iterations on an Apple M4 Pro:

| Exemplars | With index | Without index | Change |
| ---: | ---: | ---: | ---: |
| 1,000 | 9.481 ms/op | 9.065 ms/op | -4.40% (`p=0.003`) |
| 8,192 | 43.97 ms/op | 42.50 ms/op | -3.34% (`p<0.001`) |

## Testing
- `make test`
- 900 Vitest tests
- 9 Playwright accessibility tests