### PR TITLE
Bind IN lists as the column's type, not as text

### DIFF
--- a/desktopexporter/internal/store/logs/logs_test.go
+++ b/desktopexporter/internal/store/logs/logs_test.go
@@ -1098,6 +1098,32 @@ func TestSearchLogs(t *testing.T) {
 		assert.Equal(t, int32(17), entries[0].SeverityNumber)
 	})
 
+	// "Warnings and errors, not info" is the query this field exists for, and
+	// it is an int64 field, so the list of severities reaches the store as
+	// text. Bound that way it is a VARCHAR[] against a BIGINT column, which
+	// DuckDB cannot bind, and the search failed instead of narrowing.
+	t.Run("Field_SeverityNumber_In", func(t *testing.T) {
+		query := &search.QueryNode{
+			ID:   "q5c2",
+			Type: "condition",
+			Query: &search.Query{
+				Field: &search.FieldDefinition{
+					Name: "severityNumber", SearchScope: "field", Type: "int64",
+				},
+				FieldOperator: "IN",
+				Value:         `["13","17"]`, // WARN and ERROR, not INFO
+			},
+		}
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return logs.Search(ctx, db, store.BoundedTimeRange(startTime, endTime), query)
+		})
+		require.NoError(t, err)
+		entries := parseSummaries(raw)
+		require.Len(t, entries, 2)
+		assert.ElementsMatch(t, []int32{13, 17},
+			[]int32{entries[0].SeverityNumber, entries[1].SeverityNumber})
+	})
+
 	t.Run("Field_Body", func(t *testing.T) {
 		// Search predicate runs against the full body column; the
 		// summary only carries the preview. The fixture's body

--- a/desktopexporter/internal/store/search/search_tree.go
+++ b/desktopexporter/internal/store/search/search_tree.go
@@ -250,12 +250,7 @@ func BuildOperatorCondition(expression string, query *Query, params *[]NamedPara
 	// the Go struct declares Value as string. For int64 fields (e.g. duration),
 	// DuckDB needs an integer bind parameter — parse the string here as a
 	// workaround until the wire format carries typed values.
-	var bindValue any = value
-	if query.Field != nil && query.Field.Type == "int64" {
-		if n, err := strconv.ParseInt(value, 10, 64); err == nil {
-			bindValue = n
-		}
-	}
+	bindValue := bindScalarValue(query.Field, value)
 
 	switch operator {
 	case "=", "!=", ">", ">=", "<", "<=":
@@ -289,6 +284,17 @@ func BuildOperatorCondition(expression string, query *Query, params *[]NamedPara
 		if len(values) == 0 {
 			return "", fmt.Errorf("IN/NOT IN requires at least one value: %w", ErrInvalidQuery)
 		}
+		// Element by element, the same conversion the comparisons above get.
+		// A scalar varchar parameter is cast to the column's type and works,
+		// so the list looked like it would too, but `x IN param` binds as
+		// contains(param, x): a template function, which DuckDB refuses to
+		// instantiate with a VARCHAR[] against a BIGINT column. The array
+		// branch already types its elements, see handleArrayOperator.
+		for i, v := range values {
+			if s, ok := v.(string); ok {
+				values[i] = bindScalarValue(query.Field, s)
+			}
+		}
 		*params = append(*params, NamedParam{paramName, values})
 		operatorString = operator + " " + paramName
 	default:
@@ -299,6 +305,19 @@ func BuildOperatorCondition(expression string, query *Query, params *[]NamedPara
 		return strings.ReplaceAll(expression, condToken, operatorString), nil
 	}
 	return expression + " " + operatorString, nil
+}
+
+// bindScalarValue converts one wire value to the type its column expects. See
+// the note at the call site in BuildOperatorCondition for why every value
+// arrives as a string. A value the declared type cannot hold is handed on
+// unchanged, so malformed input reaches DuckDB exactly as it did before.
+func bindScalarValue(field *FieldDefinition, value string) any {
+	if field != nil && field.Type == "int64" {
+		if n, err := strconv.ParseInt(value, 10, 64); err == nil {
+			return n
+		}
+	}
+	return value
 }
 
 func mapArrayTypeToDuckDB(frontendType string) (string, error) {

--- a/desktopexporter/internal/store/search/search_tree_test.go
+++ b/desktopexporter/internal/store/search/search_tree_test.go
@@ -115,6 +115,7 @@ func TestBuildOperatorCondition(t *testing.T) {
 		name           string
 		expression     string
 		fieldName      string
+		fieldType      string
 		operator       string
 		value          string
 		expectedSQL    string
@@ -229,6 +230,62 @@ func TestBuildOperatorCondition(t *testing.T) {
 			expectedParams: []NamedParam{{"value_2", []any{"a,b", "c"}}},
 		},
 		{
+			// Every int64 field the search registry offers, on all three
+			// signals, is reachable by "is one of". The list arrives as JSON
+			// strings like every other value, and bound that way it is a
+			// VARCHAR[] tested against a BIGINT column: DuckDB binds `x IN p`
+			// as contains(p, x) and cannot deduce a template type across the
+			// two, so the whole search failed rather than returning rows.
+			name:           "IN on an int64 field binds integers",
+			expression:     "(s.end_time - s.start_time)",
+			fieldType:      "int64",
+			operator:       "IN",
+			value:          `["1000","3000"]`,
+			expectedSQL:    "(s.end_time - s.start_time) IN value_2",
+			expectedParams: []NamedParam{{"value_2", []any{int64(1000), int64(3000)}}},
+		},
+		{
+			name:           "NOT IN on an int64 field binds integers",
+			expression:     "l.severity_number",
+			fieldType:      "int64",
+			operator:       "NOT IN",
+			value:          `["13","17"]`,
+			expectedSQL:    "l.severity_number NOT IN value_2",
+			expectedParams: []NamedParam{{"value_2", []any{int64(13), int64(17)}}},
+		},
+		{
+			// The conversion follows the field's declared type, so a string
+			// field keeps binding text and a numeric-looking name is still a
+			// name.
+			name:           "IN on a string field still binds strings",
+			expression:     "s.name",
+			fieldType:      "string",
+			operator:       "IN",
+			value:          `["200","404"]`,
+			expectedSQL:    "s.name IN value_2",
+			expectedParams: []NamedParam{{"value_2", []any{"200", "404"}}},
+		},
+		{
+			// An element an int64 column cannot hold is left as it arrived,
+			// which is what the scalar comparisons already do with it.
+			name:           "an int64 element that will not parse stays text",
+			expression:     "s.flags",
+			fieldType:      "int64",
+			operator:       "IN",
+			value:          `["1","many"]`,
+			expectedSQL:    "s.flags IN value_2",
+			expectedParams: []NamedParam{{"value_2", []any{int64(1), "many"}}},
+		},
+		{
+			name:           "equality on an int64 field binds an integer",
+			expression:     "(s.end_time - s.start_time)",
+			fieldType:      "int64",
+			operator:       "=",
+			value:          "1000",
+			expectedSQL:    "(s.end_time - s.start_time) = value_2",
+			expectedParams: []NamedParam{{"value_2", int64(1000)}},
+		},
+		{
 			name:       "unsupported operator",
 			expression: "Name",
 			operator:   "UNSUPPORTED",
@@ -280,7 +337,7 @@ func TestBuildOperatorCondition(t *testing.T) {
 			}
 
 			query := &Query{
-				Field:         &FieldDefinition{Type: "", Name: tt.fieldName},
+				Field:         &FieldDefinition{Type: tt.fieldType, Name: tt.fieldName},
 				FieldOperator: tt.operator,
 				Value:         tt.value,
 			}

--- a/desktopexporter/internal/store/spans/spans_test.go
+++ b/desktopexporter/internal/store/spans/spans_test.go
@@ -2041,6 +2041,65 @@ func TestSearchTracesByFlags(t *testing.T) {
 	assert.Len(t, run("link.flags", "2"), 0)
 }
 
+// TestSearchTracesByDurationList covers "is one of" on a numeric field, which
+// the search registry offers for every int64 field on all three signals.
+//
+// Values reach the store as strings, and for a scalar comparison that is
+// harmless: DuckDB casts the parameter to the column's type. A list is not
+// harmless. `x IN param` binds as contains(param, x), and DuckDB will not
+// deduce a template type shared by a VARCHAR[] and a BIGINT column, so the
+// query failed to bind and the search returned an error instead of rows.
+func TestSearchTracesByDurationList(t *testing.T) {
+	t.Parallel()
+	s, ctx := storetest.New(t)
+
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "duration-search")
+
+	add := func(traceByte, spanByte byte, name string, duration int64) {
+		sp := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+		sp.SetTraceID([16]byte{traceByte})
+		sp.SetSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, spanByte})
+		sp.SetName(name)
+		sp.SetStartTimestamp(1000)
+		sp.SetEndTimestamp(pcommon.Timestamp(1000 + duration))
+	}
+	add(0xa1, 1, "quick", 1000)
+	add(0xa2, 2, "middling", 2000)
+	add(0xa3, 3, "slow", 3000)
+
+	require.NoError(t, s.WithConn(func(conn driver.Conn) error {
+		return spans.Ingest(ctx, conn, traces, s.FlushedIDs())
+	}))
+
+	run := func(operator, value string) []map[string]any {
+		query := &search.QueryNode{
+			ID:   "q1",
+			Type: "condition",
+			Query: &search.Query{
+				Field:         &search.FieldDefinition{Name: "duration", SearchScope: "field", Type: "int64"},
+				FieldOperator: operator,
+				Value:         value,
+			},
+		}
+		raw, err := readStore(s, func(db *sql.DB) (json.RawMessage, error) {
+			return spans.SearchTraces(ctx, db, store.BoundedTimeRange(0, 10_000), query)
+		})
+		require.NoError(t, err)
+		var out []map[string]any
+		require.NoError(t, json.Unmarshal(raw, &out))
+		return out
+	}
+
+	// The query parser serializes `duration IN [1000, 3000]` as a JSON array
+	// of strings, so that is the shape the store is handed.
+	assert.Len(t, run("IN", `["1000","3000"]`), 2, "IN keeps the two named durations")
+	assert.Len(t, run("NOT IN", `["1000","3000"]`), 1, "NOT IN keeps the rest")
+	assert.Len(t, run("IN", `["4000"]`), 0, "a duration nothing has matches nothing")
+	assert.Len(t, run("=", "2000"), 1, "equality on the same field is unaffected")
+}
+
 func TestSpanIDsRoundTripAtUint64Boundaries(t *testing.T) {
 	t.Parallel()
 	s, ctx := storetest.New(t)


### PR DESCRIPTION
## Why

"Is one of" fails on every numeric field. Picking `duration`, choosing `IN`, and giving it two values returns a store internal error carrying DuckDB's `Binder Error: Cannot deduce template type 'T' in function: 'contains(T[], T) -> BOOLEAN'` instead of rows. `NOT IN` fails the same way. The registry offers both operators for every `int64` field on all three signals, so this covers `duration`, `startTime`, `endTime`, the four dropped counts, `flags`, `event.timestamp` and `link.flags` on traces, `timestamp`, `observedTimestamp`, `severityNumber`, `flags` and `droppedAttributesCount` on logs, and `received` plus the two dropped counts on metrics.

Related issue: N/A

## Alignment

Agreed approach: N/A. Narrow bug fix, no schema, wire contract or interaction change.

## What changed

`Query.Value` is a string, and `queryParser.ts` serializes an array as JSON strings, so `duration IN [1000, 3000]` reaches the store as `["1000","3000"]`. `BuildOperatorCondition` parsed that string into an `int64` for the scalar comparisons and left the `IN` list untouched, so the list bound as `VARCHAR[]` against a `BIGINT` column. The scalar case survives that because DuckDB casts a varchar parameter to the column's type; `x IN param` does not, because it binds as `contains(param, x)` and there is no template type covering a `VARCHAR[]` and a `BIGINT`. The array-typed branch a few lines below already converts its elements through `ConvertValueForArrayType`, so the scalar list branch was the one lane doing no conversion at all.

- Moved the existing `int64` parse into `bindScalarValue` and applied it per element in the `IN` / `NOT IN` branch of `desktopexporter/internal/store/search/search_tree.go`.
- An element the declared type cannot hold is handed on unchanged, which is what the scalar comparisons already do with one, so malformed input reaches DuckDB exactly as it did before. This fixes well-formed numeric lists and deliberately does not add a new validation error for numeric fields.
- The conversion follows the field's declared type, so a string field still binds text and a numeric-looking service name is still a name.

## Verification

### Targeted tests

- `TestBuildOperatorCondition/IN_on_an_int64_field_binds_integers` and `.../NOT_IN_on_an_int64_field_binds_integers` pin that the list binds as `[]any{int64, int64}` rather than strings.
- `TestBuildOperatorCondition/IN_on_a_string_field_still_binds_strings` pins that the conversion follows the declared type and does not reach a string field.
- `TestBuildOperatorCondition/an_int64_element_that_will_not_parse_stays_text` pins the fallback for an element the column cannot hold.
- `TestBuildOperatorCondition/equality_on_an_int64_field_binds_an_integer` pins the scalar behavior that moved into the helper.
- `TestSearchTracesByDurationList` runs the query against DuckDB over three traces of 1000ns, 2000ns and 3000ns: `IN ["1000","3000"]` returns two, `NOT IN` the same list returns one, a duration nothing has returns none, and `= 2000` is unchanged. `duration` is a computed `end_time - start_time`, so this covers the expression form as well as a plain column.
- `TestSearchLogs/Field_SeverityNumber_In` runs `severityNumber IN ["13","17"]` over the INFO, WARN and ERROR fixture and gets the two non-info records, which is the query that field exists for.

Reverting only `search_tree.go` to `origin/main` and keeping the tests fails all five builder cases on the bound parameter and both integration tests on `Cannot deduce template type 'T'`.

### Commands

```text
$ go test ./desktopexporter/internal/store/search -run TestBuildOperatorCondition -count=1
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/search	0.835s

$ go test ./desktopexporter/internal/store/spans -run TestSearchTracesByDurationList -count=1
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/spans	1.716s

$ go test ./desktopexporter/internal/store/logs -run TestSearchLogs/Field_SeverityNumber_In -count=1
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/logs	1.929s

$ go test ./... -count=1
ok  	github.com/CtrlSpice/otel-desktop-viewer	3.264s
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter	6.103s
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/duckdbextension	6.794s
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/server	95.238s
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store	47.685s
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/attributes	11.779s
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/ingest	13.198s
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/logs	57.092s
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/metrics	103.377s
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/queries	43.225s
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/search	0.684s
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/spans	16.589s
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/stats	5.774s
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/store/util	2.179s
ok  	github.com/CtrlSpice/otel-desktop-viewer/desktopexporter/internal/telemetry	0.806s

$ make format-go-check
(no output)

$ go vet ./desktopexporter/... .
(no output)
```

All commands were run from the repository root on macOS 26.2 arm64 with Go 1.26.4. Nothing under `desktopexporter/internal/frontend/` or `desktopexporter/internal/server/static/` changed, so I ran the Go half of `make test` and not the frontend half.

### Manual verification

- N/A. The change is a bound parameter's type, exercised through the public `SearchTraces` and `Search` JSON responses.

## Interface evidence

N/A. No frontend source, styling or interaction changed.

## Generated artifacts

N/A. No frontend, dependency or grammar change, so no bundle or parser output is affected.

## Checklist

- [x] The change is focused and contains only related work.
- [x] I linked maintainer alignment for substantial work, or this is a narrow bug fix, documentation change, or polish.
- [x] I added or updated focused tests for every changed behavior.
- [x] I verified visual and assistive behavior for interface changes.
- [x] I reviewed and understand every submitted change, including generated or agent-assisted code.
- [x] I updated relevant documentation and comments.
- [x] I included current generated artifacts where required.
