### PR TITLE
Eliminate chained type assertions

### DIFF
--- a/desktopexporter/internal/frontend/oxlint.config.ts
+++ b/desktopexporter/internal/frontend/oxlint.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
   ],
   rules: {
     'oxc/no-accumulating-spread': 'error',
+    'anti-slop/no-chained-type-assertions': 'error',
     'anti-slop/no-conditional-empty-object-spread': 'error',
     'anti-slop/no-reduce-accumulator-copy': 'error',
     'anti-slop/no-object-parameters': 'error',

--- a/desktopexporter/internal/frontend/src/components/metrics/utils/histogram-aggregation.test.ts
+++ b/desktopexporter/internal/frontend/src/components/metrics/utils/histogram-aggregation.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import type {
+  DataPoint,
   ExponentialHistogramDataPoint,
   HistogramDataPoint,
+  MetricTimeseries,
 } from '@/types/api-types'
 import {
   HEATMAP_BUCKET_TARGET,
@@ -16,6 +18,24 @@ import {
 
 const ts1 = 1_000_000_000n
 const ts2 = 2_000_000_000n
+
+function metricSeries(
+  attributesKey: string,
+  datapoints: DataPoint[]
+): MetricTimeseries {
+  return {
+    attributesKey,
+    attributes: [],
+    resource: { attributes: [], droppedAttributesCount: 0 },
+    datapoints,
+    stats: null,
+    datapointCount: datapoints.length,
+    lastSeenNs: datapoints[0]?.timestamp ?? null,
+    views: null,
+    rateStats: null,
+    sparkline: null,
+  }
+}
 
 function histSlice(
   timestamp: bigint,
@@ -128,39 +148,41 @@ describe('HEATMAP_BUCKET_TARGET', () => {
 describe('seriesBucketsToSlices', () => {
   it('emits one slice per store bucket, keyed by its series', () => {
     const series = [
-      {
-        attributesKey: 'driver=ALO',
-        attributes: [],
-        datapoints: [
-          {
-            id: 'a',
-            metricType: 'Histogram',
-            timestamp: ts1,
-            count: 3,
-            sum: 6,
-            min: 1,
-            max: 3,
-            explicitBounds: [1, 2],
-            bucketCounts: [1, 1, 1],
-            exemplars: [],
-            flags: 0,
-          },
-          {
-            id: 'b',
-            metricType: 'Histogram',
-            timestamp: ts2,
-            count: 1,
-            sum: 5,
-            min: 5,
-            max: 5,
-            explicitBounds: [1, 2],
-            bucketCounts: [0, 0, 1],
-            exemplars: [],
-            flags: 0,
-          },
-        ],
-      },
-    ] as unknown as Parameters<typeof seriesBucketsToSlices>[0]
+      metricSeries('driver=ALO', [
+        {
+          id: 'a',
+          metricType: 'Histogram',
+          timestamp: ts1,
+          timestampMs: 1000,
+          startTime: ts1,
+          count: 3,
+          sum: 6,
+          min: 1,
+          max: 3,
+          explicitBounds: [1, 2],
+          bucketCounts: [1, 1, 1],
+          exemplars: [],
+          flags: 0,
+          aggregationTemporality: 'Cumulative',
+        },
+        {
+          id: 'b',
+          metricType: 'Histogram',
+          timestamp: ts2,
+          timestampMs: 2000,
+          startTime: ts2,
+          count: 1,
+          sum: 5,
+          min: 5,
+          max: 5,
+          explicitBounds: [1, 2],
+          bucketCounts: [0, 0, 1],
+          exemplars: [],
+          flags: 0,
+          aggregationTemporality: 'Cumulative',
+        },
+      ]),
+    ]
 
     const slices = seriesBucketsToSlices(series)
 
@@ -176,31 +198,30 @@ describe('seriesBucketsToSlices', () => {
 
   it('carries the exponential fields through untouched', () => {
     const series = [
-      {
-        attributesKey: 'driver=VER',
-        attributes: [],
-        datapoints: [
-          {
-            id: 'c',
-            metricType: 'ExponentialHistogram',
-            timestamp: ts1,
-            count: 4,
-            sum: 8,
-            min: 1,
-            max: 4,
-            scale: 2,
-            zeroCount: 1,
-            zeroThreshold: 0.5,
-            positiveBucketOffset: 3,
-            positiveBucketCounts: [1, 2],
-            negativeBucketOffset: 0,
-            negativeBucketCounts: [],
-            exemplars: [],
-            flags: 0,
-          },
-        ],
-      },
-    ] as unknown as Parameters<typeof seriesBucketsToSlices>[0]
+      metricSeries('driver=VER', [
+        {
+          id: 'c',
+          metricType: 'ExponentialHistogram',
+          timestamp: ts1,
+          timestampMs: 1000,
+          startTime: ts1,
+          count: 4,
+          sum: 8,
+          min: 1,
+          max: 4,
+          scale: 2,
+          zeroCount: 1,
+          zeroThreshold: 0.5,
+          positiveBucketOffset: 3,
+          positiveBucketCounts: [1, 2],
+          negativeBucketOffset: 0,
+          negativeBucketCounts: [],
+          exemplars: [],
+          flags: 0,
+          aggregationTemporality: 'Cumulative',
+        },
+      ]),
+    ]
 
     const slices = seriesBucketsToSlices(series)
     expect(slices).toHaveLength(1)

--- a/desktopexporter/internal/frontend/src/components/shared/ResizablePanels.test.ts
+++ b/desktopexporter/internal/frontend/src/components/shared/ResizablePanels.test.ts
@@ -11,32 +11,26 @@ const rightPanel = createRawSnippet(() => ({ render: () => '<p>detail</p>' }))
 // jsdom has no layout, so the component's ResizeObserver never fires on its
 // own. This stub records instances so a test can hand the component a
 // container measurement, which is all the real observer ever did for it.
-const observers: { cb: ResizeObserverCallback }[] = []
+class ResizeObserverStub implements ResizeObserver {
+  constructor(readonly cb: ResizeObserverCallback) {
+    observers.push(this)
+  }
+  observe(_target: Element, _options?: ResizeObserverOptions) {}
+  unobserve(_target: Element) {}
+  disconnect() {}
+}
+
+const observers: ResizeObserverStub[] = []
 beforeEach(() => {
   observers.length = 0
   localStorage.clear()
-  vi.stubGlobal(
-    'ResizeObserver',
-    class {
-      cb: ResizeObserverCallback
-      constructor(cb: ResizeObserverCallback) {
-        this.cb = cb
-        observers.push(this)
-      }
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    }
-  )
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub)
 })
 
 async function measure(width: number, height = 600) {
   await tick()
   for (const o of observers) {
-    o.cb(
-      [{ contentRect: { width, height } } as ResizeObserverEntry],
-      null as unknown as ResizeObserver
-    )
+    o.cb([{ contentRect: { width, height } } as ResizeObserverEntry], o)
   }
   await tick()
 }

--- a/desktopexporter/internal/frontend/src/components/shared/Search/codemirror/keymap.test.ts
+++ b/desktopexporter/internal/frontend/src/components/shared/Search/codemirror/keymap.test.ts
@@ -21,9 +21,12 @@ import { createQueryKeymap } from './keymap'
 
 type Binding = { key: string; run: unknown }
 
-function bindings(): Binding[] {
-  const ext = createQueryKeymap(() => {}) as unknown as { value?: Binding[] }
-  return ext.value ?? []
+function bindings(onSubmit = () => {}): Binding[] {
+  const value = Object.getOwnPropertyDescriptor(
+    createQueryKeymap(onSubmit),
+    'value'
+  )?.value
+  return Array.isArray(value) ? value : []
 }
 
 describe('query keymap', () => {
@@ -35,8 +38,7 @@ describe('query keymap', () => {
 
   it('routes the second Enter binding to the submit callback', () => {
     const onSubmit = vi.fn()
-    const ext = createQueryKeymap(onSubmit) as unknown as { value?: Binding[] }
-    const enter = (ext.value ?? []).filter(b => b.key === 'Enter')
+    const enter = bindings(onSubmit).filter(b => b.key === 'Enter')
     ;(enter[1].run as (v: unknown) => boolean)({} as never)
     expect(onSubmit).toHaveBeenCalledOnce()
   })

--- a/desktopexporter/internal/frontend/src/components/shared/utils/drag.test.ts
+++ b/desktopexporter/internal/frontend/src/components/shared/utils/drag.test.ts
@@ -11,14 +11,16 @@ function handle() {
   return el
 }
 
-function down(el: HTMLElement, x = 100, y = 100): PointerEvent {
-  const e = new MouseEvent('pointerdown', {
-    clientX: x,
-    clientY: y,
-    bubbles: true,
-    cancelable: true,
-  }) as unknown as PointerEvent
-  Object.defineProperty(e, 'pointerId', { value: 1 })
+function down(el: HTMLElement, x = 100, y = 100) {
+  const e = Object.assign(
+    new MouseEvent('pointerdown', {
+      clientX: x,
+      clientY: y,
+      bubbles: true,
+      cancelable: true,
+    }),
+    { pointerId: 1 }
+  )
   Object.defineProperty(e, 'currentTarget', { value: el })
   return e
 }

--- a/desktopexporter/internal/frontend/src/components/shared/utils/drag.ts
+++ b/desktopexporter/internal/frontend/src/components/shared/utils/drag.ts
@@ -32,7 +32,12 @@ export type DragOptions = {
 /** Ends a drag early, for a component unmounting mid-gesture. */
 export type DragHandle = { cancel: () => void }
 
-export function startDrag(e: PointerEvent, opts: DragOptions): DragHandle {
+type DragStartEvent = Pick<
+  PointerEvent,
+  'clientX' | 'clientY' | 'currentTarget' | 'pointerId' | 'preventDefault'
+>
+
+export function startDrag(e: DragStartEvent, opts: DragOptions): DragHandle {
   // Stops the browser starting a text selection or a native drag from the
   // same press. Without it the first pointermove selects whatever the handle
   // happens to sit on.

--- a/desktopexporter/internal/frontend/src/contexts/signal-list-page.integration.test.ts
+++ b/desktopexporter/internal/frontend/src/contexts/signal-list-page.integration.test.ts
@@ -5,6 +5,7 @@ import { screen } from '@testing-library/svelte'
 import SignalListPageProbe from '@/test/SignalListPageProbe.svelte'
 import { navigateToItem } from '@/route'
 import { renderWithContexts, setTestUrl } from '@/test/render-helpers'
+import type { LogSummary } from '@/types/api-types'
 import {
   beginListUpdate,
   cancelPendingListUpdates,
@@ -13,6 +14,18 @@ import {
 } from '@/components/shared/utils/list-update-seq'
 
 type Item = { id: string; name: string }
+
+function searchResult(id: string, name: string): LogSummary & Item {
+  return {
+    id,
+    name,
+    timestamp: 0n,
+    severityText: '',
+    severityNumber: 0,
+    serviceName: '',
+    bodyPreview: '',
+  }
+}
 
 function renderProbe(
   url: string,
@@ -144,8 +157,8 @@ describe('createSignalListPage integration', () => {
     page!.handleSearchResults({
       signal: 'logs',
       updateSeq: searchSeq,
-      results: [{ id: 'search-only', name: 'search-only' }],
-    } as unknown as import('@/types/api-types').SearchResultEvent)
+      results: [searchResult('search-only', 'search-only')],
+    })
     await tick()
 
     expect(screen.getByTestId('item-ids').textContent).toBe('search-only')
@@ -190,8 +203,8 @@ describe('createSignalListPage integration', () => {
     page!.handleSearchResults({
       signal: 'logs',
       updateSeq: staleSearchSeq,
-      results: [{ id: 'stale-search', name: 'stale' }],
-    } as unknown as import('@/types/api-types').SearchResultEvent)
+      results: [searchResult('stale-search', 'stale')],
+    })
     await tick()
 
     expect(screen.getByTestId('item-ids').textContent).toBe('a')

--- a/desktopexporter/internal/frontend/src/pages/MetricsPage.svelte
+++ b/desktopexporter/internal/frontend/src/pages/MetricsPage.svelte
@@ -360,7 +360,7 @@
       // The store's quantiles, computed once per datapoint from its bucket
       // vector. Recomputing them per render costs seconds on the main thread:
       // 2,700 bucket walks for one render of this metric.
-      const quantiles = DEFAULT_HISTOGRAM_QUANTILES as unknown as number[]
+      const quantiles = DEFAULT_HISTOGRAM_QUANTILES
       // Same answer as the detail fetch gives, so the aggregate is bucketed
       // over the window the series beneath it were bucketed over.
       // Both shapes of the same question, issued together so they cannot
@@ -628,7 +628,7 @@
           endNs,
           1,
           undefined,
-          DEFAULT_HISTOGRAM_QUANTILES as unknown as number[],
+          DEFAULT_HISTOGRAM_QUANTILES,
           tzOffsetNs(),
           0,
           0,
@@ -741,9 +741,7 @@
           // a Gauge or Sum has no answer to give, and asking for one is not
           // free: on a 22-series Gauge it costs 2,937 ms against 298 ms, for
           // byte-identical output.
-          isHistogramMetric
-            ? (DEFAULT_HISTOGRAM_QUANTILES as unknown as number[])
-            : undefined,
+          isHistogramMetric ? DEFAULT_HISTOGRAM_QUANTILES : undefined,
           // Bucket boundaries follow the reader's calendar rather than the
           // epoch. 0 is UTC, which is what the store assumes without this.
           tzOffsetNs(),

--- a/desktopexporter/internal/frontend/src/route/router.test.ts
+++ b/desktopexporter/internal/frontend/src/route/router.test.ts
@@ -54,13 +54,11 @@ describe('buildSearch', () => {
   })
 
   it('omits null values', () => {
-    expect(buildSearch({ a: '1', b: null as unknown as string })).toBe('?a=1')
+    expect(buildSearch({ a: '1', b: null })).toBe('?a=1')
   })
 
   it('omits undefined values', () => {
-    expect(buildSearch({ a: '1', b: undefined as unknown as string })).toBe(
-      '?a=1'
-    )
+    expect(buildSearch({ a: '1', b: undefined })).toBe('?a=1')
   })
 
   it('returns an empty string, not "?", when the result is empty', () => {

--- a/desktopexporter/internal/frontend/src/route/router.ts
+++ b/desktopexporter/internal/frontend/src/route/router.ts
@@ -58,7 +58,9 @@ export function parseRoute(href: string): Route {
  *
  * @example `{ a: '1' }` → `?a=1`
  */
-export function buildSearch(query: Record<string, string>): string {
+export function buildSearch(
+  query: Record<string, string | null | undefined>
+): string {
   const params = new URLSearchParams()
   for (const [key, value] of Object.entries(query)) {
     if (value !== undefined && value !== null && value !== '') {

--- a/desktopexporter/internal/frontend/src/services/telemetry-service.test.ts
+++ b/desktopexporter/internal/frontend/src/services/telemetry-service.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { telemetryAPI, JsonRpcError } from './telemetry-service'
 import type { QueryNode } from '@/components/shared/Search/queryTree'
+import { OPERATORS } from '@/constants/operators'
 
 // The backend signals not-found with JSON-RPC errors (one convention across
 // all signals; see internal/server/errors.go). getMetric's callers expect
@@ -572,11 +573,11 @@ describe('request parameters', () => {
       id: 'q1',
       type: 'condition',
       query: {
-        field: { name: 'name', type: 'string', searchScope: 'global' },
-        operator: { symbol: 'contains' },
+        field: { searchScope: 'global' },
+        operator: OPERATORS.CONTAINS,
         value: 'checkout',
       },
-    } as unknown as QueryNode
+    } satisfies QueryNode
 
     const sent = captureRequest()
     await telemetryAPI.searchTraces(2, 5, tree).catch(() => {})

--- a/desktopexporter/internal/frontend/src/services/telemetry-service.ts
+++ b/desktopexporter/internal/frontend/src/services/telemetry-service.ts
@@ -660,7 +660,7 @@ export let telemetryAPI = {
     seriesIDs?: string[],
     /** Quantiles to compute per histogram datapoint, keyed by the quantile in
      *  the response. Omit to skip the work. */
-    quantiles?: number[],
+    quantiles?: readonly number[],
     /** The viewer's UTC offset in nanoseconds, so bucket boundaries fall where
      *  the reader's calendar puts them. Omit for UTC. */
     tzOffsetNs?: number,
@@ -737,7 +737,7 @@ export let telemetryAPI = {
      *  every series, and narrowing here would redefine the answer rather than
      *  trim the payload. */
     seriesIDs: string[] | null,
-    quantiles: number[],
+    quantiles: readonly number[],
     tzOffsetNs: number,
     viewBuckets = 0,
     /** Which series are checked, for the scalar Selected pool.

--- a/desktopexporter/internal/frontend/src/test/setup.ts
+++ b/desktopexporter/internal/frontend/src/test/setup.ts
@@ -66,13 +66,12 @@ if (
   typeof window !== 'undefined' &&
   typeof globalThis.ResizeObserver === 'undefined'
 ) {
-  class ResizeObserverStub {
-    observe() {}
-    unobserve() {}
+  class ResizeObserverStub implements ResizeObserver {
+    observe(_target: Element, _options?: ResizeObserverOptions) {}
+    unobserve(_target: Element) {}
     disconnect() {}
   }
-  globalThis.ResizeObserver =
-    ResizeObserverStub as unknown as typeof ResizeObserver
+  globalThis.ResizeObserver = ResizeObserverStub
 }
 
 // jsdom lacks the Web Animations API that Svelte transitions/animations use.
@@ -82,23 +81,48 @@ if (
   typeof Element !== 'undefined' &&
   typeof Element.prototype.animate !== 'function'
 ) {
-  Element.prototype.animate = function (): Animation {
-    const animation = {
-      onfinish: null as ((event?: unknown) => void) | null,
-      oncancel: null,
-      cancel() {},
-      finish() {},
-      pause() {},
-      play() {},
-      reverse() {},
-      finished: Promise.resolve(),
-      playState: 'finished',
-      currentTime: 0,
-      startTime: 0,
-      effect: null,
+  class AnimationStub extends EventTarget implements Animation {
+    currentTime: CSSNumberish | null = 0
+    effect: AnimationEffect | null = null
+    readonly finished: Promise<Animation>
+    id = ''
+    oncancel: Animation['oncancel'] = null
+    onfinish: Animation['onfinish'] = null
+    onremove: Animation['onremove'] = null
+    readonly overallProgress = 1
+    readonly pending = false
+    readonly playState: AnimationPlayState = 'finished'
+    playbackRate = 1
+    readonly ready: Promise<Animation>
+    readonly replaceState: AnimationReplaceState = 'active'
+    startTime: CSSNumberish | null = 0
+    timeline: AnimationTimeline | null = null
+
+    constructor() {
+      super()
+      this.finished = Promise.resolve(this)
+      this.ready = Promise.resolve(this)
+      const finishEvent: AnimationPlaybackEvent = Object.assign(
+        new Event('finish'),
+        { currentTime: 0, timelineTime: 0 }
+      )
+      queueMicrotask(() => this.onfinish?.call(this, finishEvent))
     }
-    queueMicrotask(() => animation.onfinish?.())
-    return animation as unknown as Animation
+
+    cancel() {}
+    commitStyles() {}
+    finish() {}
+    pause() {}
+    persist() {}
+    play() {}
+    reverse() {}
+    updatePlaybackRate(playbackRate: number) {
+      this.playbackRate = playbackRate
+    }
+  }
+
+  Element.prototype.animate = function (): Animation {
+    return new AnimationStub()
   }
 }
 

--- a/desktopexporter/internal/frontend/src/utils/resource.test.ts
+++ b/desktopexporter/internal/frontend/src/utils/resource.test.ts
@@ -29,10 +29,10 @@ describe('getServiceName', () => {
     // The Attribute type declares `value: string`, but the function performs
     // no runtime check -- it returns whatever is found. This models data that
     // has bypassed the type system (e.g. parsed straight from JSON).
-    const resource = {
-      attributes: [{ key: 'service.name', value: 123, type: 'int' }],
-      droppedAttributesCount: 0,
-    } as unknown as ResourceData
+    const resource = resourceWith([
+      { key: 'service.name', value: 'checkout', type: 'string' },
+    ])
+    Object.defineProperty(resource.attributes[0], 'value', { value: 123 })
     expect(getServiceName(resource)).toBe(123)
   })
 })

--- a/desktopexporter/internal/frontend/src/utils/series-labels.test.ts
+++ b/desktopexporter/internal/frontend/src/utils/series-labels.test.ts
@@ -5,20 +5,25 @@ import type { MetricTimeseries } from '@/types/api-types'
 const series = (
   key: string,
   resourceAttrs: Array<[string, string]>
-): MetricTimeseries =>
-  ({
-    attributesKey: key,
-    attributes: [{ key: 'http.route', value: '/checkout', type: 'string' }],
-    resource: {
-      attributes: resourceAttrs.map(([k, v]) => ({
-        key: k,
-        value: v,
-        type: 'string',
-      })),
-      droppedAttributesCount: 0,
-    },
-    datapoints: [],
-  }) as unknown as MetricTimeseries
+): MetricTimeseries => ({
+  attributesKey: key,
+  attributes: [{ key: 'http.route', value: '/checkout', type: 'string' }],
+  resource: {
+    attributes: resourceAttrs.map(([k, v]) => ({
+      key: k,
+      value: v,
+      type: 'string',
+    })),
+    droppedAttributesCount: 0,
+  },
+  datapoints: [],
+  stats: null,
+  datapointCount: 0,
+  lastSeenNs: null,
+  views: null,
+  rateStats: null,
+  sparkline: null,
+})
 
 describe('distinguishingResourceAttributes', () => {
   // The case the whole feature exists for: two replicas of one service emit

--- a/desktopexporter/internal/frontend/src/utils/time.test.ts
+++ b/desktopexporter/internal/frontend/src/utils/time.test.ts
@@ -44,7 +44,7 @@ function makeSummary(
     traceID: 't1',
     hasRootSpan: true,
     startTime: 0n,
-    durationNs: durationNs as unknown as bigint | null,
+    durationNs: durationNs as bigint | null,
     spanCount: 1,
     errorCount: 0,
   }


### PR DESCRIPTION
## Summary

- remove all frontend chained type assertions by correcting readonly and nullable contracts
- replace incomplete fixtures and DOM type escapes with structurally valid test data and interface implementations
- enable `anti-slop/no-chained-type-assertions` in the enforced Oxlint configuration
- reduce the full anti-slop evaluation from 377 to 339 diagnostics

## Testing

- `make test`
- 902 Vitest tests
- all Go test packages
- 9 Playwright accessibility tests
- production bundle/static parity check
- independent code review completed with no remaining findings