### PR TITLE
Preserve series line prop inference

### DIFF
--- a/desktopexporter/internal/frontend/src/components/metrics/Charts/MetricTimeSeriesChart.svelte
+++ b/desktopexporter/internal/frontend/src/components/metrics/Charts/MetricTimeSeriesChart.svelte
@@ -220,7 +220,7 @@
     curve: curveStepAfter,
   } as const
 
-  function seriesLineProps(key: string): Record<string, unknown> {
+  function seriesLineProps(key: string) {
     if (isAggregateKey(key)) return { props: AGG_LINE_PROPS }
     return {}
   }


### PR DESCRIPTION
## Changes
- Let TypeScript infer the closed `{ props } | {}` result from `seriesLineProps` instead of widening it to `Record<string, unknown>`.
- Remove both the unsafe-dictionary and known-value-widening findings produced by the annotation.

## Verification
- `npm run lint`
- `npm run check`
- `npx vitest run src/components/metrics/Charts/AnalyticalCharts.test.ts`
- `npm run lint:anti-slop:evaluate` (302 findings reduced to 300)