### PR TITLE
Name custom time result contracts

### DIFF
--- a/desktopexporter/internal/frontend/src/components/metrics/Detail/SeriesDatapointList.svelte
+++ b/desktopexporter/internal/frontend/src/components/metrics/Detail/SeriesDatapointList.svelte
@@ -164,8 +164,10 @@
     pageIndex = Math.max(0, Math.min(next, pageCount - 1))
   }
 
-  function changePageSize(e: Event): void {
-    const next = Number((e.currentTarget as HTMLSelectElement).value)
+  function changePageSize(
+    e: Event & { currentTarget: HTMLSelectElement }
+  ): void {
+    const next = Number(e.currentTarget.value)
     if (next !== 25 && next !== 50 && next !== 100) return
     pageIndex = 0
     pageSize = next
@@ -266,10 +268,7 @@
     }
   }
 
-  function datapointValueParts(dp: DataPoint): {
-    number: string
-    unit: string | null
-  } {
+  function datapointValueParts(dp: DataPoint) {
     const unit = displayUnit(metricUnit)
     if (dp.metricType === 'Gauge' || dp.metricType === 'Sum') {
       const raw = dp.doubleValue ?? dp.intValue

--- a/desktopexporter/internal/frontend/src/components/shared/Toolbar/CustomTimeRange.svelte
+++ b/desktopexporter/internal/frontend/src/components/shared/Toolbar/CustomTimeRange.svelte
@@ -30,6 +30,11 @@
   type Endpoint = 'start' | 'end'
   type Choice = Exclude<WallClockDisambiguation, 'reject'>
   type Ambiguity = { earlier: number; later: number }
+  type EditableParts = { date: string; time: string }
+  type InitializedChoice = {
+    ambiguity: Ambiguity | null
+    choice: Choice | null
+  }
 
   const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
   const TIME_PATTERN = /^(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d\.\d{3}$/
@@ -76,7 +81,7 @@
 
   let today = $state(calendarDateForTimestamp(initialNow))
 
-  function editableParts(timestamp: number): { date: string; time: string } {
+  function editableParts(timestamp: number): EditableParts {
     const formatted = formatEditableDateTime(timestamp, ctx.tz)
     return { date: formatted.slice(0, 10), time: formatted.slice(11, 23) }
   }
@@ -137,7 +142,7 @@
     date: string,
     time: string,
     timestamp: number
-  ): { ambiguity: Ambiguity | null; choice: Choice | null } {
+  ): InitializedChoice {
     const ambiguity = ambiguityFor(date, time)
     if (!ambiguity) return { ambiguity: null, choice: null }
     return {


### PR DESCRIPTION
## Stack
- Depends on #470. Review this PR after #470.

## Summary
- give editable date/time parts a component-owned result type
- preserve ambiguity and disambiguation choice literals through initialization
- remove three anti-slop findings without changing emitted frontend assets

## Testing
- `npm test -- src/components/shared/Toolbar/CustomTimeRange.test.ts`
- `npm run check`
- `npm run lint:anti-slop:evaluate` (187 -> 184 relative to #470)
- `make build-ts`
- `make test`