### PR TITLE
Infer metric projection result types

### DIFF
--- a/desktopexporter/internal/frontend/src/components/metrics/Detail/SeriesDatapointList.svelte
+++ b/desktopexporter/internal/frontend/src/components/metrics/Detail/SeriesDatapointList.svelte
@@ -164,8 +164,10 @@
     pageIndex = Math.max(0, Math.min(next, pageCount - 1))
   }
 
-  function changePageSize(e: Event): void {
-    const next = Number((e.currentTarget as HTMLSelectElement).value)
+  function changePageSize(
+    e: Event & { currentTarget: HTMLSelectElement }
+  ): void {
+    const next = Number(e.currentTarget.value)
     if (next !== 25 && next !== 50 && next !== 100) return
     pageIndex = 0
     pageSize = next
@@ -266,10 +268,7 @@
     }
   }
 
-  function datapointValueParts(dp: DataPoint): {
-    number: string
-    unit: string | null
-  } {
+  function datapointValueParts(dp: DataPoint) {
     const unit = displayUnit(metricUnit)
     if (dp.metricType === 'Gauge' || dp.metricType === 'Sum') {
       const raw = dp.doubleValue ?? dp.intValue

--- a/desktopexporter/internal/frontend/src/components/metrics/utils/chart-projection.ts
+++ b/desktopexporter/internal/frontend/src/components/metrics/utils/chart-projection.ts
@@ -66,6 +66,9 @@ export function rateBucketStartForSourceDatapoint(
  * LineChart wants monotonically-increasing x, so this walks each series
  * backwards. It used to build forwards and sort, which re-ordered data the
  * store had already ordered.
+ *
+ * @returns Projected chart series and their keys. `keys` preserves the input
+ * order so callers can seed `visibleKeys` without mapping over the series.
  */
 export function timeseriesToChartTimeseries(
   timeseries: MetricTimeseries[],
@@ -75,13 +78,7 @@ export function timeseriesToChartTimeseries(
    *  which resource attributes distinguish them), which this function is not
    *  always given, so the caller supplies it. */
   labelFor?: (ts: MetricTimeseries) => string
-): {
-  chartTimeseries: ChartTimeseries[]
-  /** Convenience: same `key` strings the timeseries have, in the
-   * same order. Caller can seed `visibleKeys` from this without
-   * having to map over `chartTimeseries`. */
-  keys: string[]
-} {
+) {
   const chartTimeseries: ChartTimeseries[] = []
   const keys: string[] = []
 

--- a/desktopexporter/internal/frontend/src/components/metrics/utils/histogram-heatmap-data.ts
+++ b/desktopexporter/internal/frontend/src/components/metrics/utils/histogram-heatmap-data.ts
@@ -402,7 +402,7 @@ export function buildHistogramHeatmapData(
 /** Pure instrumentation entry point for structural projection tests. */
 export function buildHistogramHeatmapDataWithStats(
   points: readonly HistogramSlicePoint[]
-): { data: HistogramHeatmapData; stats: HistogramHeatmapBuildStats } {
+) {
   const stats: HistogramHeatmapBuildStats = {
     explicitSchemaCount: 0,
     exponentialSchemaCount: 0,

--- a/desktopexporter/internal/frontend/src/components/shared/Toolbar/CustomTimeRange.svelte
+++ b/desktopexporter/internal/frontend/src/components/shared/Toolbar/CustomTimeRange.svelte
@@ -30,6 +30,11 @@
   type Endpoint = 'start' | 'end'
   type Choice = Exclude<WallClockDisambiguation, 'reject'>
   type Ambiguity = { earlier: number; later: number }
+  type EditableParts = { date: string; time: string }
+  type InitializedChoice = {
+    ambiguity: Ambiguity | null
+    choice: Choice | null
+  }
 
   const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
   const TIME_PATTERN = /^(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d\.\d{3}$/
@@ -76,7 +81,7 @@
 
   let today = $state(calendarDateForTimestamp(initialNow))
 
-  function editableParts(timestamp: number): { date: string; time: string } {
+  function editableParts(timestamp: number): EditableParts {
     const formatted = formatEditableDateTime(timestamp, ctx.tz)
     return { date: formatted.slice(0, 10), time: formatted.slice(11, 23) }
   }
@@ -137,7 +142,7 @@
     date: string,
     time: string,
     timestamp: number
-  ): { ambiguity: Ambiguity | null; choice: Choice | null } {
+  ): InitializedChoice {
     const ambiguity = ambiguityFor(date, time)
     if (!ambiguity) return { ambiguity: null, choice: null }
     return {


### PR DESCRIPTION
## Summary
- infer the chart projection result from its typed local arrays
- infer the histogram instrumentation result from its typed data and stats
- preserve the chart key ordering contract in exported function documentation

## Verification
- `npm test -- src/components/metrics/utils/chart-projection.test.ts src/components/metrics/utils/histogram-heatmap-data.test.ts`
- `npm run check`
- `make build-ts`
- `make build-ts && make test` (916 frontend tests, all Go tests, 9 accessibility tests)
- anti-slop findings: 184 -> 182
- independent review: no findings