### PR TITLE
Type histogram click targets

### DIFF
--- a/desktopexporter/internal/frontend/src/components/metrics/Charts/HistogramChart.svelte
+++ b/desktopexporter/internal/frontend/src/components/metrics/Charts/HistogramChart.svelte
@@ -448,11 +448,11 @@
     }
   })
 
-  function handlePlotClick(event: MouseEvent) {
+  function handlePlotClick(
+    event: MouseEvent & { currentTarget: HTMLDivElement }
+  ) {
     if (!enableValueBucketPin || !chartContext || buckets.length === 0) return
-    const root = (event.currentTarget as HTMLElement).querySelector(
-      '.lc-root-container'
-    )
+    const root = event.currentTarget.querySelector('.lc-root-container')
     if (!root) return
     const rect = root.getBoundingClientRect()
     const pointX = event.clientX - rect.left

--- a/desktopexporter/internal/frontend/src/components/metrics/Charts/HistogramHeatmap.svelte
+++ b/desktopexporter/internal/frontend/src/components/metrics/Charts/HistogramHeatmap.svelte
@@ -281,9 +281,11 @@
     }
   })
 
-  function handleHeatmapClick(event: MouseEvent) {
+  function handleHeatmapClick(
+    event: MouseEvent & { currentTarget: HTMLDivElement }
+  ) {
     if (!onSelect || timeDomain.length === 0 || columnPitch <= 0) return
-    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
+    const rect = event.currentTarget.getBoundingClientRect()
     const plotX = event.clientX - rect.left - heatmapPlotPadding.left
     if (plotX < 0 || plotX > plotWidth) return
     const idx = Math.floor(plotX / columnPitch)


### PR DESCRIPTION
## Summary
- type histogram click handlers with their div current targets
- remove two DOM type assertions without changing runtime behavior

## Verification
- make test
- npm test -- src/components/metrics/Charts/AnalyticalCharts.test.ts
- npm run check
- make build-ts
- npm run lint:anti-slop:evaluate (expected non-zero; findings reduced from 243 to 241)