### PR TITLE
Type browser API test doubles

### DIFF
--- a/desktopexporter/internal/frontend/src/components/shared/ResizablePanels.test.ts
+++ b/desktopexporter/internal/frontend/src/components/shared/ResizablePanels.test.ts
@@ -29,8 +29,15 @@ beforeEach(() => {
 
 async function measure(width: number, height = 600) {
   await tick()
+  const entry = {
+    target: document.body,
+    contentRect: new DOMRect(0, 0, width, height),
+    borderBoxSize: [],
+    contentBoxSize: [],
+    devicePixelContentBoxSize: [],
+  } satisfies ResizeObserverEntry
   for (const o of observers) {
-    o.cb([{ contentRect: { width, height } } as ResizeObserverEntry], o)
+    o.cb([entry], o)
   }
   await tick()
 }

--- a/desktopexporter/internal/frontend/src/components/shared/Toolbar/TimeRangeFilterBody.test.ts
+++ b/desktopexporter/internal/frontend/src/components/shared/Toolbar/TimeRangeFilterBody.test.ts
@@ -183,7 +183,7 @@ describe('TimeRangeFilterBody', () => {
       if (original) {
         Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', original)
       } else {
-        delete (HTMLElement.prototype as Partial<HTMLElement>).scrollIntoView
+        Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView')
       }
     }
   })

--- a/desktopexporter/internal/frontend/src/test/setup.ts
+++ b/desktopexporter/internal/frontend/src/test/setup.ts
@@ -58,7 +58,7 @@ if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
         addListener: () => {},
         removeListener: () => {},
         dispatchEvent: () => false,
-      }) as MediaQueryList,
+      }) satisfies MediaQueryList,
   })
 }
 
@@ -187,7 +187,7 @@ if (
     const target = event.target
     if (!(target instanceof Element)) return
     const invoker = target.closest('button[popovertarget]')
-    if (!invoker || (invoker as HTMLButtonElement).disabled) return
+    if (!(invoker instanceof HTMLButtonElement) || invoker.disabled) return
     const id = invoker.getAttribute('popovertarget')
     const popover = id ? document.getElementById(id) : null
     if (!(popover instanceof HTMLElement) || !popover.hasAttribute('popover')) {


### PR DESCRIPTION
## Summary
- provide a complete ResizeObserverEntry fixture instead of asserting a partial shape
- restore optional prototype methods through Reflect.deleteProperty
- verify the matchMedia shim with `satisfies MediaQueryList`
- narrow popover invokers to HTMLButtonElement at runtime
- remove four browser API test-double assertions

## Testing
- 29 focused tests passed
- focused type-assertion check: 0 findings
- `npm run check`
- `make test`

## Stack
- Base: #458
- Second: #459
- Third: #460
- This PR targets `chore/remove-codemirror-test-assertions` and is the top layer.