### PR TITLE
Disallow unknown return contracts

### DIFF
--- a/desktopexporter/internal/frontend/oxlint.config.ts
+++ b/desktopexporter/internal/frontend/oxlint.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
     'anti-slop/no-object-parameters': 'error',
     'anti-slop/no-reflect-apply': 'error',
     'anti-slop/no-reflect-get': 'error',
+    'anti-slop/no-unknown-returns': 'error',
     'anti-slop/no-unknown-type-aliases': 'error',
     'anti-slop/no-widen-then-assert': 'error',
   },

--- a/desktopexporter/internal/frontend/src/components/metrics/Charts/MetricQuantileAreaChart.svelte
+++ b/desktopexporter/internal/frontend/src/components/metrics/Charts/MetricQuantileAreaChart.svelte
@@ -420,13 +420,13 @@
 
   function tooltipXDate(context: {
     tooltip: { data: unknown }
-    x: (d: unknown) => unknown
+    x: (d: unknown) => Date | string | number | null | undefined
   }): Date | null {
     const d = context.tooltip.data
     if (d == null) return null
     const v = context.x(d)
     if (v instanceof Date) return v
-    if (v != null) return new Date(v as string | number)
+    if (v != null) return new Date(v)
     return null
   }
 

--- a/desktopexporter/internal/frontend/src/components/metrics/Charts/MetricTimeSeriesChart.svelte
+++ b/desktopexporter/internal/frontend/src/components/metrics/Charts/MetricTimeSeriesChart.svelte
@@ -94,14 +94,14 @@
 
   function tooltipXDate(context: {
     tooltip: { data: unknown }
-    x: (d: unknown) => unknown
+    x: (d: unknown) => Date | string | number | null | undefined
     valueAxis: string
   }): Date | null {
     const d = context.tooltip.data
     if (d == null) return null
     const v = context.x(d)
     if (v instanceof Date) return v
-    if (v != null) return new Date(v as string | number)
+    if (v != null) return new Date(v)
     return null
   }
 

--- a/desktopexporter/internal/frontend/src/services/telemetry-service.test.ts
+++ b/desktopexporter/internal/frontend/src/services/telemetry-service.test.ts
@@ -528,40 +528,40 @@ function captureRequest() {
 describe('request parameters', () => {
   // Named methods, with the exact object each one is expected to send.
   // toNanoseconds renders milliseconds as a decimal string, hence '2000000'.
-  const named: [string, () => Promise<unknown>, Record<string, unknown>][] = [
+  const named: [string, () => Promise<void>, Record<string, unknown>][] = [
     [
       'searchAttributes',
-      () => telemetryAPI.searchAttributes('http'),
+      () => telemetryAPI.searchAttributes('http').then(() => {}),
       { term: 'http' },
     ],
     [
       'getAttributesByTraceID',
-      () => telemetryAPI.getAttributesByTraceID('abc'),
+      () => telemetryAPI.getAttributesByTraceID('abc').then(() => {}),
       { traceID: 'abc' },
     ],
     [
       'searchTraces',
-      () => telemetryAPI.searchTraces(2, 5),
+      () => telemetryAPI.searchTraces(2, 5).then(() => {}),
       { startTime: '2000000', endTime: '5000000' },
     ],
     [
       'searchLogs',
-      () => telemetryAPI.searchLogs(2, 5),
+      () => telemetryAPI.searchLogs(2, 5).then(() => {}),
       { startTime: '2000000', endTime: '5000000' },
     ],
     [
       'searchMetricSummaries',
-      () => telemetryAPI.searchMetricSummaries(2, 5),
+      () => telemetryAPI.searchMetricSummaries(2, 5).then(() => {}),
       { startTime: '2000000', endTime: '5000000' },
     ],
     [
       'getTraceSpanCount',
-      () => telemetryAPI.getTraceSpanCount('abc'),
+      () => telemetryAPI.getTraceSpanCount('abc').then(() => {}),
       { traceID: 'abc' },
     ],
     [
       'deleteMetricStream',
-      () => telemetryAPI.deleteMetricStream('s1'),
+      () => telemetryAPI.deleteMetricStream('s1').then(() => {}),
       { streamID: 's1' },
     ],
   ]


### PR DESCRIPTION
## Changes
- Give LayerChart tooltip accessors the concrete date-compatible return contract their consumers already handle.
- Make request-contract test operations explicitly discard API results instead of advertising `Promise<unknown>`.
- Enable `anti-slop/no-unknown-returns` in the default frontend lint gate.

## Verification
- `npm run lint`
- `npm run check`
- 60 focused chart and telemetry service tests
- `make test` (900 frontend tests and 9 accessibility tests)
- `make build-ts` (no generated asset changes)
- independent review completed with no findings
- all GitHub checks pass on macOS, Ubuntu, Windows, frontend, Go, CodeQL, and analysis jobs