### PR TITLE
Infer checkbox change targets

### DIFF
--- a/desktopexporter/internal/frontend/src/components/metrics/Charts/AllSeriesAggregateToggle.svelte
+++ b/desktopexporter/internal/frontend/src/components/metrics/Charts/AllSeriesAggregateToggle.svelte
@@ -20,10 +20,7 @@
       class="checkbox checkbox-xs checkbox-soft all-series-aggregate-toggle__checkbox"
       checked={ctx.showAllSeriesAggregate}
       aria-label={label}
-      onchange={e =>
-        ctx.setShowAllSeriesAggregate(
-          (e.currentTarget as HTMLInputElement).checked
-        )}
+      onchange={e => ctx.setShowAllSeriesAggregate(e.currentTarget.checked)}
     />
     <span class="all-series-aggregate-toggle__label">{label}</span>
   </label>

--- a/desktopexporter/internal/frontend/src/components/metrics/Charts/ChartStatOverlaysToggle.svelte
+++ b/desktopexporter/internal/frontend/src/components/metrics/Charts/ChartStatOverlaysToggle.svelte
@@ -20,10 +20,7 @@
       class="checkbox checkbox-xs checkbox-soft chart-stat-overlays-toggle__checkbox"
       checked={ctx.showSelectionStatOverlays}
       aria-label="Show chart stat overlays"
-      onchange={e =>
-        ctx.setShowSelectionStatOverlays(
-          (e.currentTarget as HTMLInputElement).checked
-        )}
+      onchange={e => ctx.setShowSelectionStatOverlays(e.currentTarget.checked)}
     />
     <span class="chart-stat-overlays-toggle__label">Overlays</span>
   </label>

--- a/desktopexporter/internal/frontend/src/components/metrics/Detail/TimeseriesPanel.svelte
+++ b/desktopexporter/internal/frontend/src/components/metrics/Detail/TimeseriesPanel.svelte
@@ -190,11 +190,7 @@
                     style:color={fg}
                     {checked}
                     disabled={checkboxDisabled}
-                    onchange={e =>
-                      toggle(
-                        ts.key,
-                        (e.currentTarget as HTMLInputElement).checked
-                      )}
+                    onchange={e => toggle(ts.key, e.currentTarget.checked)}
                   />
                 </label>
                 <div class="ts-row__attrs" title={tooltip}>


### PR DESCRIPTION
## Summary
- use Svelte's contextual input event typing in three mounted metric controls
- remove redundant HTMLInputElement assertions without runtime changes
- leave the explicitly dormant TimeseriesLegend component unchanged

## Verification
- make test
- npm run check
- make build-ts
- independent review: no findings
- npm run lint:anti-slop:evaluate (expected non-zero; unchanged at 241 because template expressions are not evaluated)