### PR TITLE
Stabilize tied span timestamp ordering

### DIFF
--- a/desktopexporter/internal/store/queries/spans/search_spans.sql
+++ b/desktopexporter/internal/store/queries/spans/search_spans.sql
@@ -25,7 +25,7 @@
 		-- Sibling order, decided once, before the walk.
 		--
 		-- A span's rank among its siblings is a property of the trace, not of
-		-- the traversal: it depends only on parent and start time, both known
+		-- the traversal: it depends only on parent, start time, and span id, all known
 		-- before the first row is walked. Computing it with a window inside
 		-- the recursive arm instead re-runs a WINDOW operator once per level
 		-- of the tree, paying full operator setup each time to rank a handful
@@ -43,11 +43,11 @@
 		ranked as materialized (
 			select t.*,
 				row_number() over (
-					partition by t.parent_span_id order by t.start_time
+					partition by t.parent_span_id order by t.start_time, t.span_id
 				) as sibling_rank,
 				row_number() over (order by
 					case when t.parent_span_id is null then 0 else 1 end,
-					t.start_time
+					t.start_time, t.span_id
 				) as root_rank
 			from trace_spans t
 		),
@@ -273,4 +273,3 @@
 		-- whole thing this split exists to avoid.
 		(select n from unplaced_count) as unplaced
 		from ordered_spans
-	

--- a/desktopexporter/internal/store/spans/spans_test.go
+++ b/desktopexporter/internal/store/spans/spans_test.go
@@ -1700,10 +1700,11 @@ func TestSearchSpansReportsUnplacedSpans(t *testing.T) {
 	cycleWithEarlyChild := "000000000000000000000000000000a7"
 
 	traces := ptrace.NewTraces()
-	// Healthy: root with two children.
+	// Healthy: tied roots and tied siblings, inserted in reverse id order.
+	add(traces, healthy, "0000000000000004", "", 0)
 	add(traces, healthy, "0000000000000001", "", 0)
+	add(traces, healthy, "0000000000000003", "0000000000000001", 10)
 	add(traces, healthy, "0000000000000002", "0000000000000001", 10)
-	add(traces, healthy, "0000000000000003", "0000000000000001", 20)
 	// A reachable root plus a two-span cycle hanging off nothing.
 	add(traces, withCycle, "0000000000000011", "", 0)
 	add(traces, withCycle, "0000000000000012", "0000000000000013", 10)
@@ -1799,11 +1800,17 @@ func TestSearchSpansReportsUnplacedSpans(t *testing.T) {
 
 	t.Run("healthy trace carries no flags", func(t *testing.T) {
 		w := get(healthy)
-		assert.Equal(t, 3, w.placed, "all three spans placed")
+		assert.Equal(t, 4, w.placed, "all four spans placed")
 		assert.Equal(t, 0, w.unplaced)
 		assert.Equal(t, 0, w.salvaged, "nothing to salvage in a well-formed trace")
 		assert.Equal(t, 0, w.cyclePoint)
 		assert.Empty(t, w.cycleIDs)
+		assert.Equal(t, []placement{
+			{spanID: "0000000000000001", depth: 0, matched: true},
+			{spanID: "0000000000000002", parentSpanID: "0000000000000001", depth: 1, matched: true},
+			{spanID: "0000000000000003", parentSpanID: "0000000000000001", depth: 1, matched: true},
+			{spanID: "0000000000000004", depth: 0, matched: true},
+		}, w.spans, "equal timestamps use span id as the deterministic tie-break")
 	})
 
 	t.Run("cycle members are salvaged, not dropped", func(t *testing.T) {

--- a/desktopexporter/internal/store/spans/testdata/search_spans_no_search.sql
+++ b/desktopexporter/internal/store/spans/testdata/search_spans_no_search.sql
@@ -25,7 +25,7 @@
 		-- Sibling order, decided once, before the walk.
 		--
 		-- A span's rank among its siblings is a property of the trace, not of
-		-- the traversal: it depends only on parent and start time, both known
+		-- the traversal: it depends only on parent, start time, and span id, all known
 		-- before the first row is walked. Computing it with a window inside
 		-- the recursive arm instead re-runs a WINDOW operator once per level
 		-- of the tree, paying full operator setup each time to rank a handful
@@ -43,11 +43,11 @@
 		ranked as materialized (
 			select t.*,
 				row_number() over (
-					partition by t.parent_span_id order by t.start_time
+					partition by t.parent_span_id order by t.start_time, t.span_id
 				) as sibling_rank,
 				row_number() over (order by
 					case when t.parent_span_id is null then 0 else 1 end,
-					t.start_time
+					t.start_time, t.span_id
 				) as root_rank
 			from trace_spans t
 		),
@@ -273,4 +273,3 @@
 		-- whole thing this split exists to avoid.
 		(select n from unplaced_count) as unplaced
 		from ordered_spans
-	

--- a/desktopexporter/internal/store/spans/testdata/search_spans_with_search.sql
+++ b/desktopexporter/internal/store/spans/testdata/search_spans_with_search.sql
@@ -25,7 +25,7 @@
 		-- Sibling order, decided once, before the walk.
 		--
 		-- A span's rank among its siblings is a property of the trace, not of
-		-- the traversal: it depends only on parent and start time, both known
+		-- the traversal: it depends only on parent, start time, and span id, all known
 		-- before the first row is walked. Computing it with a window inside
 		-- the recursive arm instead re-runs a WINDOW operator once per level
 		-- of the tree, paying full operator setup each time to rank a handful
@@ -43,11 +43,11 @@
 		ranked as materialized (
 			select t.*,
 				row_number() over (
-					partition by t.parent_span_id order by t.start_time
+					partition by t.parent_span_id order by t.start_time, t.span_id
 				) as sibling_rank,
 				row_number() over (order by
 					case when t.parent_span_id is null then 0 else 1 end,
-					t.start_time
+					t.start_time, t.span_id
 				) as root_rank
 			from trace_spans t
 		),
@@ -280,4 +280,3 @@
 		-- whole thing this split exists to avoid.
 		(select n from unplaced_count) as unplaced
 		from ordered_spans
-	


### PR DESCRIPTION
## Summary
- use span ID as the deterministic secondary key for equal-start-time roots and siblings
- align the healthy trace walk with the existing salvage ordering contract
- add an adversarial regression fixture that ingests tied spans in reverse ID order
- refresh the rendered SQL goldens

## Testing
- regression test fails before the query change with order `4, 1, 3, 2`
- focused equal-timestamp regression test passes 10 consecutive runs
- `go test ./desktopexporter/internal/store/spans -count=1`
- `make test`