### PR TITLE
Use typed CodeMirror test contracts

### DIFF
--- a/desktopexporter/internal/frontend/src/components/shared/Search/codemirror/completions.test.ts
+++ b/desktopexporter/internal/frontend/src/components/shared/Search/codemirror/completions.test.ts
@@ -15,11 +15,7 @@ const source = createQueryCompletionSource(() => fields)
 
 function complete(doc: string, pos = doc.length, explicit = false) {
   const state = EditorState.create({ doc, extensions: [queryLanguage] })
-  return source(new CompletionContext(state, pos, explicit)) as {
-    from: number
-    options: { label: string }[]
-    validFor?: RegExp
-  } | null
+  return source(new CompletionContext(state, pos, explicit))
 }
 
 function labels(doc: string, pos?: number): string[] | null {
@@ -81,8 +77,7 @@ describe('operator positions', () => {
     // Which is also what makes the operator list fire next, so picking a
     // field leads to picking an operator without a guessed keystroke.
     const r = complete('nam')
-    const name = r!.options.find(o => o.label === 'name') as
-      { apply?: string } | undefined
+    const name = r!.options.find(o => o.label === 'name')
     expect(name?.apply).toBe('name ')
   })
 
@@ -109,7 +104,7 @@ describe('operator positions', () => {
     const r = complete('name = x', 2)
     expect(r).not.toBeNull()
     expect(r!.from).toBe(0)
-    expect((r as { to?: number }).to).toBe(4)
+    expect(r!.to).toBe(4)
   })
 
   it("offers a field's own operators while typing one after its name", () => {
@@ -130,9 +125,13 @@ describe('operator positions', () => {
 
   it('marks further typing as continuation, so the list filters not closes', () => {
     const r = complete('name C')
-    expect(r!.validFor).toBeInstanceOf(RegExp)
-    expect((r!.validFor as RegExp).test('CONT')).toBe(true)
-    expect((r!.validFor as RegExp).test('!=')).toBe(true)
+    const validFor = r!.validFor
+    expect(validFor).toBeInstanceOf(RegExp)
+    if (!(validFor instanceof RegExp)) {
+      throw new Error('Expected validFor to be a regular expression')
+    }
+    expect(validFor.test('CONT')).toBe(true)
+    expect(validFor.test('!=')).toBe(true)
   })
 
   it('never offers the derived wire operators', () => {
@@ -211,8 +210,7 @@ describe('array quote and group edges', () => {
   it('closes a manually typed opening quote on accept', () => {
     const r = complete('statusCode IN ["O')
     expect(r).not.toBeNull()
-    const ok = r!.options.find(o => o.label === 'Ok') as
-      { label: string; apply?: string } | undefined
+    const ok = r!.options.find(o => o.label === 'Ok')
     expect(ok?.apply).toBe('Ok"')
   })
 

--- a/desktopexporter/internal/frontend/src/components/shared/Search/codemirror/field-value-completions.test.ts
+++ b/desktopexporter/internal/frontend/src/components/shared/Search/codemirror/field-value-completions.test.ts
@@ -7,9 +7,10 @@ import { getFieldsBySignal } from '@/constants/fields'
 import { queryLanguage } from './query-language'
 
 const NAMES = ['checkout/pay', 'checkout/verify', 'db select "users"']
+type Signal = Parameters<typeof getFieldsBySignal>[0]
 
 function makeSource(
-  signal = 'traces',
+  signal: Signal = 'traces',
   fetch: (
     signal: string,
     field: string,
@@ -19,7 +20,7 @@ function makeSource(
 ) {
   return {
     source: createFieldValueSource(createFieldValueCache(fetch, signal), () =>
-      getFieldsBySignal(signal as 'traces' | 'logs' | 'metrics')
+      getFieldsBySignal(signal)
     ),
     fetch,
   }
@@ -27,7 +28,7 @@ function makeSource(
 
 async function run(
   doc: string,
-  signal = 'traces',
+  signal: Signal = 'traces',
   fetch?: () => Promise<string[]>
 ) {
   const { source } = makeSource(signal, fetch)
@@ -217,7 +218,7 @@ describe('operator gating', () => {
     expect(r!.options.map(o => o.label)).toEqual(['['])
     // A function rather than a string: it reopens completion on the values
     // inside, so the bracket is one step rather than a dead end.
-    expect(typeof r!.options[0].apply).toBe('function')
+    expect(r!.options[0].apply).toBeTypeOf('function')
   })
 
   it('offers values once the bracket is there', async () => {

--- a/desktopexporter/internal/frontend/src/components/shared/Search/codemirror/keymap.test.ts
+++ b/desktopexporter/internal/frontend/src/components/shared/Search/codemirror/keymap.test.ts
@@ -1,5 +1,8 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest'
 import { acceptCompletion } from '@codemirror/autocomplete'
+import { EditorState } from '@codemirror/state'
+import { EditorView, keymap, type KeyBinding } from '@codemirror/view'
 import { createQueryKeymap } from './keymap'
 
 /**
@@ -12,21 +15,16 @@ import { createQueryKeymap } from './keymap'
  * acceptCompletion never got a turn — suggestions could only be taken with the
  * mouse, which is not how anyone uses a search box.
  *
- * These assert the wiring rather than the runtime behaviour: constructing a
- * live EditorView needs a real layout that this jsdom setup does not provide.
- * The wiring is the change, and the failure mode if acceptCompletion declines
- * is simply the previous behaviour, so the risk of the untested half is
- * bounded.
+ * These assert the wiring through CodeMirror's public keymap facet. The submit
+ * command itself performs no layout work, so a detached EditorView is enough to
+ * exercise it with the real command contract.
  */
 
-type Binding = { key: string; run: unknown }
-
-function bindings(onSubmit = () => {}): Binding[] {
-  const value = Object.getOwnPropertyDescriptor(
-    createQueryKeymap(onSubmit),
-    'value'
-  )?.value
-  return Array.isArray(value) ? value : []
+function bindings(onSubmit = () => {}): readonly KeyBinding[] {
+  const state = EditorState.create({
+    extensions: [createQueryKeymap(onSubmit)],
+  })
+  return state.facet(keymap).flat()
 }
 
 describe('query keymap', () => {
@@ -38,9 +36,22 @@ describe('query keymap', () => {
 
   it('routes the second Enter binding to the submit callback', () => {
     const onSubmit = vi.fn()
-    const enter = bindings(onSubmit).filter(b => b.key === 'Enter')
-    ;(enter[1].run as (v: unknown) => boolean)({} as never)
-    expect(onSubmit).toHaveBeenCalledOnce()
+    const view = new EditorView({
+      extensions: [createQueryKeymap(onSubmit)],
+    })
+    try {
+      const enter = view.state
+        .facet(keymap)
+        .flat()
+        .filter(binding => binding.key === 'Enter')
+      const submit = enter[1]?.run
+      expect(submit).toBeDefined()
+      if (!submit) throw new Error('Expected a submit binding')
+      expect(submit(view)).toBe(true)
+      expect(onSubmit).toHaveBeenCalledOnce()
+    } finally {
+      view.destroy()
+    }
   })
 
   it('binds Escape once, conditionally', () => {

--- a/desktopexporter/internal/frontend/src/components/shared/Search/codemirror/value-completions.test.ts
+++ b/desktopexporter/internal/frontend/src/components/shared/Search/codemirror/value-completions.test.ts
@@ -248,9 +248,9 @@ describe('bare-text discovery of enums and columns', () => {
     // Eight attribute matches would fill the cap on their own; the quota
     // keeps room so `kind = Server` still surfaces.
     const manyAttrs = async (): Promise<JsonAttributeMatch[]> =>
-      Array.from({ length: 8 }, (_, i) => ({
+      Array.from({ length: 8 }, (_, i): JsonAttributeMatch => ({
         name: 'service.name',
-        attributeScope: 'resource' as AttributeScope,
+        attributeScope: 'resource',
         type: 'string',
         matchCount: 1,
         sampleValues: [`service-${i}`],


### PR DESCRIPTION
## Summary
- preserve CodeMirror completion result types without local assertions
- derive test signal types from the production field lookup contract
- inspect key bindings through the public facet API and invoke submit with a real detached EditorView
- contextually type generated attribute fixtures
- remove ten CodeMirror test type assertions and one adjacent runtime `typeof` check

## Testing
- 72 focused tests passed
- focused anti-slop check: 0 findings
- `npm run check`
- `make test`

## Stack
- Base: #458
- Second: #459
- This PR targets `chore/remove-test-dom-assertions` and is the top layer.