### PR TITLE
Narrow test DOM elements at runtime

### DIFF
--- a/desktopexporter/internal/frontend/src/components/metrics/Charts/AnalyticalCharts.test.ts
+++ b/desktopexporter/internal/frontend/src/components/metrics/Charts/AnalyticalCharts.test.ts
@@ -33,6 +33,17 @@ const EMPTY_SCOPE: ScopeData = {
   droppedAttributesCount: 0,
 }
 
+function queryHTMLElement(
+  selector: string,
+  root: ParentNode = document
+): HTMLElement {
+  const element = root.querySelector(selector)
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`Expected HTMLElement matching ${selector}`)
+  }
+  return element
+}
+
 function gaugeDatapoint(id: string, timestamp: bigint, value: number) {
   return {
     id,
@@ -525,25 +536,10 @@ describe('HistogramChart keyboard model', () => {
     const surface = screen.getByRole('application', {
       name: 'Histogram distribution chart',
     })
-    const scroller = document.querySelector(
-      '.histogram-chart-scroll'
-    ) as HTMLElement
-    const wrapper = document.querySelector(
-      '.histogram-chart-wrapper'
-    ) as HTMLElement
-    const root = wrapper.querySelector('.lc-root-container') as HTMLElement
-    root.getBoundingClientRect = () =>
-      ({
-        x: 0,
-        y: 0,
-        left: 0,
-        top: 0,
-        right: 630,
-        bottom: 320,
-        width: 630,
-        height: 320,
-        toJSON: () => ({}),
-      }) as DOMRect
+    const scroller = queryHTMLElement('.histogram-chart-scroll')
+    const wrapper = queryHTMLElement('.histogram-chart-wrapper')
+    const root = queryHTMLElement('.lc-root-container', wrapper)
+    root.getBoundingClientRect = () => new DOMRect(0, 0, 630, 320)
     Object.defineProperty(scroller, 'clientWidth', {
       configurable: true,
       value: 80,
@@ -653,7 +649,7 @@ describe('HistogramHeatmap keyboard model', () => {
     const surface = screen.getByRole('application', {
       name: 'Histogram heatmap',
     })
-    const scroller = document.querySelector('.heatmap-scroll') as HTMLElement
+    const scroller = queryHTMLElement('.heatmap-scroll')
     scroller.scrollLeft = 17
     expect(document.querySelector('.chart-keyboard-cursor-cell')).toBeNull()
 

--- a/desktopexporter/internal/frontend/src/components/metrics/Detail/SeriesDatapointList.test.ts
+++ b/desktopexporter/internal/frontend/src/components/metrics/Detail/SeriesDatapointList.test.ts
@@ -128,9 +128,7 @@ describe('SeriesDatapointList pagination and keyboard access', () => {
     expect(pagination.children[1]).toHaveClass('dp-list__page-nav')
     expect(pagination.children[2]).toHaveClass('dp-list__page-size')
     expect(
-      screen
-        .getAllByRole('option')
-        .map(option => (option as HTMLOptionElement).value)
+      screen.getAllByRole('option').map(option => option.getAttribute('value'))
     ).toEqual(['25', '50', '100'])
     expect(screen.queryByRole('columnheader', { name: 'Action' })).toBeNull()
     expect(screen.getAllByRole('row', { name: /^Datapoint at / })).toHaveLength(

--- a/desktopexporter/internal/frontend/src/components/shared/Toolbar/DateTimeFilter.test.ts
+++ b/desktopexporter/internal/frontend/src/components/shared/Toolbar/DateTimeFilter.test.ts
@@ -7,8 +7,12 @@ import { renderWithContexts, setTestUrl } from '@/test/render-helpers'
 
 // The popover JS API comes from the shared polyfill in src/test/setup.ts.
 
-function getPopover() {
-  return document.querySelector('[popover="auto"]') as HTMLElement
+function getPopover(): HTMLElement {
+  const popover = document.querySelector('[popover="auto"]')
+  if (!(popover instanceof HTMLElement)) {
+    throw new Error('Expected the time-range popover')
+  }
+  return popover
 }
 
 function renderComponent() {


### PR DESCRIPTION
## Summary
- replace selector result assertions with reusable runtime HTMLElement checks
- use a real DOMRect for chart geometry
- read option values through DOM attributes
- remove seven test DOM type assertions

## Testing
- 40 focused tests passed
- focused anti-slop check has no type-assertion findings
- `npm run check`
- `make test`

## Stack
- Base: #458
- This PR targets `chore/remove-history-mock-assertions` and should be reviewed as the second layer.